### PR TITLE
make 'dev' default branch in docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, dev ]
 
 name: Continuous integration
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,8 @@
 # Contributing
+
 Before contributing, please read [our code style](https://github.com/teloxide/teloxide/blob/master/CODE_STYLE.md) and [the license](https://github.com/teloxide/teloxide/blob/master/LICENSE).
 
-To change the source code, fork the `master` branch of this repository and work inside your own branch. Then send us a PR into `master` branch and wait for the CI to check everything. However, you'd better check changes first locally:
+To change the source code, fork the `dev` branch of this repository and work inside your own branch. Then send us a PR into `dev` branch and wait for the CI to check everything. However, you'd better check changes first locally:
 
 ```
 cargo clippy --all --all-features --all-targets

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
     <img src="https://github.com/teloxide/teloxide/workflows/Continuous%20integration/badge.svg">
   </a>
   <a href="https://teloxide.netlify.com">
-    <img src="https://img.shields.io/badge/docs-master-blue)">
+    <img src="https://img.shields.io/badge/docs-dev-blue)">
   </a>
   <a href="https://docs.rs/teloxide/">
     <img src="https://img.shields.io/badge/docs.rs-v0.3.0-blue.svg">


### PR DESCRIPTION
Since we now use `dev` as a default/development branch, we need to update `README.md` and `CONTRIBUTING.md`