### PR TITLE
remove unnecessary type bound

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,8 @@ async fn main() {
 
     let bot = Bot::from_env();
 
-    teloxide::commands_repl(bot, panic!("Your bot's name here"), answer).await;
+    let bot_name: String = panic!("Your bot's name here");
+    teloxide::commands_repl(bot, bot_name, action).await;
 }
 ```
 

--- a/examples/admin_bot/src/main.rs
+++ b/examples/admin_bot/src/main.rs
@@ -139,5 +139,6 @@ async fn run() {
 
     let bot = Bot::from_env();
 
-    teloxide::commands_repl(bot, panic!("Your bot's name here"), action).await;
+    let bot_name: String = panic!("Your bot's name here");
+    teloxide::commands_repl(bot, bot_name, action).await;
 }

--- a/examples/simple_commands_bot/src/main.rs
+++ b/examples/simple_commands_bot/src/main.rs
@@ -36,5 +36,6 @@ async fn run() {
 
     let bot = Bot::from_env();
 
-    teloxide::commands_repl(bot, panic!("Your bot's name here"), answer).await;
+    let bot_name: String = panic!("Your bot's name here");
+    teloxide::commands_repl(bot, bot_name, answer).await;
 }


### PR DESCRIPTION
I was trying to build my own bot with your great project, and met a problem, here is my code:

```Rust
let bot_name = bot
    .get_me()
    .send()
    .await?
    .user
    .username
    .or(std::env::var("TELOXIDE_BOT_NAME").ok())
    .expect("no bot name found, specified environment variable 'TELOXIDE_BOT_NAME'");
teloxide::commands_repl(bot, bot_name, answer).await;
```

And I found that the type bound `'static` is not unnecessary, and created this PR