### PR TITLE
feat(logging): respect package names with hyphens

### DIFF
--- a/src/logging.rs
+++ b/src/logging.rs
@@ -45,7 +45,7 @@ macro_rules! enable_logging_with_filter {
     ($filter:expr) => {
         pretty_env_logger::formatted_builder()
             .write_style(pretty_env_logger::env_logger::WriteStyle::Auto)
-            .filter(Some(env!("CARGO_PKG_NAME")), $filter)
+            .filter(Some(&env!("CARGO_PKG_NAME").replace("-", "_")), log::LevelFilter::Info)
             .filter(Some("teloxide"), log::LevelFilter::Error)
             .init();
     };

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -45,7 +45,10 @@ macro_rules! enable_logging_with_filter {
     ($filter:expr) => {
         pretty_env_logger::formatted_builder()
             .write_style(pretty_env_logger::env_logger::WriteStyle::Auto)
-            .filter(Some(&env!("CARGO_PKG_NAME").replace("-", "_")), log::LevelFilter::Info)
+            .filter(
+                Some(&env!("CARGO_PKG_NAME").replace("-", "_")),
+                log::LevelFilter::Info,
+            )
             .filter(Some("teloxide"), log::LevelFilter::Error)
             .init();
     };


### PR DESCRIPTION
Because hyphens in package names get converted to underscores during compilation the logger isn't working probably for package names using kebab-case.

This change replaces every hyphen with an underscore in the cargo package name.

I've tested it locally.