### PR TITLE
Fix polling_default

### DIFF
--- a/src/dispatching/update_listeners.rs
+++ b/src/dispatching/update_listeners.rs
@@ -120,7 +120,7 @@ impl<S, E> UpdateListener<E> for S where S: Stream<Item = Result<Update, E>> {}
 ///
 /// See also: [`polling`](polling).
 pub fn polling_default(bot: Arc<Bot>) -> impl UpdateListener<RequestError> {
-    polling(bot, Some(Duration::from_secs(1)), None, None)
+    polling(bot, Some(Duration::from_secs(60)), None, None)
 }
 
 /// Returns a long/short polling update listener with some additional options.

--- a/src/dispatching/update_listeners.rs
+++ b/src/dispatching/update_listeners.rs
@@ -116,11 +116,11 @@ pub trait UpdateListener<E>: Stream<Item = Result<Update, E>> {
 }
 impl<S, E> UpdateListener<E> for S where S: Stream<Item = Result<Update, E>> {}
 
-/// Returns a long polling update listener with the default configuration.
+/// Returns a long polling update listener with `timeout` of 1 minute.
 ///
 /// See also: [`polling`](polling).
 pub fn polling_default(bot: Arc<Bot>) -> impl UpdateListener<RequestError> {
-    polling(bot, None, None, None)
+    polling(bot, Some(Duration::from_secs(1)), None, None)
 }
 
 /// Returns a long/short polling update listener with some additional options.


### PR DESCRIPTION
According to our documentation, `polling_default` must return a long polling update listener, but now it returns a short polling one. This PR fixes the problem, making `polling_default` returning a long polling update listener with `timeout=1min`.