### PR TITLE
resolves #254 issue

### DIFF
--- a/src/bot/api.rs
+++ b/src/bot/api.rs
@@ -183,12 +183,32 @@ impl Bot {
         )
     }
 
+    /// Use this method to send audio files, if you want Telegram clients to display
+    /// them in the music player.
     ///
+    /// Your audio must be in the .MP3 or .M4A format. Bots can currently send audio
+    /// files of up to 50 MB in size, this limit may be changed in the future.
+    ///
+    /// For sending voice messages, use the [`Bot::send_voice`] method instead.
+    ///
+    /// [The official docs](https://core.telegram.org/bots/api#sendaudio).
+    ///
+    /// [`Bot::send_voice`]: crate::Bot::send_voice
     ///
     /// # Params
     ///   - `chat_id`: Unique identifier for the target chat or username of the
     ///     target supergroup or channel (in the format `@channelusername`).
     ///
+    /// Pass [`InputFile::File`] to send a file that exists on
+    /// the Telegram servers (recommended), pass an [`InputFile::Url`] for
+    /// Telegram to get a .webp file from the Internet, or upload a new one
+    /// using [`InputFile::FileId`]. [More info on Sending Files »].
+    ///
+    /// [`InputFile::File`]: crate::types::InputFile::File
+    /// [`InputFile::Url`]: crate::types::InputFile::Url
+    /// [`InputFile::FileId`]: crate::types::InputFile::FileId
+    ///
+    /// [More info on Sending Files »]: https://core.telegram.org/bots/api#sending-files
     /// # Notes
     /// Uses [a default parse mode] if specified in [`BotBuilder`].
     ///

--- a/src/requests/all/send_audio.rs
+++ b/src/requests/all/send_audio.rs
@@ -5,11 +5,12 @@ use crate::{
     Bot,
 };
 
-/// Use this method to send audio files, if you want Telegram clients to display
-/// them in the music player.
+/// Use this method to send audio files, if you want Telegram clients to 
+/// display them in the music player.
 ///
-/// Your audio must be in the .MP3 or .M4A format. Bots can currently send audio
-/// files of up to 50 MB in size, this limit may be changed in the future.
+/// Your audio must be in the .MP3 or .M4A format. Bots can currently send
+/// audio files of up to 50 MB in size, this limit may be changed in the
+/// future.
 ///
 /// For sending voice messages, use the [`Bot::send_voice`] method instead.
 ///

--- a/src/requests/all/send_photo.rs
+++ b/src/requests/all/send_photo.rs
@@ -76,7 +76,7 @@ impl SendPhoto {
     /// Pass [`InputFile::FileId`] to send a photo that exists on
     /// the Telegram servers (recommended), pass an [`InputFile::Url`] for
     /// Telegram to get a photo from the Internet, or upload a new one
-    /// using [`InputFile::File`] or [`InputFile::Memory`]. 
+    /// using [`InputFile::File`] or [`InputFile::Memory`].
     ///
     /// [`InputFile::File`]: crate::types::InputFile::File
     /// [`InputFile::Url`]: crate::types::InputFile::Url

--- a/src/requests/all/send_photo.rs
+++ b/src/requests/all/send_photo.rs
@@ -73,10 +73,10 @@ impl SendPhoto {
 
     /// Photo to send.
     ///
-    /// Pass [`InputFile::File`] to send a photo that exists on
+    /// Pass [`InputFile::FileId`] to send a photo that exists on
     /// the Telegram servers (recommended), pass an [`InputFile::Url`] for
-    /// Telegram to get a .webp file from the Internet, or upload a new one
-    /// using [`InputFile::FileId`]. [More info on Sending Files »].
+    /// Telegram to get a photo from the Internet, or upload a new one
+    /// using [`InputFile::File`] or [`InputFile::Memory`]. 
     ///
     /// [`InputFile::File`]: crate::types::InputFile::File
     /// [`InputFile::Url`]: crate::types::InputFile::Url


### PR DESCRIPTION
[`InputFile::FileId`] is now described as thing to send a photo that exists on the Telegram servers as needed. 

Added [`InputFile::Memory`] which is used to upload a new photo. That is also the function of method [`InputFile::File`].

.webp mention deleted, replaced with "photo"