### PR TITLE
Remove `#[macro_use]` and use `use` instead

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,4 +1,6 @@
+use derive_more::From;
 use reqwest::StatusCode;
+use thiserror::Error;
 
 //<editor-fold desc="download">
 #[derive(Debug, Error, From)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,13 +5,6 @@
     html_favicon_url = "https://github.com/teloxide/teloxide/raw/dev/ICON.png"
 )]
 
-#[macro_use]
-extern crate derive_more;
-#[macro_use]
-extern crate serde;
-#[macro_use]
-extern crate thiserror;
-
 pub use bot::Bot;
 pub use errors::{DownloadError, RequestError};
 

--- a/src/network/telegram_response.rs
+++ b/src/network/telegram_response.rs
@@ -1,4 +1,5 @@
 use reqwest::StatusCode;
+use serde::Deserialize;
 
 use crate::{
     requests::ResponseResult,

--- a/src/requests/payloads/add_sticker_to_set.rs
+++ b/src/requests/payloads/add_sticker_to_set.rs
@@ -1,3 +1,4 @@
+use serde::{Deserialize, Serialize};
 use reqwest::multipart::Form;
 
 use crate::{

--- a/src/requests/payloads/answer_callback_query.rs
+++ b/src/requests/payloads/answer_callback_query.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::{
     requests::{dynamic, json, Method},
     types::True,

--- a/src/requests/payloads/answer_inline_query.rs
+++ b/src/requests/payloads/answer_inline_query.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::{
     requests::{dynamic, json, Method},
     types::InlineQueryResult,

--- a/src/requests/payloads/answer_pre_checkout_query.rs
+++ b/src/requests/payloads/answer_pre_checkout_query.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::{
     requests::{dynamic, json, Method},
     types::True,

--- a/src/requests/payloads/answer_shipping_query.rs
+++ b/src/requests/payloads/answer_shipping_query.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::{
     requests::{dynamic, json, Method},
     types::{ShippingOption, True},

--- a/src/requests/payloads/create_new_sticker_set.rs
+++ b/src/requests/payloads/create_new_sticker_set.rs
@@ -1,3 +1,4 @@
+use serde::{Deserialize, Serialize};
 use reqwest::multipart::Form;
 
 use crate::{

--- a/src/requests/payloads/delete_chat_photo.rs
+++ b/src/requests/payloads/delete_chat_photo.rs
@@ -1,7 +1,9 @@
+use serde::{Deserialize, Serialize};
+
 use crate::{
     requests::{dynamic, json, Method},
+    types::{ChatId, True},
 };
-use crate::types::{ChatId, True};
 
 /// Use this method to delete a chat photo. Photos can't be changed for private chats. The bot must be an administrator in the chat for this to work and must have the appropriate admin rights. Returns True on success.
 #[serde_with_macros::skip_serializing_none]

--- a/src/requests/payloads/delete_chat_sticker_set.rs
+++ b/src/requests/payloads/delete_chat_sticker_set.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::{
     requests::{dynamic, json, Method},
     types::{ChatId, True},

--- a/src/requests/payloads/delete_message.rs
+++ b/src/requests/payloads/delete_message.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::{
     requests::{dynamic, json, Method},
     types::{ChatId, True},

--- a/src/requests/payloads/delete_sticker_from_set.rs
+++ b/src/requests/payloads/delete_sticker_from_set.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::{
     requests::{dynamic, json, Method},
     types::True,

--- a/src/requests/payloads/delete_webhook.rs
+++ b/src/requests/payloads/delete_webhook.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::{
     requests::{dynamic, json, Method},
     types::True,

--- a/src/requests/payloads/edit_message_caption.rs
+++ b/src/requests/payloads/edit_message_caption.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::{
     requests::{dynamic, json, Method},
     types::{ChatId, ParseMode, InlineKeyboardMarkup, Message},

--- a/src/requests/payloads/edit_message_caption_inline.rs
+++ b/src/requests/payloads/edit_message_caption_inline.rs
@@ -1,10 +1,9 @@
-
+use serde::{Deserialize, Serialize};
 
 use crate::{
     requests::{dynamic, json, Method},
-    types::{ParseMode, InlineKeyboardMarkup},
+    types::{ParseMode, InlineKeyboardMarkup, Message},
 };
-use crate::types::Message;
 
 /// Use this method to edit captions of messages. On success, if edited message is sent by the bot, the edited Message is returned, otherwise True is returned.
 #[serde_with_macros::skip_serializing_none]

--- a/src/requests/payloads/edit_message_live_location.rs
+++ b/src/requests/payloads/edit_message_live_location.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::{
     requests::{dynamic, json, Method},
     types::{ChatId, InlineKeyboardMarkup, Message},

--- a/src/requests/payloads/edit_message_live_location_inline.rs
+++ b/src/requests/payloads/edit_message_live_location_inline.rs
@@ -1,3 +1,4 @@
+use serde::{Deserialize, Serialize};
 
 use crate::{
     requests::{dynamic, json, Method},

--- a/src/requests/payloads/edit_message_media.rs
+++ b/src/requests/payloads/edit_message_media.rs
@@ -1,3 +1,4 @@
+use serde::{Deserialize, Serialize};
 use reqwest::multipart::Form;
 
 use crate::{

--- a/src/requests/payloads/edit_message_media_inline.rs
+++ b/src/requests/payloads/edit_message_media_inline.rs
@@ -1,3 +1,4 @@
+use serde::{Deserialize, Serialize};
 use reqwest::multipart::Form;
 
 use crate::{

--- a/src/requests/payloads/edit_message_reply_markup.rs
+++ b/src/requests/payloads/edit_message_reply_markup.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::{
     requests::{dynamic, json, Method},
     types::{ChatId, InlineKeyboardMarkup, Message},

--- a/src/requests/payloads/edit_message_reply_markup_inline.rs
+++ b/src/requests/payloads/edit_message_reply_markup_inline.rs
@@ -1,3 +1,4 @@
+use serde::{Deserialize, Serialize};
 
 use crate::{
     requests::{dynamic, json, Method},

--- a/src/requests/payloads/edit_message_text.rs
+++ b/src/requests/payloads/edit_message_text.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::{
     requests::{dynamic, json, Method},
     types::{ChatId, ParseMode, InlineKeyboardMarkup, Message},

--- a/src/requests/payloads/edit_message_text_inline.rs
+++ b/src/requests/payloads/edit_message_text_inline.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::{
     requests::{dynamic, json, Method},
     types::{ParseMode, InlineKeyboardMarkup, Message},

--- a/src/requests/payloads/export_chat_invite_link.rs
+++ b/src/requests/payloads/export_chat_invite_link.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::{
     requests::{dynamic, json, Method},
     types::ChatId,

--- a/src/requests/payloads/forward_message.rs
+++ b/src/requests/payloads/forward_message.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::{
     requests::{dynamic, json, Method},
     types::{ChatId, Message},

--- a/src/requests/payloads/get_chat.rs
+++ b/src/requests/payloads/get_chat.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::{
     requests::{dynamic, json, Method},
     types::{ChatId, Chat},

--- a/src/requests/payloads/get_chat_administrators.rs
+++ b/src/requests/payloads/get_chat_administrators.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::{
     requests::{dynamic, json, Method},
     types::{ChatId, ChatMember},

--- a/src/requests/payloads/get_chat_member.rs
+++ b/src/requests/payloads/get_chat_member.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::{
     requests::{dynamic, json, Method},
     types::{ChatId, ChatMember},

--- a/src/requests/payloads/get_chat_members_count.rs
+++ b/src/requests/payloads/get_chat_members_count.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::{
     requests::{dynamic, json, Method},
     types::ChatId,

--- a/src/requests/payloads/get_file.rs
+++ b/src/requests/payloads/get_file.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::{
     requests::{dynamic, json, Method},
     types::File,

--- a/src/requests/payloads/get_game_high_scores.rs
+++ b/src/requests/payloads/get_game_high_scores.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::{
     requests::{dynamic, json, Method},
     types::GameHighScore,

--- a/src/requests/payloads/get_game_high_scores_inline.rs
+++ b/src/requests/payloads/get_game_high_scores_inline.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::{
     requests::{dynamic, json, Method},
     types::GameHighScore,

--- a/src/requests/payloads/get_me.rs
+++ b/src/requests/payloads/get_me.rs
@@ -1,3 +1,4 @@
+use serde::{Deserialize, Serialize};
 use crate::{
     requests::{dynamic, json, Method},
     types::User,

--- a/src/requests/payloads/get_sticker_set.rs
+++ b/src/requests/payloads/get_sticker_set.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::{
     requests::{dynamic, json, Method},
     types::StickerSet,

--- a/src/requests/payloads/get_updates.rs
+++ b/src/requests/payloads/get_updates.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::{
     requests::{dynamic, json, Method},
     types::Update,

--- a/src/requests/payloads/get_user_profile_photos.rs
+++ b/src/requests/payloads/get_user_profile_photos.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::{
     requests::{dynamic, json, Method},
     types::UserProfilePhotos,

--- a/src/requests/payloads/get_webhook_info.rs
+++ b/src/requests/payloads/get_webhook_info.rs
@@ -1,7 +1,9 @@
+use serde::{Deserialize, Serialize};
+
 use crate::{
     requests::{dynamic, json, Method},
+    types::WebhookInfo,
 };
-use crate::types::WebhookInfo;
 
 /// Use this method to get current webhook status. Requires no parameters. On success, returns a WebhookInfo object. If the bot is using getUpdates, will return an object with the url field empty.
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Deserialize, Serialize, Default)]

--- a/src/requests/payloads/kick_chat_member.rs
+++ b/src/requests/payloads/kick_chat_member.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::{
     requests::{dynamic, json, Method},
     types::{ChatId, True},

--- a/src/requests/payloads/leave_chat.rs
+++ b/src/requests/payloads/leave_chat.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::{
     requests::{dynamic, json, Method},
     types::{ChatId, True},

--- a/src/requests/payloads/pin_chat_message.rs
+++ b/src/requests/payloads/pin_chat_message.rs
@@ -1,7 +1,9 @@
+use serde::{Deserialize, Serialize};
+
 use crate::{
     requests::{dynamic, json, Method},
+    types::{ChatId, True},
 };
-use crate::types::{ChatId, True};
 
 /// Use this method to pin a message in a group, a supergroup, or a channel. The bot must be an administrator in the chat for this to work and must have the ‘can_pin_messages’ admin right in the supergroup or ‘can_edit_messages’ admin right in the channel. Returns True on success.
 #[serde_with_macros::skip_serializing_none]

--- a/src/requests/payloads/promote_chat_member.rs
+++ b/src/requests/payloads/promote_chat_member.rs
@@ -1,7 +1,9 @@
+use serde::{Deserialize, Serialize};
+
 use crate::{
     requests::{dynamic, json, Method},
+    types::{ChatId, True},
 };
-use crate::types::{ChatId, True};
 
 /// Use this method to promote or demote a user in a supergroup or a channel. The bot must be an administrator in the chat for this to work and must have the appropriate admin rights. Pass False for all boolean parameters to demote a user. Returns True on success.
 #[serde_with_macros::skip_serializing_none]

--- a/src/requests/payloads/restrict_chat_member.rs
+++ b/src/requests/payloads/restrict_chat_member.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::{
     requests::{dynamic, json, Method},
     types::{ChatId, ChatPermissions, True},

--- a/src/requests/payloads/send_animation.rs
+++ b/src/requests/payloads/send_animation.rs
@@ -1,3 +1,4 @@
+use serde::{Deserialize, Serialize};
 use reqwest::multipart::Form;
 
 use crate::{

--- a/src/requests/payloads/send_audio.rs
+++ b/src/requests/payloads/send_audio.rs
@@ -1,3 +1,4 @@
+use serde::{Deserialize, Serialize};
 use reqwest::multipart::Form;
 
 use crate::{

--- a/src/requests/payloads/send_chat_action.rs
+++ b/src/requests/payloads/send_chat_action.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::{
     requests::{dynamic, json, Method},
     types::{ChatId, True},

--- a/src/requests/payloads/send_contact.rs
+++ b/src/requests/payloads/send_contact.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::{
     requests::{dynamic, json, Method},
     types::{ChatId, ReplyMarkup, Message},

--- a/src/requests/payloads/send_document.rs
+++ b/src/requests/payloads/send_document.rs
@@ -1,3 +1,4 @@
+use serde::{Deserialize, Serialize};
 use reqwest::multipart::Form;
 
 use crate::{

--- a/src/requests/payloads/send_game.rs
+++ b/src/requests/payloads/send_game.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::{
     requests::{dynamic, json, Method},
     types::{InlineKeyboardMarkup, Message},

--- a/src/requests/payloads/send_invoice.rs
+++ b/src/requests/payloads/send_invoice.rs
@@ -1,7 +1,9 @@
+use serde::{Deserialize, Serialize};
+
 use crate::{
     requests::{dynamic, json, Method},
+    types::{LabeledPrice, InlineKeyboardMarkup, Message},
 };
-use crate::types::{LabeledPrice, InlineKeyboardMarkup, Message};
 
 /// Use this method to send invoices. On success, the sent Message is returned.
 #[serde_with_macros::skip_serializing_none]

--- a/src/requests/payloads/send_location.rs
+++ b/src/requests/payloads/send_location.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::{
     requests::{dynamic, json, Method},
     types::{ChatId, ReplyMarkup, Message},

--- a/src/requests/payloads/send_media_group.rs
+++ b/src/requests/payloads/send_media_group.rs
@@ -1,3 +1,4 @@
+use serde::{Deserialize, Serialize};
 use reqwest::multipart::Form;
 
 use crate::{

--- a/src/requests/payloads/send_message.rs
+++ b/src/requests/payloads/send_message.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::{
     requests::{dynamic, json, Method},
     types::{ChatId, Message, ParseMode, ReplyMarkup},

--- a/src/requests/payloads/send_photo.rs
+++ b/src/requests/payloads/send_photo.rs
@@ -1,3 +1,4 @@
+use serde::{Deserialize, Serialize};
 use reqwest::multipart::Form;
 
 use crate::{

--- a/src/requests/payloads/send_poll.rs
+++ b/src/requests/payloads/send_poll.rs
@@ -1,7 +1,9 @@
+use serde::{Deserialize, Serialize};
+
 use crate::{
     requests::{dynamic, json, Method},
+    types::{ChatId, ReplyMarkup, Message},
 };
-use crate::types::{ChatId, ReplyMarkup, Message};
 
 /// Use this method to send a native poll. A native poll can't be sent to a private chat. On success, the sent Message is returned.
 #[serde_with_macros::skip_serializing_none]

--- a/src/requests/payloads/send_sticker.rs
+++ b/src/requests/payloads/send_sticker.rs
@@ -1,3 +1,4 @@
+use serde::{Deserialize, Serialize};
 use reqwest::multipart::Form;
 
 use crate::{

--- a/src/requests/payloads/send_venue.rs
+++ b/src/requests/payloads/send_venue.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::{
     requests::{dynamic, json, Method},
     types::{ChatId, ReplyMarkup, Message},

--- a/src/requests/payloads/send_video.rs
+++ b/src/requests/payloads/send_video.rs
@@ -1,3 +1,4 @@
+use serde::{Deserialize, Serialize};
 use reqwest::multipart::Form;
 
 use crate::{

--- a/src/requests/payloads/send_video_note.rs
+++ b/src/requests/payloads/send_video_note.rs
@@ -1,3 +1,4 @@
+use serde::{Deserialize, Serialize};
 use reqwest::multipart::Form;
 
 use crate::{

--- a/src/requests/payloads/send_voice.rs
+++ b/src/requests/payloads/send_voice.rs
@@ -1,3 +1,4 @@
+use serde::{Deserialize, Serialize};
 use reqwest::multipart::Form;
 
 use crate::{

--- a/src/requests/payloads/set_chat_description.rs
+++ b/src/requests/payloads/set_chat_description.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::{
     requests::{dynamic, json, Method},
     types::{ChatId, True},

--- a/src/requests/payloads/set_chat_permissions.rs
+++ b/src/requests/payloads/set_chat_permissions.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::{
     requests::{dynamic, json, Method},
     types::{ChatId, ChatPermissions, True},

--- a/src/requests/payloads/set_chat_photo.rs
+++ b/src/requests/payloads/set_chat_photo.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::{
     requests::{dynamic, json, Method},
     types::{ChatId, InputFile, True},

--- a/src/requests/payloads/set_chat_sticker_set.rs
+++ b/src/requests/payloads/set_chat_sticker_set.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::{
     requests::{dynamic, json, Method},
     types::{ChatId, True},

--- a/src/requests/payloads/set_chat_title.rs
+++ b/src/requests/payloads/set_chat_title.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::{
     requests::{dynamic, json, Method},
     types::{ChatId, True},

--- a/src/requests/payloads/set_game_score.rs
+++ b/src/requests/payloads/set_game_score.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::{
     requests::{dynamic, json, Method},
     types::{Message, ChatId},

--- a/src/requests/payloads/set_game_score_inline.rs
+++ b/src/requests/payloads/set_game_score_inline.rs
@@ -1,3 +1,4 @@
+use serde::{Deserialize, Serialize};
 
 use crate::{
     requests::{dynamic, json, Method},

--- a/src/requests/payloads/set_sticker_position_in_set.rs
+++ b/src/requests/payloads/set_sticker_position_in_set.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::{
     requests::{dynamic, json, Method},
     types::True,

--- a/src/requests/payloads/set_webhook.rs
+++ b/src/requests/payloads/set_webhook.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::{
     requests::{dynamic, json, Method},
     types::{InputFile, True},

--- a/src/requests/payloads/stop_message_live_location.rs
+++ b/src/requests/payloads/stop_message_live_location.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::{
     requests::{dynamic, json, Method},
     types::{ChatId, InlineKeyboardMarkup, Message},

--- a/src/requests/payloads/stop_message_live_location_inline.rs
+++ b/src/requests/payloads/stop_message_live_location_inline.rs
@@ -1,4 +1,4 @@
-
+use serde::{Deserialize, Serialize};
 
 use crate::{
     requests::{dynamic, json, Method},

--- a/src/requests/payloads/stop_poll.rs
+++ b/src/requests/payloads/stop_poll.rs
@@ -1,8 +1,9 @@
+use serde::{Deserialize, Serialize};
+
 use crate::{
     requests::{dynamic, json, Method},
-    types::{ChatId, InlineKeyboardMarkup},
+    types::{ChatId, InlineKeyboardMarkup, Poll},
 };
-use crate::types::Poll;
 
 /// Use this method to stop a poll which was sent by the bot. On success, the stopped Poll with the final results is returned.
 #[serde_with_macros::skip_serializing_none]

--- a/src/requests/payloads/unban_chat_member.rs
+++ b/src/requests/payloads/unban_chat_member.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::{
     requests::{dynamic, json, Method},
     types::{ChatId, True},

--- a/src/requests/payloads/unpin_chat_message.rs
+++ b/src/requests/payloads/unpin_chat_message.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::{
     requests::{dynamic, json, Method},
     types::{ChatId, True},

--- a/src/requests/payloads/upload_sticker_file.rs
+++ b/src/requests/payloads/upload_sticker_file.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::{
     requests::{dynamic, json, Method},
     types::{InputFile, File},

--- a/src/types/animation.rs
+++ b/src/types/animation.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::types::PhotoSize;
 
 /// This object represents an animation file (GIF or H.264/MPEG-4 AVC video

--- a/src/types/audio.rs
+++ b/src/types/audio.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::types::PhotoSize;
 
 /// This object represents an audio file to be treated as music by the Telegram

--- a/src/types/callback_query.rs
+++ b/src/types/callback_query.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::types::{Message, User};
 
 /// This object represents an incoming callback query from a callback button in

--- a/src/types/chat.rs
+++ b/src/types/chat.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::types::{ChatPermissions, ChatPhoto, Message};
 
 /// This object represents a chat.

--- a/src/types/chat_action.rs
+++ b/src/types/chat_action.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ChatAction {

--- a/src/types/chat_id.rs
+++ b/src/types/chat_id.rs
@@ -1,3 +1,6 @@
+use derive_more::{Display, From};
+use serde::{Deserialize, Serialize};
+
 /// A unique identifier for the target chat or username of the target channel
 /// (in the format `@channelusername`).
 #[derive(

--- a/src/types/chat_member.rs
+++ b/src/types/chat_member.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::types::User;
 
 /// This object contains information about one member of the chat.

--- a/src/types/chat_permissions.rs
+++ b/src/types/chat_permissions.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 /// Describes actions that a non-administrator user is allowed to take in a
 /// chat.
 ///

--- a/src/types/chat_photo.rs
+++ b/src/types/chat_photo.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 /// This object represents a chat photo.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#chatphoto).

--- a/src/types/chosen_inline_result.rs
+++ b/src/types/chosen_inline_result.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::types::{Location, User};
 
 /// Represents a [result] of an inline query that was chosen by the user and

--- a/src/types/contact.rs
+++ b/src/types/contact.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 /// This object represents a phone contact.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#contact).

--- a/src/types/document.rs
+++ b/src/types/document.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::types::PhotoSize;
 
 /// This object represents a general file (as opposed to [photos], [voice

--- a/src/types/encrypted_credentials.rs
+++ b/src/types/encrypted_credentials.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 /// Contains data required for decrypting and authenticating
 /// [`EncryptedPassportElement`]. See the [Telegram Passport Documentation] for
 /// a complete description of the data decryption and authentication processes.

--- a/src/types/encrypted_passport_element.rs
+++ b/src/types/encrypted_passport_element.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use super::PassportFile;
 
 /// Contains information about documents or other Telegram Passport elements

--- a/src/types/file.rs
+++ b/src/types/file.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 /// This object represents a file ready to be downloaded. The file can be
 /// downloaded via the link `https://api.telegram.org/file/bot<token>/<file_path>`.
 /// It is guaranteed that the link will be valid for at least 1 hour. When the

--- a/src/types/force_reply.rs
+++ b/src/types/force_reply.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::types::True;
 
 /// Upon receiving a message with this object, Telegram clients will display a

--- a/src/types/game.rs
+++ b/src/types/game.rs
@@ -1,4 +1,4 @@
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::types::{Animation, MessageEntity, PhotoSize};
 

--- a/src/types/game_high_score.rs
+++ b/src/types/game_high_score.rs
@@ -1,4 +1,4 @@
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::types::user::User;
 

--- a/src/types/inline_keyboard_button.rs
+++ b/src/types/inline_keyboard_button.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 /// This object represents one button of an inline keyboard.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#inlinekeyboardbutton).

--- a/src/types/inline_keyboard_markup.rs
+++ b/src/types/inline_keyboard_markup.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::types::InlineKeyboardButton;
 
 /// This object represents an [inline keyboard] that appears right next to the

--- a/src/types/inline_query.rs
+++ b/src/types/inline_query.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::types::{Location, User};
 
 /// This object represents an incoming inline query. When the user sends an

--- a/src/types/inline_query_result.rs
+++ b/src/types/inline_query_result.rs
@@ -1,5 +1,8 @@
 #![allow(clippy::large_enum_variant)]
 
+use derive_more::From;
+use serde::{Deserialize, Serialize};
+
 use crate::types::{
     InlineQueryResultArticle, InlineQueryResultAudio,
     InlineQueryResultCachedAudio, InlineQueryResultCachedDocument,

--- a/src/types/inline_query_result_article.rs
+++ b/src/types/inline_query_result_article.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::types::{InlineKeyboardMarkup, InputMessageContent};
 
 /// Represents a link to an article or web page.

--- a/src/types/inline_query_result_audio.rs
+++ b/src/types/inline_query_result_audio.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::types::{InlineKeyboardMarkup, InputMessageContent, ParseMode};
 
 /// Represents a link to an MP3 audio file. By default, this audio file will be

--- a/src/types/inline_query_result_cached_audio.rs
+++ b/src/types/inline_query_result_cached_audio.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::types::{InlineKeyboardMarkup, InputMessageContent, ParseMode};
 
 /// Represents a link to an MP3 audio file stored on the Telegram servers. By

--- a/src/types/inline_query_result_cached_document.rs
+++ b/src/types/inline_query_result_cached_document.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::types::{InlineKeyboardMarkup, InputMessageContent, ParseMode};
 
 /// Represents a link to a file stored on the Telegram servers. By default, this

--- a/src/types/inline_query_result_cached_gif.rs
+++ b/src/types/inline_query_result_cached_gif.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::types::{InlineKeyboardMarkup, InputMessageContent, ParseMode};
 
 /// Represents a link to an animated GIF file stored on the Telegram servers. By

--- a/src/types/inline_query_result_cached_mpeg4_gif.rs
+++ b/src/types/inline_query_result_cached_mpeg4_gif.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::types::{InlineKeyboardMarkup, InputMessageContent, ParseMode};
 
 /// Represents a link to a video animation (H.264/MPEG-4 AVC video without

--- a/src/types/inline_query_result_cached_photo.rs
+++ b/src/types/inline_query_result_cached_photo.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::types::{InlineKeyboardMarkup, InputMessageContent, ParseMode};
 
 /// Represents a link to a photo stored on the Telegram servers. By default,

--- a/src/types/inline_query_result_cached_sticker.rs
+++ b/src/types/inline_query_result_cached_sticker.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::types::{InlineKeyboardMarkup, InputMessageContent};
 
 /// Represents a link to a sticker stored on the Telegram servers. By default,

--- a/src/types/inline_query_result_cached_video.rs
+++ b/src/types/inline_query_result_cached_video.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::types::{InlineKeyboardMarkup, InputMessageContent, ParseMode};
 
 /// Represents a link to a video file stored on the Telegram servers. By

--- a/src/types/inline_query_result_cached_voice.rs
+++ b/src/types/inline_query_result_cached_voice.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::types::{InlineKeyboardMarkup, InputMessageContent, ParseMode};
 
 /// Represents a link to a voice message stored on the Telegram servers. By

--- a/src/types/inline_query_result_contact.rs
+++ b/src/types/inline_query_result_contact.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::types::{InlineKeyboardMarkup, InputMessageContent};
 
 /// Represents a contact with a phone number. By default, this contact will be

--- a/src/types/inline_query_result_document.rs
+++ b/src/types/inline_query_result_document.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::types::{InlineKeyboardMarkup, InputMessageContent, ParseMode};
 
 /// Represents a link to a file. By default, this file will be sent by the user

--- a/src/types/inline_query_result_game.rs
+++ b/src/types/inline_query_result_game.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::types::InlineKeyboardMarkup;
 
 /// Represents a [game].

--- a/src/types/inline_query_result_gif.rs
+++ b/src/types/inline_query_result_gif.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::types::{InlineKeyboardMarkup, InputMessageContent, ParseMode};
 
 /// Represents a link to an animated GIF file. By default, this animated GIF

--- a/src/types/inline_query_result_location.rs
+++ b/src/types/inline_query_result_location.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::types::{InlineKeyboardMarkup, InputMessageContent};
 
 /// Represents a location on a map. By default, the location will be sent by the

--- a/src/types/inline_query_result_mpeg4_gif.rs
+++ b/src/types/inline_query_result_mpeg4_gif.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::types::{InlineKeyboardMarkup, InputMessageContent, ParseMode};
 
 /// Represents a link to a video animation (H.264/MPEG-4 AVC video without

--- a/src/types/inline_query_result_photo.rs
+++ b/src/types/inline_query_result_photo.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::types::{InlineKeyboardMarkup, InputMessageContent, ParseMode};
 
 /// Represents a link to a photo. By default, this photo will be sent by the

--- a/src/types/inline_query_result_venue.rs
+++ b/src/types/inline_query_result_venue.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::types::{InlineKeyboardMarkup, InputMessageContent};
 
 /// Represents a venue. By default, the venue will be sent by the user.

--- a/src/types/inline_query_result_video.rs
+++ b/src/types/inline_query_result_video.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::types::{InlineKeyboardMarkup, InputMessageContent, ParseMode};
 
 /// Represents a link to a page containing an embedded video player or a video

--- a/src/types/inline_query_result_voice.rs
+++ b/src/types/inline_query_result_voice.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::types::{InlineKeyboardMarkup, InputMessageContent, ParseMode};
 
 /// Represents a link to a voice recording in an .ogg container encoded with

--- a/src/types/input_file.rs
+++ b/src/types/input_file.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use std::path::PathBuf;
 
 /// This object represents the contents of a file to be uploaded.
@@ -60,7 +62,7 @@ impl From<InputFile> for Option<PathBuf> {
     }
 }
 
-impl serde::Serialize for InputFile {
+impl Serialize for InputFile {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,

--- a/src/types/input_media.rs
+++ b/src/types/input_media.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::types::{InputFile, ParseMode};
 
 // TODO: should variants use new-type?

--- a/src/types/input_message_content.rs
+++ b/src/types/input_message_content.rs
@@ -1,4 +1,4 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::types::ParseMode;
 

--- a/src/types/invoice.rs
+++ b/src/types/invoice.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 /// This object contains basic information about an invoice.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#invoice).

--- a/src/types/keyboard_button.rs
+++ b/src/types/keyboard_button.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 /// This object represents one button of the reply keyboard. For filter text
 /// buttons String can be used instead of this object to specify text of the
 /// button. Optional fields are mutually exclusive.

--- a/src/types/label_price.rs
+++ b/src/types/label_price.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 /// This object represents a portion of the price for goods or services.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#labeledprice).

--- a/src/types/location.rs
+++ b/src/types/location.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 /// This object represents a point on the map.
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct Location {

--- a/src/types/login_url.rs
+++ b/src/types/login_url.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 /// This object represents a parameter of the inline keyboard button used to
 /// automatically authorize a user. Serves as a great replacement for the
 /// [Telegram Login Widget] when the user is coming from Telegram. All the user

--- a/src/types/mask_position.rs
+++ b/src/types/mask_position.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 /// This object describes the position on faces where a mask should be placed by
 /// default.
 ///

--- a/src/types/message.rs
+++ b/src/types/message.rs
@@ -1,5 +1,7 @@
 #![allow(clippy::large_enum_variant)]
 
+use serde::{Deserialize, Serialize};
+
 use crate::types::{
     Animation, Audio, Chat, Contact, Document, Game, InlineKeyboardMarkup,
     Invoice, Location, MessageEntity, PassportData, PhotoSize, Poll, Sticker,

--- a/src/types/message_entity.rs
+++ b/src/types/message_entity.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::types::User;
 
 /// This object represents one special entity in a text message. For example,

--- a/src/types/order_info.rs
+++ b/src/types/order_info.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::types::ShippingAddress;
 
 /// This object represents information about an order.

--- a/src/types/passport_data.rs
+++ b/src/types/passport_data.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use super::{EncryptedCredentials, EncryptedPassportElement};
 
 /// Contains information about Telegram Passport data shared with the bot by the

--- a/src/types/passport_file.rs
+++ b/src/types/passport_file.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 /// This object represents a file uploaded to Telegram Passport. Currently all
 /// Telegram Passport files are in JPEG format when decrypted and don't exceed
 /// 10MB.

--- a/src/types/photo_size.rs
+++ b/src/types/photo_size.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 /// This object represents one size of a photo or a [file]/[sticker] thumbnail.
 ///
 /// [file]: crate::types::Document

--- a/src/types/poll.rs
+++ b/src/types/poll.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 /// This object contains information about a poll.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#poll).

--- a/src/types/pre_checkout_query.rs
+++ b/src/types/pre_checkout_query.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::types::{OrderInfo, User};
 
 /// This object contains information about an incoming pre-checkout query.

--- a/src/types/reply_keyboard_markup.rs
+++ b/src/types/reply_keyboard_markup.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::types::KeyboardButton;
 
 /// This object represents a [custom keyboard] with reply options (see

--- a/src/types/reply_keyboard_remove.rs
+++ b/src/types/reply_keyboard_remove.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::types::True;
 
 /// Upon receiving a message with this object, Telegram clients will remove the

--- a/src/types/reply_markup.rs
+++ b/src/types/reply_markup.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::types::{
     ForceReply, InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove,
 };

--- a/src/types/response_parameters.rs
+++ b/src/types/response_parameters.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 /// Contains information about why a request was unsuccessful.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#responseparameters).

--- a/src/types/send_invoice.rs
+++ b/src/types/send_invoice.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::types::{ChatId, InlineKeyboardMarkup, LabeledPrice};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]

--- a/src/types/shipping_address.rs
+++ b/src/types/shipping_address.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 /// This object represents a shipping address.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#shippingaddress).

--- a/src/types/shipping_option.rs
+++ b/src/types/shipping_option.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::types::LabeledPrice;
 
 /// This object represents one shipping option.

--- a/src/types/shipping_query.rs
+++ b/src/types/shipping_query.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::types::{ShippingAddress, User};
 
 /// This object contains information about an incoming shipping query.

--- a/src/types/sticker.rs
+++ b/src/types/sticker.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::types::{MaskPosition, PhotoSize};
 
 /// This object represents a sticker.

--- a/src/types/sticker_set.rs
+++ b/src/types/sticker_set.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::types::Sticker;
 
 /// This object represents a sticker set.

--- a/src/types/successful_payment.rs
+++ b/src/types/successful_payment.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::types::OrderInfo;
 
 /// This object contains basic information about a successful payment.

--- a/src/types/update.rs
+++ b/src/types/update.rs
@@ -1,5 +1,7 @@
 #![allow(clippy::large_enum_variant)]
 
+use serde::{Deserialize, Serialize};
+
 use crate::types::{CallbackQuery, ChosenInlineResult, InlineQuery, Message};
 
 /// This [object] represents an incoming update.

--- a/src/types/user.rs
+++ b/src/types/user.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 /// This object represents a Telegram user or bot.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#user).

--- a/src/types/user_profile_photos.rs
+++ b/src/types/user_profile_photos.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::types::PhotoSize;
 
 /// This object represent a user's profile pictures.

--- a/src/types/venue.rs
+++ b/src/types/venue.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::types::Location;
 
 /// This object represents a venue.

--- a/src/types/video.rs
+++ b/src/types/video.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::types::PhotoSize;
 
 /// This object represents a video file.

--- a/src/types/video_note.rs
+++ b/src/types/video_note.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::types::PhotoSize;
 
 /// This object represents a [video message] (available in Telegram apps as of

--- a/src/types/voice.rs
+++ b/src/types/voice.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 /// This object represents a voice note.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#voice).

--- a/src/types/webhook_info.rs
+++ b/src/types/webhook_info.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 /// Contains information about the current status of a webhook.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#webhookinfo).


### PR DESCRIPTION
In the 2018 edition it's possible to `use` macros instead of `#[macro_use] extern crate ...`. And `use` is prefered.