### PR TITLE
Skip serializing nones with `#[skip_serializing_none]`

### DIFF
--- a/src/types/animation.rs
+++ b/src/types/animation.rs
@@ -4,6 +4,7 @@ use crate::types::PhotoSize;
 /// without sound).
 ///
 /// [The official docs](https://core.telegram.org/bots/api#animation).
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct Animation {
     /// An identifier for this file.

--- a/src/types/audio.rs
+++ b/src/types/audio.rs
@@ -4,6 +4,7 @@ use crate::types::PhotoSize;
 /// clients.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#audio).
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct Audio {
     /// An identifier for this file.

--- a/src/types/callback_game.rs
+++ b/src/types/callback_game.rs
@@ -1,4 +1,5 @@
 /// A placeholder, currently holds no information. Use [@BotFather](https://t.me/botfather) to set up your game.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#callbackgame).
+// TODO: derives?
 pub struct CallbackGame;

--- a/src/types/callback_query.rs
+++ b/src/types/callback_query.rs
@@ -11,6 +11,7 @@ use crate::types::{Message, User};
 ///
 /// [inline keyboard]: https://core.telegram.org/bots#inline-keyboards-and-on-the-fly-updating
 /// [inline mode]: https://core.telegram.org/bots/api#inline-mode
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct CallbackQuery {
     /// An unique identifier for this query.

--- a/src/types/chat.rs
+++ b/src/types/chat.rs
@@ -3,6 +3,7 @@ use crate::types::{ChatPermissions, ChatPhoto, Message};
 /// This object represents a chat.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#chat).
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct Chat {
     /// A unique identifier for this chat. This number may be greater than 32
@@ -21,6 +22,7 @@ pub struct Chat {
     pub photo: Option<ChatPhoto>,
 }
 
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(untagged)]
 pub enum ChatKind {
@@ -74,6 +76,7 @@ pub enum ChatKind {
     },
 }
 
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
 #[serde(tag = "type")]

--- a/src/types/chat_permissions.rs
+++ b/src/types/chat_permissions.rs
@@ -2,45 +2,38 @@
 /// chat.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#chatpermissions).
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct ChatPermissions {
     /// `true`, if the user is allowed to send text messages, contacts,
     /// locations and venues.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub can_send_messages: Option<bool>,
 
     /// `true`, if the user is allowed to send audios, documents,
     /// photos, videos, video notes and voice notes, implies
     /// `can_send_messages`.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub can_send_media_messages: Option<bool>,
 
     /// `true`, if the user is allowed to send polls, implies
     /// `can_send_messages`.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub can_send_polls: Option<bool>,
 
     /// `true`, if the user is allowed to send animations, games, stickers and
     /// use inline bots, implies `can_send_media_messages`.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub can_send_other_messages: Option<bool>,
 
     /// `true`, if the user is allowed to add web page previews to
     /// their messages, implies `can_send_media_messages`.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub can_add_web_page_previews: Option<bool>,
 
     /// `true`, if the user is allowed to change the chat title, photo and
     /// other settings. Ignored in public supergroups.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub can_change_info: Option<bool>,
 
     /// `true`, if the user is allowed to invite new users to the chat.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub can_invite_users: Option<bool>,
 
     /// `true`, if the user is allowed to pin messages. Ignored in public
     /// supergroups.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub can_pin_messages: Option<bool>,
 }

--- a/src/types/chosen_inline_result.rs
+++ b/src/types/chosen_inline_result.rs
@@ -6,6 +6,7 @@ use crate::types::{Location, User};
 /// [The official docs](https://core.telegram.org/bots/api#choseninlineresult).
 ///
 /// [result]: https://core.telegram.org/bots/api#inlinequeryresult
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct ChosenInlineResult {
     /// The unique identifier for the result that was chosen.

--- a/src/types/contact.rs
+++ b/src/types/contact.rs
@@ -1,6 +1,7 @@
 /// This object represents a phone contact.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#contact).
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct Contact {
     /// A contact's phone number.

--- a/src/types/document.rs
+++ b/src/types/document.rs
@@ -8,6 +8,7 @@ use crate::types::PhotoSize;
 /// [photos]: https://core.telegram.org/bots/api#photosize
 /// [voice messages]: https://core.telegram.org/bots/api#voice
 /// [audio files]: https://core.telegram.org/bots/api#audio
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct Document {
     /// An identifier for this file.

--- a/src/types/encrypted_credentials.rs
+++ b/src/types/encrypted_credentials.rs
@@ -7,6 +7,7 @@
 /// [`EncryptedPassportElement`]:
 /// crate::types::EncryptedPassportElement
 /// [Telegram Passport Documentation]: https://core.telegram.org/passport#receiving-information
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct EncryptedCredentials {
     /// Base64-encoded encrypted JSON-serialized data with unique user's

--- a/src/types/encrypted_passport_element.rs
+++ b/src/types/encrypted_passport_element.rs
@@ -17,6 +17,7 @@ pub struct EncryptedPassportElement {
     pub kind: EncryptedPassportElementKind,
 }
 
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum EncryptedPassportElementKind {

--- a/src/types/file.rs
+++ b/src/types/file.rs
@@ -14,6 +14,7 @@ pub struct File {
     /// File size, if known.
     pub file_size: u32,
 
+    // TODO: chacge "Use ..." to use bot.download...
     /// File path. Use `https://api.telegram.org/file/bot<token>/<file_path>`
     /// to get the file.
     pub file_path: String,

--- a/src/types/force_reply.rs
+++ b/src/types/force_reply.rs
@@ -9,6 +9,7 @@ use crate::types::True;
 /// [The official docs](https://core.telegram.org/bots/api#forcereply).
 ///
 /// [privacy mode]: https://core.telegram.org/bots#privacy-mode
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct ForceReply {
     /// Shows reply interface to the user, as if they manually selected the
@@ -21,6 +22,5 @@ pub struct ForceReply {
     /// (has reply_to_message_id), sender of the original message.
     ///
     /// [`Message`]: crate::types::Message
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub selective: Option<bool>,
 }

--- a/src/types/game.rs
+++ b/src/types/game.rs
@@ -6,6 +6,7 @@ use crate::types::{Animation, MessageEntity, PhotoSize};
 /// their short names will act as unique identifiers.
 ///
 /// [@Botfather]: https://t.me/botfather
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct Game {
     /// Title of the game.

--- a/src/types/inline_query.rs
+++ b/src/types/inline_query.rs
@@ -4,6 +4,7 @@ use crate::types::{Location, User};
 /// empty query, your bot could return some default or trending results.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#inlinequery).
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct InlineQuery {
     /// Unique identifier for this query.

--- a/src/types/inline_query_result_article.rs
+++ b/src/types/inline_query_result_article.rs
@@ -3,6 +3,7 @@ use crate::types::{InlineKeyboardMarkup, InputMessageContent};
 /// Represents a link to an article or web page.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#inlinequeryresultarticle).
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct InlineQueryResultArticle {
     /// Unique identifier for this result, 1-64 Bytes.
@@ -15,31 +16,24 @@ pub struct InlineQueryResultArticle {
     pub input_message_content: InputMessageContent,
 
     /// Inline keyboard attached to the message.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_markup: Option<InlineKeyboardMarkup>,
 
     /// URL of the result.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
 
     /// Pass `true`, if you don't want the URL to be shown in the
     /// message.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub hide_url: Option<bool>,
 
     /// Short description of the result.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
 
     /// Url of the thumbnail for the result.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub thumb_url: Option<String>,
 
     /// Thumbnail width.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub thumb_width: Option<i32>,
 
     /// Thumbnail height.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub thumb_height: Option<i32>,
 }

--- a/src/types/inline_query_result_audio.rs
+++ b/src/types/inline_query_result_audio.rs
@@ -5,6 +5,7 @@ use crate::types::{InlineKeyboardMarkup, InputMessageContent, ParseMode};
 /// a message with the specified content instead of the audio.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#inlinequeryresultaudio).
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct InlineQueryResultAudio {
     /// Unique identifier for this result, 1-64 bytes.
@@ -17,7 +18,6 @@ pub struct InlineQueryResultAudio {
     pub title: String,
 
     /// Caption, 0-1024 characters.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub caption: Option<String>,
 
     /// Send [Markdown] or [HTML], if you want Telegram apps to show [bold,
@@ -26,24 +26,19 @@ pub struct InlineQueryResultAudio {
     /// [Markdown]: https://core.telegram.org/bots/api#markdown-style
     /// [HTML]: https://core.telegram.org/bots/api#html-style
     /// [bold, italic, fixed-width text or inline URLs]: https://core.telegram.org/bots/api#formatting-options
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub parse_mode: Option<ParseMode>,
 
     /// Performer.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub performer: Option<String>,
 
     /// Audio duration in seconds.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub audio_duration: Option<String>,
 
     /// [Inline keyboard] attached to the message.
     ///
     /// [Inline keyboard]: https://core.telegram.org/bots#inline-keyboards-and-on-the-fly-updating
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_markup: Option<InlineKeyboardMarkup>,
 
     /// Content of the message to be sent instead of the audio.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub input_message_content: Option<InputMessageContent>,
 }

--- a/src/types/inline_query_result_cached_audio.rs
+++ b/src/types/inline_query_result_cached_audio.rs
@@ -6,6 +6,7 @@ use crate::types::{InlineKeyboardMarkup, InputMessageContent, ParseMode};
 /// instead of the audio.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#inlinequeryresultcachedaudio).
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct InlineQueryResultCachedAudio {
     /// Unique identifier for this result, 1-64 bytes.
@@ -15,7 +16,6 @@ pub struct InlineQueryResultCachedAudio {
     pub audio_file_id: String,
 
     /// Caption, 0-1024 characters.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub caption: Option<String>,
 
     /// Send [Markdown] or [HTML], if you want Telegram apps to show [bold,
@@ -24,16 +24,13 @@ pub struct InlineQueryResultCachedAudio {
     /// [Markdown]: https://core.telegram.org/bots/api#markdown-style
     /// [HTML]: https://core.telegram.org/bots/api#html-style
     /// [bold, italic, fixed-width text or inline URLs]: https://core.telegram.org/bots/api#formatting-options
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub parse_mode: Option<ParseMode>,
 
     /// [Inline keyboard] attached to the message.
     ///
     /// [Inline keyboard]: https://core.telegram.org/bots#inline-keyboards-and-on-the-fly-updating
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_markup: Option<InlineKeyboardMarkup>,
 
     /// Content of the message to be sent instead of the audio.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub input_message_content: Option<InputMessageContent>,
 }

--- a/src/types/inline_query_result_cached_document.rs
+++ b/src/types/inline_query_result_cached_document.rs
@@ -6,6 +6,7 @@ use crate::types::{InlineKeyboardMarkup, InputMessageContent, ParseMode};
 /// instead of the file.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#inlinequeryresultcacheddocument).
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct InlineQueryResultCachedDocument {
     /// Unique identifier for this result, 1-64 bytes.
@@ -18,11 +19,9 @@ pub struct InlineQueryResultCachedDocument {
     pub document_file_id: String,
 
     /// Short description of the result.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
 
     /// Caption of the document to be sent, 0-1024 characters.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub caption: Option<String>,
 
     /// Send [Markdown] or [HTML], if you want Telegram apps to show [bold,
@@ -31,16 +30,13 @@ pub struct InlineQueryResultCachedDocument {
     /// [Markdown]: https://core.telegram.org/bots/api#markdown-style
     /// [HTML]: https://core.telegram.org/bots/api#html-style
     /// [bold, italic, fixed-width text or inline URLs]: https://core.telegram.org/bots/api#formatting-options
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub parse_mode: Option<ParseMode>,
 
     /// [Inline keyboard] attached to the message.
     ///
     /// [Inline keyboard]: https://core.telegram.org/bots#inline-keyboards-and-on-the-fly-updating
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_markup: Option<InlineKeyboardMarkup>,
 
     /// Content of the message to be sent instead of the file.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub input_message_content: Option<InputMessageContent>,
 }

--- a/src/types/inline_query_result_cached_gif.rs
+++ b/src/types/inline_query_result_cached_gif.rs
@@ -6,6 +6,7 @@ use crate::types::{InlineKeyboardMarkup, InputMessageContent, ParseMode};
 /// message with specified content instead of the animation.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#inlinequeryresultcachedgif).
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct InlineQueryResultCachedGif {
     /// Unique identifier for this result, 1-64 bytes.
@@ -15,11 +16,9 @@ pub struct InlineQueryResultCachedGif {
     pub gif_file_id: String,
 
     /// Title for the result.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
 
     /// Caption of the GIF file to be sent, 0-1024 characters.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub caption: Option<String>,
 
     /// Send [`ParseMode::Markdown`] or [`ParseMode::HTML`], if you want
@@ -29,16 +28,13 @@ pub struct InlineQueryResultCachedGif {
     /// [`ParseMode::Markdown`]: crate::types::ParseMode::Markdown
     /// [`ParseMode::HTML`]: crate::types::ParseMode::HTML
     /// [bold, italic, fixed-width text or inline URLs]: https://core.telegram.org/bots/api#formatting-options
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub parse_mode: Option<ParseMode>,
 
     /// [Inline keyboard] attached to the message.
     ///
     /// [Inline keyboard]: https://core.telegram.org/bots#inline-keyboards-and-on-the-fly-updating
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_markup: Option<InlineKeyboardMarkup>,
 
     /// Content of the message to be sent instead of the GIF animation.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub input_message_content: Option<InputMessageContent>,
 }

--- a/src/types/inline_query_result_cached_mpeg4_gif.rs
+++ b/src/types/inline_query_result_cached_mpeg4_gif.rs
@@ -7,6 +7,7 @@ use crate::types::{InlineKeyboardMarkup, InputMessageContent, ParseMode};
 /// instead of the animation.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#inlinequeryresultcachedmpeg4gif).
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct InlineQueryResultCachedMpeg4Gif {
     /// Unique identifier for this result, 1-64 bytes.
@@ -16,11 +17,9 @@ pub struct InlineQueryResultCachedMpeg4Gif {
     pub mpeg4_file_id: String,
 
     /// Title for the result.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
 
     /// Caption of the MPEG-4 file to be sent, 0-1024 characters.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub caption: Option<String>,
 
     /// Send [Markdown] or [HTML], if you want Telegram apps to show [bold,
@@ -29,16 +28,13 @@ pub struct InlineQueryResultCachedMpeg4Gif {
     /// [Markdown]: https://core.telegram.org/bots/api#markdown-style
     /// [HTML]: https://core.telegram.org/bots/api#html-style
     /// [bold, italic, fixed-width text or inline URLs]: https://core.telegram.org/bots/api#formatting-options
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub parse_mode: Option<ParseMode>,
 
     /// [Inline keyboard] attached to the message.
     ///
     /// [Inline keyboard]: https://core.telegram.org/bots#inline-keyboards-and-on-the-fly-updating
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_markup: Option<InlineKeyboardMarkup>,
 
     /// Content of the message to be sent instead of the video animation.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub input_message_content: Option<InputMessageContent>,
 }

--- a/src/types/inline_query_result_cached_photo.rs
+++ b/src/types/inline_query_result_cached_photo.rs
@@ -6,6 +6,7 @@ use crate::types::{InlineKeyboardMarkup, InputMessageContent, ParseMode};
 /// content instead of the photo.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#inlinequeryresultcachedphoto).
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct InlineQueryResultCachedPhoto {
     /// Unique identifier for this result, 1-64 bytes.
@@ -15,15 +16,12 @@ pub struct InlineQueryResultCachedPhoto {
     pub photo_file_id: String,
 
     /// Title for the result.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
 
     /// Short description of the result.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
 
     /// Caption of the photo to be sent, 0-1024 characters.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub caption: Option<String>,
 
     /// Send [Markdown] or [HTML], if you want Telegram apps to show [bold,
@@ -32,16 +30,13 @@ pub struct InlineQueryResultCachedPhoto {
     /// [Markdown]: https://core.telegram.org/bots/api#markdown-style
     /// [HTML]: https://core.telegram.org/bots/api#html-style
     /// [bold, italic, fixed-width text or inline URLs]: https://core.telegram.org/bots/api#formatting-options
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub parse_mode: Option<ParseMode>,
 
     /// [Inline keyboard] attached to the message.
     ///
     /// [Inline keyboard]: https://core.telegram.org/bots#inline-keyboards-and-on-the-fly-updating
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_markup: Option<InlineKeyboardMarkup>,
 
     /// Content of the message to be sent instead of the photo.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub input_message_content: Option<InputMessageContent>,
 }

--- a/src/types/inline_query_result_cached_sticker.rs
+++ b/src/types/inline_query_result_cached_sticker.rs
@@ -6,6 +6,7 @@ use crate::types::{InlineKeyboardMarkup, InputMessageContent};
 /// of the sticker.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#inlinequeryresultcachedsticker).
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct InlineQueryResultCachedSticker {
     /// Unique identifier for this result, 1-64 bytes.
@@ -17,10 +18,8 @@ pub struct InlineQueryResultCachedSticker {
     /// [Inline keyboard] attached to the message.
     ///
     /// [Inline keyboard]: https://core.telegram.org/bots#inline-keyboards-and-on-the-fly-updating
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_markup: Option<InlineKeyboardMarkup>,
 
     /// Content of the message to be sent instead of the sticker.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub input_message_content: Option<InputMessageContent>,
 }

--- a/src/types/inline_query_result_cached_video.rs
+++ b/src/types/inline_query_result_cached_video.rs
@@ -6,6 +6,7 @@ use crate::types::{InlineKeyboardMarkup, InputMessageContent, ParseMode};
 /// the specified content instead of the video.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#inlinequeryresultcachedvideo).
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct InlineQueryResultCachedVideo {
     /// Unique identifier for this result, 1-64 bytes.
@@ -18,11 +19,9 @@ pub struct InlineQueryResultCachedVideo {
     pub title: String,
 
     /// Short description of the result.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
 
     /// Caption of the video to be sent, 0-1024 characters.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub caption: Option<String>,
 
     /// Send [Markdown] or [HTML], if you want Telegram apps to show [bold,
@@ -31,16 +30,13 @@ pub struct InlineQueryResultCachedVideo {
     /// [Markdown]: https://core.telegram.org/bots/api#markdown-style
     /// [HTML]: https://core.telegram.org/bots/api#html-style
     /// [bold, italic, fixed-width text or inline URLs]: https://core.telegram.org/bots/api#formatting-options
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub parse_mode: Option<ParseMode>,
 
     /// [Inline keyboard] attached to the message.
     ///
     /// [Inline keyboard]: https://core.telegram.org/bots#inline-keyboards-and-on-the-fly-updating
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_markup: Option<InlineKeyboardMarkup>,
 
     /// Content of the message to be sent instead of the video.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub input_message_content: Option<InputMessageContent>,
 }

--- a/src/types/inline_query_result_cached_voice.rs
+++ b/src/types/inline_query_result_cached_voice.rs
@@ -6,6 +6,7 @@ use crate::types::{InlineKeyboardMarkup, InputMessageContent, ParseMode};
 /// instead of the voice message.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#inlinequeryresultcachedvideo).
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct InlineQueryResultCachedVoice {
     /// Unique identifier for this result, 1-64 bytes.
@@ -18,7 +19,6 @@ pub struct InlineQueryResultCachedVoice {
     pub title: String,
 
     /// Caption, 0-1024 characters.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub caption: Option<String>,
 
     /// Send [Markdown] or [HTML], if you want Telegram apps to show [bold,
@@ -27,16 +27,13 @@ pub struct InlineQueryResultCachedVoice {
     /// [Markdown]: https://core.telegram.org/bots/api#markdown-style
     /// [HTML]: https://core.telegram.org/bots/api#html-style
     /// [bold, italic, fixed-width text or inline URLs]: https://core.telegram.org/bots/api#formatting-options
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub parse_mode: Option<ParseMode>,
 
     /// [Inline keyboard] attached to the message.
     ///
     /// [Inline keyboard]: https://core.telegram.org/bots#inline-keyboards-and-on-the-fly-updating
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_markup: Option<InlineKeyboardMarkup>,
 
     /// Content of the message to be sent instead of the voice message.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub input_message_content: Option<InputMessageContent>,
 }

--- a/src/types/inline_query_result_contact.rs
+++ b/src/types/inline_query_result_contact.rs
@@ -5,6 +5,7 @@ use crate::types::{InlineKeyboardMarkup, InputMessageContent};
 /// a message with the specified content instead of the contact.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#inlinequeryresultcachedvideo).
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct InlineQueryResultContact {
     /// Unique identifier for this result, 1-64 Bytes.
@@ -17,35 +18,28 @@ pub struct InlineQueryResultContact {
     pub first_name: String,
 
     /// Contact's last name.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub last_name: Option<String>,
 
     /// Additional data about the contact in the form of a [vCard], 0-2048
     /// bytes.
     ///
     /// [VCard]: https://en.wikipedia.org/wiki/VCard
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub vcard: Option<String>,
 
     /// [Inline keyboard] attached to the message.
     ///
     /// [Inline keyboard]: https://core.telegram.org/bots#inline-keyboards-and-on-the-fly-updating
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_markup: Option<InlineKeyboardMarkup>,
 
     /// Content of the message to be sent instead of the contact.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub input_message_content: Option<InputMessageContent>,
 
     /// Url of the thumbnail for the result.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub thumb_url: Option<String>,
 
     /// Thumbnail width.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub thumb_width: Option<i32>,
 
     /// Thumbnail height.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub thumb_height: Option<i32>,
 }

--- a/src/types/inline_query_result_document.rs
+++ b/src/types/inline_query_result_document.rs
@@ -6,6 +6,7 @@ use crate::types::{InlineKeyboardMarkup, InputMessageContent, ParseMode};
 /// only **.PDF** and **.ZIP** files can be sent using this method.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#inlinequeryresultdocument).
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct InlineQueryResultDocument {
     /// Unique identifier for this result, 1-64 bytes.
@@ -15,7 +16,6 @@ pub struct InlineQueryResultDocument {
     pub title: String,
 
     /// Caption of the document to be sent, 0-1024 characters.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub caption: Option<String>,
 
     /// Send [Markdown] or [HTML], if you want Telegram apps to show [bold,
@@ -24,7 +24,6 @@ pub struct InlineQueryResultDocument {
     /// [Markdown]: https://core.telegram.org/bots/api#markdown-style
     /// [HTML]: https://core.telegram.org/bots/api#html-style
     /// [bold, italic, fixed-width text or inline URLs]: https://core.telegram.org/bots/api#formatting-options
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub parse_mode: Option<ParseMode>,
 
     /// A valid URL for the file.
@@ -35,26 +34,20 @@ pub struct InlineQueryResultDocument {
     pub mime_type: String,
 
     /// Short description of the result.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
 
     /// Inline keyboard attached to the message.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_markup: Option<InlineKeyboardMarkup>,
 
     /// Content of the message to be sent instead of the file.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub input_message_content: Option<InputMessageContent>,
 
     /// URL of the thumbnail (jpeg only) for the file.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub thumb_url: Option<String>,
 
     /// Thumbnail width.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub thumb_width: Option<i32>,
 
     /// Thumbnail height.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub thumb_height: Option<i32>,
 }

--- a/src/types/inline_query_result_game.rs
+++ b/src/types/inline_query_result_game.rs
@@ -5,6 +5,7 @@ use crate::types::InlineKeyboardMarkup;
 /// [The official docs](https://core.telegram.org/bots/api#inlinequeryresultgame).
 ///
 /// [game]: https://core.telegram.org/bots/api#games
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct InlineQueryResultGame {
     /// Unique identifier for this result, 1-64 bytes.
@@ -16,6 +17,5 @@ pub struct InlineQueryResultGame {
     /// [Inline keyboard] attached to the message.
     ///
     /// [Inline keyboard]: https://core.telegram.org/bots#inline-keyboards-and-on-the-fly-updating
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_markup: Option<InlineKeyboardMarkup>,
 }

--- a/src/types/inline_query_result_gif.rs
+++ b/src/types/inline_query_result_gif.rs
@@ -6,6 +6,7 @@ use crate::types::{InlineKeyboardMarkup, InputMessageContent, ParseMode};
 /// instead of the animation.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#inlinequeryresultgif).
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct InlineQueryResultGif {
     /// Unique identifier for this result, 1-64 bytes.
@@ -15,26 +16,21 @@ pub struct InlineQueryResultGif {
     pub gif_url: String,
 
     /// Width of the GIF.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub gif_width: Option<i32>,
 
     /// Height of the GIFv.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub gif_height: Option<i32>,
 
     /// Duration of the GIF.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub gif_duration: Option<i32>,
 
     /// URL of the static thumbnail for the result (jpeg or gif).
     pub thumb_url: String,
 
     /// Title for the result.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
 
     /// Caption of the GIF file to be sent, 0-1024 characters.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub caption: Option<String>,
 
     /// Send [Markdown] or [HTML], if you want Telegram apps to show [bold,
@@ -43,16 +39,13 @@ pub struct InlineQueryResultGif {
     /// [Markdown]: https://core.telegram.org/bots/api#markdown-style
     /// [HTML]: https://core.telegram.org/bots/api#html-style
     /// [bold, italic, fixed-width text or inline URLs]: https://core.telegram.org/bots/api#formatting-options
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub parse_mode: Option<ParseMode>,
 
     /// [Inline keyboard] attached to the message.
     ///
     /// [Inline keyboard]: https://core.telegram.org/bots#inline-keyboards-and-on-the-fly-updating
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_markup: Option<InlineKeyboardMarkup>,
 
     /// Content of the message to be sent instead of the GIF animation.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub input_message_content: Option<InputMessageContent>,
 }

--- a/src/types/inline_query_result_location.rs
+++ b/src/types/inline_query_result_location.rs
@@ -5,6 +5,7 @@ use crate::types::{InlineKeyboardMarkup, InputMessageContent};
 /// with the specified content instead of the location.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#inlinequeryresultlocation).
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct InlineQueryResultLocation {
     /// Unique identifier for this result, 1-64 Bytes.
@@ -21,28 +22,22 @@ pub struct InlineQueryResultLocation {
 
     /// Period in seconds for which the location can be updated, should be
     /// between 60 and 86400.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub live_period: Option<i32>,
 
     /// [Inline keyboard] attached to the message.
     ///
     /// [Inline keyboard]: https://core.telegram.org/bots#inline-keyboards-and-on-the-fly-updating
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_markup: Option<InlineKeyboardMarkup>,
 
     /// Content of the message to be sent instead of the location.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub input_message_content: Option<InputMessageContent>,
 
     /// Url of the thumbnail for the result.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub thumb_url: Option<String>,
 
     /// Thumbnail width.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub thumb_width: Option<i32>,
 
     /// Thumbnail height.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub thumb_height: Option<i32>,
 }

--- a/src/types/inline_query_result_mpeg4_gif.rs
+++ b/src/types/inline_query_result_mpeg4_gif.rs
@@ -6,6 +6,7 @@ use crate::types::{InlineKeyboardMarkup, InputMessageContent, ParseMode};
 /// a message with the specified content instead of the animation.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#inlinequeryresultmpeg4gif).
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct InlineQueryResultMpeg4Gif {
     /// Unique identifier for this result, 1-64 bytes.
@@ -15,26 +16,21 @@ pub struct InlineQueryResultMpeg4Gif {
     pub mpeg4_url: String,
 
     /// Video width.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub mpeg4_width: Option<i32>,
 
     /// Video height.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub mpeg4_height: Option<i32>,
 
     /// Video duration.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub mpeg4_duration: Option<i32>,
 
     /// URL of the static thumbnail (jpeg or gif) for the result.
     pub thumb_url: String,
 
     /// Title for the result.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
 
     /// Caption of the MPEG-4 file to be sent, 0-1024 characters.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub caption: Option<String>,
 
     /// Send [Markdown] or [HTML], if you want Telegram apps to show [bold,
@@ -43,16 +39,13 @@ pub struct InlineQueryResultMpeg4Gif {
     /// [Markdown]: https://core.telegram.org/bots/api#markdown-style
     /// [HTML]: https://core.telegram.org/bots/api#html-style
     /// [bold, italic, fixed-width text or inline URLs]: https://core.telegram.org/bots/api#formatting-options
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub parse_mode: Option<ParseMode>,
 
     /// [Inline keyboard] attached to the message.
     ///
     /// [Inline keyboard]: https://core.telegram.org/bots#inline-keyboards-and-on-the-fly-updating
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_markup: Option<InlineKeyboardMarkup>,
 
     /// Content of the message to be sent instead of the video animation.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub input_message_content: Option<InputMessageContent>,
 }

--- a/src/types/inline_query_result_photo.rs
+++ b/src/types/inline_query_result_photo.rs
@@ -6,6 +6,7 @@ use crate::types::{InlineKeyboardMarkup, InputMessageContent, ParseMode};
 /// of the photo.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#inlinequeryresultphoto).
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct InlineQueryResultPhoto {
     /// Unique identifier for this result, 1-64 bytes.
@@ -19,23 +20,18 @@ pub struct InlineQueryResultPhoto {
     pub thumb_url: String,
 
     /// Width of the photo.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub photo_width: Option<i32>,
 
     /// Height of the photo.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub photo_height: Option<i32>,
 
     /// Title for the result.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
 
     /// Short description of the result.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
 
     /// Caption of the photo to be sent, 0-1024 characters.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub caption: Option<String>,
 
     /// Send [Markdown] or [HTML], if you want Telegram apps to show [bold,
@@ -44,16 +40,13 @@ pub struct InlineQueryResultPhoto {
     /// [Markdown]: https://core.telegram.org/bots/api#markdown-style
     /// [HTML]: https://core.telegram.org/bots/api#html-style
     /// [bold, italic, fixed-width text or inline URLs]: https://core.telegram.org/bots/api#formatting-options
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub parse_mode: Option<ParseMode>,
 
     /// [Inline keyboard] attached to the message.
     ///
     /// [Inline keyboard]: https://core.telegram.org/bots#inline-keyboards-and-on-the-fly-updating
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_markup: Option<InlineKeyboardMarkup>,
 
     /// Content of the message to be sent instead of the photo.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub input_message_content: Option<InputMessageContent>,
 }

--- a/src/types/inline_query_result_venue.rs
+++ b/src/types/inline_query_result_venue.rs
@@ -5,6 +5,7 @@ use crate::types::{InlineKeyboardMarkup, InputMessageContent};
 /// the specified content instead of the venue.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#inlinequeryresultvenue).
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct InlineQueryResultVenue {
     /// Unique identifier for this result, 1-64 Bytes.
@@ -23,34 +24,27 @@ pub struct InlineQueryResultVenue {
     pub address: String,
 
     /// Foursquare identifier of the venue if known.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub foursquare_id: Option<String>,
 
     /// Foursquare type of the venue, if known. (For example,
     /// `arts_entertainment/default`, `arts_entertainment/aquarium` or
     /// `food/icecream`.)
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub foursquare_type: Option<String>,
 
     /// [Inline keyboard] attached to the message.
     ///
     /// [Inline keyboard]: https://core.telegram.org/bots#inline-keyboards-and-on-the-fly-updating
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_markup: Option<InlineKeyboardMarkup>,
 
     /// Content of the message to be sent instead of the venue.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub input_message_content: Option<InputMessageContent>,
 
     /// Url of the thumbnail for the result.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub thumb_url: Option<String>,
 
     /// Thumbnail width.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub thumb_width: Option<i32>,
 
     /// Thumbnail height.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub thumb_height: Option<i32>,
 }

--- a/src/types/inline_query_result_video.rs
+++ b/src/types/inline_query_result_video.rs
@@ -6,6 +6,7 @@ use crate::types::{InlineKeyboardMarkup, InputMessageContent, ParseMode};
 /// message with the specified content instead of the video.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#inlinequeryresultvideo).
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct InlineQueryResultVideo {
     /// Unique identifier for this result, 1-64 bytes.
@@ -24,7 +25,6 @@ pub struct InlineQueryResultVideo {
     pub title: String,
 
     /// Caption of the video to be sent, 0-1024 characters.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub caption: Option<String>,
 
     /// Send [Markdown] or [HTML], if you want Telegram apps to show [bold,
@@ -33,29 +33,23 @@ pub struct InlineQueryResultVideo {
     /// [Markdown]: https://core.telegram.org/bots/api#markdown-style
     /// [HTML]: https://core.telegram.org/bots/api#html-style
     /// [bold, italic, fixed-width text or inline URLs]: https://core.telegram.org/bots/api#formatting-options
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub parse_mode: Option<ParseMode>,
 
     /// Video width.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub video_width: Option<i32>,
 
     /// Video height.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub video_height: Option<i32>,
 
     /// Video duration in seconds.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub video_duration: Option<i32>,
 
     /// Short description of the result.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
 
     /// [Inline keyboard] attached to the message.
     ///
     /// [Inline keyboard]: https://core.telegram.org/bots#inline-keyboards-and-on-the-fly-updating
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_markup: Option<InlineKeyboardMarkup>,
 
     /// Content of the message to be sent instead of the video. This field is
@@ -64,6 +58,5 @@ pub struct InlineQueryResultVideo {
     ///
     /// [`InlineQueryResultVideo`]:
     /// crate::types::InlineQueryResultVideo
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub input_message_content: Option<InputMessageContent>,
 }

--- a/src/types/inline_query_result_voice.rs
+++ b/src/types/inline_query_result_voice.rs
@@ -6,6 +6,7 @@ use crate::types::{InlineKeyboardMarkup, InputMessageContent, ParseMode};
 /// the specified content instead of the the voice message.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#inlinequeryresultvoice).
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct InlineQueryResultVoice {
     /// Unique identifier for this result, 1-64 bytes.
@@ -18,7 +19,6 @@ pub struct InlineQueryResultVoice {
     pub title: String,
 
     /// Caption, 0-1024 characters.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub caption: Option<String>,
 
     /// Send [Markdown] or [HTML], if you want Telegram apps to show [bold,
@@ -27,20 +27,16 @@ pub struct InlineQueryResultVoice {
     /// [Markdown]: https://core.telegram.org/bots/api#markdown-style
     /// [HTML]: https://core.telegram.org/bots/api#html-style
     /// [bold, italic, fixed-width text or inline URLs]: https://core.telegram.org/bots/api#formatting-options
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub parse_mode: Option<ParseMode>,
 
     /// Recording duration in seconds.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub voice_duration: Option<i32>,
 
     /// [Inline keyboard] attached to the message.
     ///
     /// [Inline keyboard]: https://core.telegram.org/bots#inline-keyboards-and-on-the-fly-updating
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_markup: Option<InlineKeyboardMarkup>,
 
     /// Content of the message to be sent instead of the voice recording.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub input_message_content: Option<InputMessageContent>,
 }

--- a/src/types/input_media.rs
+++ b/src/types/input_media.rs
@@ -1,6 +1,7 @@
 use crate::types::{InputFile, ParseMode};
 
 // TODO: should variants use new-type?
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 #[serde(tag = "type")]
 #[serde(rename_all = "snake_case")]
@@ -16,7 +17,6 @@ pub enum InputMedia {
         media: InputFile,
 
         /// Caption of the photo to be sent, 0-1024 characters.
-        #[serde(skip_serializing_if = "Option::is_none")]
         caption: Option<String>,
 
         /// Send [Markdown] or [HTML], if you want Telegram apps to show [bold,
@@ -25,7 +25,6 @@ pub enum InputMedia {
         /// [Markdown]: https://core.telegram.org/bots/api#markdown-style
         /// [HTML]: https://core.telegram.org/bots/api#html-style
         /// [bold, italic, fixed-width text or inline URLs]: https://core.telegram.org/bots/api#formatting-options
-        #[serde(skip_serializing_if = "Option::is_none")]
         parse_mode: Option<ParseMode>,
     },
 
@@ -41,11 +40,9 @@ pub enum InputMedia {
         /// JPEG format and less than 200 kB in size. A thumbnail‘s width and
         /// height should not exceed 320. Ignored if the file is not uploaded
         /// using multipart/form-data.
-        #[serde(skip_serializing_if = "Option::is_none")]
         thumb: Option<InputFile>,
 
         /// Caption of the video to be sent, 0-1024 characters.
-        #[serde(skip_serializing_if = "Option::is_none")]
         caption: Option<String>,
 
         /// Send [Markdown] or [HTML], if you want Telegram apps to show [bold,
@@ -54,23 +51,18 @@ pub enum InputMedia {
         /// [Markdown]: https://core.telegram.org/bots/api#markdown-style
         /// [HTML]: https://core.telegram.org/bots/api#html-style
         /// [bold, italic, fixed-width text or inline URLs]: https://core.telegram.org/bots/api#formatting-options
-        #[serde(skip_serializing_if = "Option::is_none")]
         parse_mode: Option<ParseMode>,
 
         /// Video width.
-        #[serde(skip_serializing_if = "Option::is_none")]
         width: Option<u16>,
 
         /// Video height.
-        #[serde(skip_serializing_if = "Option::is_none")]
         height: Option<u16>,
 
         /// Video duration.
-        #[serde(skip_serializing_if = "Option::is_none")]
         duration: Option<u16>,
 
         /// Pass `true`, if the uploaded video is suitable for streaming.
-        #[serde(skip_serializing_if = "Option::is_none")]
         supports_streaming: Option<bool>,
     },
 
@@ -87,11 +79,9 @@ pub enum InputMedia {
         /// JPEG format and less than 200 kB in size. A thumbnail‘s width and
         /// height should not exceed 320. Ignored if the file is not uploaded
         /// using multipart/form-data.
-        #[serde(skip_serializing_if = "Option::is_none")]
         thumb: Option<InputFile>,
 
         /// Caption of the animation to be sent, 0-1024 characters.
-        #[serde(skip_serializing_if = "Option::is_none")]
         caption: Option<String>,
 
         /// Send [Markdown] or [HTML], if you want Telegram apps to show [bold,
@@ -100,19 +90,15 @@ pub enum InputMedia {
         /// [Markdown]: https://core.telegram.org/bots/api#markdown-style
         /// [HTML]: https://core.telegram.org/bots/api#html-style
         /// [bold, italic, fixed-width text or inline URLs]: https://core.telegram.org/bots/api#formatting-options
-        #[serde(skip_serializing_if = "Option::is_none")]
         parse_mode: Option<ParseMode>,
 
         /// Animation width.
-        #[serde(skip_serializing_if = "Option::is_none")]
         width: Option<u16>,
 
         /// Animation height.
-        #[serde(skip_serializing_if = "Option::is_none")]
         height: Option<u16>,
 
         /// Animation duration.
-        #[serde(skip_serializing_if = "Option::is_none")]
         duration: Option<u16>,
     },
 
@@ -128,11 +114,9 @@ pub enum InputMedia {
         /// JPEG format and less than 200 kB in size. A thumbnail‘s width and
         /// height should not exceed 320. Ignored if the file is not uploaded
         /// using multipart/form-data.
-        #[serde(skip_serializing_if = "Option::is_none")]
         thumb: Option<InputFile>,
 
         /// Caption of the audio to be sent, 0-1024 characters.
-        #[serde(skip_serializing_if = "Option::is_none")]
         caption: Option<String>,
 
         /// Send [Markdown] or [HTML], if you want Telegram apps to show [bold,
@@ -141,19 +125,15 @@ pub enum InputMedia {
         /// [Markdown]: https://core.telegram.org/bots/api#markdown-style
         /// [HTML]: https://core.telegram.org/bots/api#html-style
         /// [bold, italic, fixed-width text or inline URLs]: https://core.telegram.org/bots/api#formatting-options
-        #[serde(skip_serializing_if = "Option::is_none")]
         parse_mode: Option<String>,
 
         /// Duration of the audio in seconds.
-        #[serde(skip_serializing_if = "Option::is_none")]
         duration: Option<u16>,
 
         /// Performer of the audio.
-        #[serde(skip_serializing_if = "Option::is_none")]
         performer: Option<String>,
 
         /// Title of the audio.
-        #[serde(skip_serializing_if = "Option::is_none")]
         title: Option<String>,
     },
 
@@ -169,11 +149,9 @@ pub enum InputMedia {
         /// JPEG format and less than 200 kB in size. A thumbnail‘s width and
         /// height should not exceed 320. Ignored if the file is not uploaded
         /// using multipart/form-data.
-        #[serde(skip_serializing_if = "Option::is_none")]
         thumb: Option<InputFile>,
 
         /// Caption of the document to be sent, 0-1024 charactersю
-        #[serde(skip_serializing_if = "Option::is_none")]
         caption: Option<String>,
 
         /// Send [Markdown] or [HTML], if you want Telegram apps to show [bold,
@@ -182,7 +160,6 @@ pub enum InputMedia {
         /// [Markdown]: https://core.telegram.org/bots/api#markdown-style
         /// [HTML]: https://core.telegram.org/bots/api#html-style
         /// [bold, italic, fixed-width text or inline URLs]: https://core.telegram.org/bots/api#formatting-options
-        #[serde(skip_serializing_if = "Option::is_none")]
         parse_mode: Option<ParseMode>,
     },
 }

--- a/src/types/input_message_content.rs
+++ b/src/types/input_message_content.rs
@@ -2,6 +2,7 @@ use serde::Serialize;
 
 use crate::types::ParseMode;
 
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(untagged)]
 /// This object represents the content of a message to be sent as a result of an
@@ -21,11 +22,9 @@ pub enum InputMessageContent {
         /// [Markdown]: https://core.telegram.org/bots/api#markdown-style
         /// [HTML]: https://core.telegram.org/bots/api#html-style
         /// [bold, italic, fixed-width text or inline URLs]: https://core.telegram.org/bots/api#formatting-options
-        #[serde(skip_serializing_if = "Option::is_none")]
         parse_mode: Option<ParseMode>,
 
         /// Disables link previews for links in the sent message.
-        #[serde(skip_serializing_if = "Option::is_none")]
         disable_web_page_preview: Option<bool>,
     },
 
@@ -40,7 +39,6 @@ pub enum InputMessageContent {
 
         /// Period in seconds for which the location can be updated, should be
         /// between 60 and 86400.
-        #[serde(skip_serializing_if = "Option::is_none")]
         live_period: Option<u32>,
     },
 
@@ -60,13 +58,11 @@ pub enum InputMessageContent {
         address: String,
 
         /// Foursquare identifier of the venue, if known.
-        #[serde(skip_serializing_if = "Option::is_none")]
         foursquare_id: Option<String>,
 
         /// Foursquare type of the venue, if known. (For example,
         /// `arts_entertainment/default`, `arts_entertainment/aquarium`
         /// or `food/icecream`.)
-        #[serde(skip_serializing_if = "Option::is_none")]
         foursquare_type: Option<String>,
     },
 
@@ -80,14 +76,12 @@ pub enum InputMessageContent {
         first_name: String,
 
         /// Contact's last name.
-        #[serde(skip_serializing_if = "Option::is_none")]
         last_name: Option<String>,
 
         /// Additional data about the contact in the form of a [vCard], 0-2048
         /// bytes.
         ///
         /// [vCard]: https://en.wikipedia.org/wiki/VCard
-        #[serde(skip_serializing_if = "Option::is_none")]
         vcard: Option<String>,
     },
 }

--- a/src/types/login_url.rs
+++ b/src/types/login_url.rs
@@ -8,16 +8,11 @@
 /// </div>
 ///
 /// [Telegram Login Widget]: https://core.telegram.org/widgets/login
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct LoginUrl {
     pub url: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub forward_text: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub bot_username: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub request_write_access: Option<bool>,
 }

--- a/src/types/message.rs
+++ b/src/types/message.rs
@@ -25,6 +25,7 @@ pub struct Message {
     pub kind: MessageKind,
 }
 
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(untagged)]
 pub enum MessageKind {

--- a/src/types/photo_size.rs
+++ b/src/types/photo_size.rs
@@ -2,6 +2,7 @@
 ///
 /// [file]: crate::types::Document
 /// [sticker]: crate::types::Sticker
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct PhotoSize {
     /// Identifier for this file.

--- a/src/types/pre_checkout_query.rs
+++ b/src/types/pre_checkout_query.rs
@@ -3,6 +3,7 @@ use crate::types::{OrderInfo, User};
 /// This object contains information about an incoming pre-checkout query.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#precheckoutquery).
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct PreCheckoutQuery {
     /// Unique query identifier.

--- a/src/types/reply_keyboard_markup.rs
+++ b/src/types/reply_keyboard_markup.rs
@@ -7,6 +7,7 @@ use crate::types::KeyboardButton;
 ///
 /// [custom keyboard]: https://core.telegram.org/bots#keyboards
 /// [Introduction to bots]: https://core.telegram.org/bots#keyboards
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct ReplyKeyboardMarkup {
     /// Array of button rows, each represented by an Array of
@@ -19,7 +20,6 @@ pub struct ReplyKeyboardMarkup {
     /// (e.g., make the keyboard smaller if there are just two rows of
     /// buttons). Defaults to `false`, in which case the custom keyboard is
     /// always of the same height as the app's standard keyboard.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub resize_keyboard: Option<bool>,
 
     /// Requests clients to hide the keyboard as soon as it's been used. The
@@ -27,7 +27,6 @@ pub struct ReplyKeyboardMarkup {
     /// display the usual letter-keyboard in the chat – the user can press a
     /// special button in the input field to see the custom keyboard again.
     /// Defaults to `false`.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub one_time_keyboard: Option<bool>,
 
     /// Use this parameter if you want to show the keyboard to specific users
@@ -40,6 +39,5 @@ pub struct ReplyKeyboardMarkup {
     /// in the group don’t see the keyboard.
     ///
     /// [`Message`]: crate::types::Message
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub selective: Option<bool>,
 }

--- a/src/types/reply_keyboard_remove.rs
+++ b/src/types/reply_keyboard_remove.rs
@@ -9,6 +9,7 @@ use crate::types::True;
 /// [The official docs](https://core.telegram.org/bots/api#replykeyboardremove).
 ///
 /// [`ReplyKeyboardMarkup`]: crate::types::ReplyKeyboardMarkup
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct ReplyKeyboardRemove {
     /// Requests clients to remove the custom keyboard (user will not be able
@@ -29,6 +30,5 @@ pub struct ReplyKeyboardRemove {
     /// showing the keyboard with poll options to users who haven't voted yet.
     ///
     /// [`Message`]: crate::types::Message
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub selective: Option<bool>,
 }

--- a/src/types/send_invoice.rs
+++ b/src/types/send_invoice.rs
@@ -1,5 +1,7 @@
 use crate::types::{ChatId, InlineKeyboardMarkup, LabeledPrice};
 
+// TODO: missing docs
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct SendInvoice {
     pub chat_id: ChatId,

--- a/src/types/sticker.rs
+++ b/src/types/sticker.rs
@@ -3,6 +3,7 @@ use crate::types::{MaskPosition, PhotoSize};
 /// This object represents a sticker.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#sticker).
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct Sticker {
     /// Identifier for this file.

--- a/src/types/successful_payment.rs
+++ b/src/types/successful_payment.rs
@@ -3,6 +3,7 @@ use crate::types::OrderInfo;
 /// This object contains basic information about a successful payment.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#successfulpayment).
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct SuccessfulPayment {
     /// Three-letter ISO 4217 [currency] code.

--- a/src/types/user.rs
+++ b/src/types/user.rs
@@ -1,6 +1,7 @@
 /// This object represents a Telegram user or bot.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#user).
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct User {
     /// Unique identifier for this user or bot.

--- a/src/types/venue.rs
+++ b/src/types/venue.rs
@@ -1,6 +1,7 @@
 use crate::types::Location;
 
 /// This object represents a venue.
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct Venue {
     /// Venue location.
@@ -13,12 +14,10 @@ pub struct Venue {
     pub address: String,
 
     /// Foursquare identifier of the venue.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub foursquare_id: Option<String>,
 
     /// Foursquare type of the venue. (For example,
     /// `arts_entertainment/default`, `arts_entertainment/aquarium` or
     /// `food/icecream`.)
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub foursquare_type: Option<String>, // TODO: is this enum?...
+    pub foursquare_type: Option<String>,
 }

--- a/src/types/video.rs
+++ b/src/types/video.rs
@@ -3,6 +3,7 @@ use crate::types::PhotoSize;
 /// This object represents a video file.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#video).
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct Video {
     /// Identifier for this file.

--- a/src/types/video_note.rs
+++ b/src/types/video_note.rs
@@ -7,6 +7,7 @@ use crate::types::PhotoSize;
 ///
 /// [video message]: https://telegram.org/blog/video-messages-and-telescope
 /// [v4.0]: https://telegram.org/blog/video-messages-and-telescope
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct VideoNote {
     /// Identifier for this file.

--- a/src/types/voice.rs
+++ b/src/types/voice.rs
@@ -1,6 +1,7 @@
 /// This object represents a voice note.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#voice).
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct Voice {
     /// Identifier for this file.

--- a/src/types/webhook_info.rs
+++ b/src/types/webhook_info.rs
@@ -1,6 +1,7 @@
 /// Contains information about the current status of a webhook.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#webhookinfo).
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct WebhookInfo {
     /// Webhook URL, may be empty if webhook is not set up.


### PR DESCRIPTION
Skip serializing nones with `#[serde_with_macros::skip_serializing_none]` instead of many `#[serde(skip_serializing_if = "Option::is_none")]`