### PR TITLE
Escape '>' using markdown utilities

### DIFF
--- a/src/utils/markdown.rs
+++ b/src/utils/markdown.rs
@@ -97,6 +97,7 @@ pub fn escape(s: &str) -> String {
         .replace(")", r"\)")
         .replace("~", r"\~")
         .replace("`", r"\`")
+        .replace(">", r"\>")
         .replace("#", r"\#")
         .replace("+", r"\+")
         .replace("-", r"\-")
@@ -218,8 +219,8 @@ mod tests {
     fn test_escape() {
         assert_eq!(escape("* foobar *"), r"\* foobar \*");
         assert_eq!(
-            escape(r"_ * [ ] ( ) ~ \ ` # + - = | { } . !"),
-            r"\_ \* \[ \] \( \) \~ \ \` \# \+ \- \= \| \{ \} \. \!",
+            escape(r"_ * [ ] ( ) ~ \ ` > # + - = | { } . !"),
+            r"\_ \* \[ \] \( \) \~ \ \` \> \# \+ \- \= \| \{ \} \. \!",
         );
     }
 


### PR DESCRIPTION
According to the telegram [markdownv2](https://core.telegram.org/bots/api#markdownv2-style) style guide, the '>' character should also be escaped.

With this PR, any '>" will be escaped properly using the markdown utilities. Tests have been updated accordingly.