### PR TITLE
Added failing test case for command with single non-String arg

### DIFF
--- a/tests/command.rs
+++ b/tests/command.rs
@@ -33,7 +33,6 @@ fn parse_command_with_non_string_arg() {
     assert_eq!(actual, expected)
 }
 
-
 #[test]
 fn attribute_prefix() {
     #[command(rename = "lowercase")]

--- a/tests/command.rs
+++ b/tests/command.rs
@@ -19,6 +19,22 @@ fn parse_command_with_args() {
 }
 
 #[test]
+fn parse_command_with_non_string_arg() {
+    #[command(rename = "lowercase")]
+    #[derive(BotCommand, Debug, PartialEq)]
+    enum DefaultCommands {
+        Start(i32),
+        Help,
+    }
+
+    let data = "/start -50";
+    let expected = DefaultCommands::Start("-50".parse().unwrap());
+    let actual = DefaultCommands::parse(data, "").unwrap();
+    assert_eq!(actual, expected)
+}
+
+
+#[test]
 fn attribute_prefix() {
     #[command(rename = "lowercase")]
     #[derive(BotCommand, Debug, PartialEq)]


### PR DESCRIPTION
This adds a currently failing test case showing the issue teloxide/teloxide-macros#8 .
The test passes with the change from teloxide/teloxide-macros#9 .