### PR TITLE
add doc(cfg) attributes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ tokio = { version = "0.2.21", features = ["fs", "stream", "rt-threaded", "macros
 
 [package.metadata."docs.rs"]
 all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
 
 [[test]]
 name = "redis"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ pretty_env_logger = "0.4.0"
 lazy_static = "1.4.0"
 tokio = { version = "0.2.21", features = ["fs", "stream", "rt-threaded", "macros"] }
 
-[package.metadata."docs.rs"]
+[package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ frunk- = ["frunk"]
 
 macros = ["teloxide-macros"]
 
-nightly = [] # currently used only for `README.md` tests
+nightly = [] # currently used for `README.md` tests and building docs for `docsrs` to add `This is supported on feature="..." only.`
 
 [dependencies]
 serde_json = "1.0.55"

--- a/src/bot/download.rs
+++ b/src/bot/download.rs
@@ -56,7 +56,8 @@ impl Bot {
     /// [`tokio::fs::File`]: tokio::fs::File
     /// [`Bot::download_file`]: crate::Bot::download_file
     #[cfg(feature = "unstable-stream")]
-    #[cfg_attr(all(docsrs, feature = "nightly"), doc(cfg(feature = "unstable-stream")))]
+    // FIXME(waffle): use `docsrs` here when issue with combine is resolved <https://github.com/teloxide/teloxide/pull/305#issuecomment-716172103>
+    #[cfg_attr(all(teloxide_docsrs, feature = "nightly"), doc(cfg(feature = "unstable-stream")))]
     pub async fn download_file_stream(
         &self,
         path: &str,

--- a/src/bot/download.rs
+++ b/src/bot/download.rs
@@ -56,6 +56,7 @@ impl Bot {
     /// [`tokio::fs::File`]: tokio::fs::File
     /// [`Bot::download_file`]: crate::Bot::download_file
     #[cfg(feature = "unstable-stream")]
+    #[cfg_attr(all(docsrs, feature = "nightly"), doc(cfg(feature = "unstable-stream")))]
     pub async fn download_file_stream(
         &self,
         path: &str,

--- a/src/dispatching/dialogue/mod.rs
+++ b/src/dispatching/dialogue/mod.rs
@@ -162,6 +162,7 @@ pub use transition::{
 pub use teloxide_macros::Transition;
 
 #[cfg(feature = "redis-storage")]
+#[cfg_attr(all(docsrs, feature = "nightly"), doc(cfg(feature = "redis-storage")))]
 pub use storage::{RedisStorage, RedisStorageError};
 
 pub use storage::{serializer, InMemStorage, Serializer, Storage};

--- a/src/dispatching/dialogue/mod.rs
+++ b/src/dispatching/dialogue/mod.rs
@@ -158,11 +158,13 @@ pub use transition::{
 };
 
 #[cfg(feature = "macros")]
-#[cfg_attr(all(docsrs, feature = "nightly"), doc(cfg(feature = "macros")))]
+// FIXME(waffle): use `docsrs` here when issue with combine is resolved <https://github.com/teloxide/teloxide/pull/305#issuecomment-716172103>
+#[cfg_attr(all(teloxide_docsrs, feature = "nightly"), doc(cfg(feature = "macros")))]
 pub use teloxide_macros::Transition;
 
 #[cfg(feature = "redis-storage")]
-#[cfg_attr(all(docsrs, feature = "nightly"), doc(cfg(feature = "redis-storage")))]
+// FIXME(waffle): use `docsrs` here when issue with combine is resolved <https://github.com/teloxide/teloxide/pull/305#issuecomment-716172103>
+#[cfg_attr(all(teloxide_docsrs, feature = "nightly"), doc(cfg(feature = "redis-storage")))]
 pub use storage::{RedisStorage, RedisStorageError};
 
 pub use storage::{serializer, InMemStorage, Serializer, Storage};

--- a/src/dispatching/dialogue/storage/mod.rs
+++ b/src/dispatching/dialogue/storage/mod.rs
@@ -9,6 +9,7 @@ use futures::future::BoxFuture;
 
 pub use in_mem_storage::InMemStorage;
 #[cfg(feature = "redis-storage")]
+#[cfg_attr(all(docsrs, feature = "nightly"), doc(cfg(feature = "redis-storage")))]
 pub use redis_storage::{RedisStorage, RedisStorageError};
 pub use serializer::Serializer;
 use std::sync::Arc;

--- a/src/dispatching/dialogue/storage/mod.rs
+++ b/src/dispatching/dialogue/storage/mod.rs
@@ -9,7 +9,8 @@ use futures::future::BoxFuture;
 
 pub use in_mem_storage::InMemStorage;
 #[cfg(feature = "redis-storage")]
-#[cfg_attr(all(docsrs, feature = "nightly"), doc(cfg(feature = "redis-storage")))]
+// FIXME(waffle): use `docsrs` here when issue with combine is resolved <https://github.com/teloxide/teloxide/pull/305#issuecomment-716172103>
+#[cfg_attr(all(teloxide_docsrs, feature = "nightly"), doc(cfg(feature = "redis-storage")))]
 pub use redis_storage::{RedisStorage, RedisStorageError};
 pub use serializer::Serializer;
 use std::sync::Arc;

--- a/src/dispatching/dialogue/storage/serializer.rs
+++ b/src/dispatching/dialogue/storage/serializer.rs
@@ -32,9 +32,11 @@ where
 ///
 /// [CBOR]: https://en.wikipedia.org/wiki/CBOR
 #[cfg(feature = "cbor-serializer")]
+#[cfg_attr(all(docsrs, feature = "nightly"), doc(cfg(feature = "cbor-serializer")))]
 pub struct CBOR;
 
 #[cfg(feature = "cbor-serializer")]
+#[cfg_attr(all(docsrs, feature = "nightly"), doc(cfg(feature = "cbor-serializer")))]
 impl<D> Serializer<D> for CBOR
 where
     D: Serialize + DeserializeOwned,
@@ -54,9 +56,11 @@ where
 ///
 /// [Bincode]: https://github.com/servo/bincode
 #[cfg(feature = "bincode-serializer")]
+#[cfg_attr(all(docsrs, feature = "nightly"), doc(cfg(feature = "bincode-serializer")))]
 pub struct Bincode;
 
 #[cfg(feature = "bincode-serializer")]
+#[cfg_attr(all(docsrs, feature = "nightly"), doc(cfg(feature = "bincode-serializer")))]
 impl<D> Serializer<D> for Bincode
 where
     D: Serialize + DeserializeOwned,

--- a/src/dispatching/dialogue/storage/serializer.rs
+++ b/src/dispatching/dialogue/storage/serializer.rs
@@ -32,11 +32,13 @@ where
 ///
 /// [CBOR]: https://en.wikipedia.org/wiki/CBOR
 #[cfg(feature = "cbor-serializer")]
-#[cfg_attr(all(docsrs, feature = "nightly"), doc(cfg(feature = "cbor-serializer")))]
+// FIXME(waffle): use `docsrs` here when issue with combine is resolved <https://github.com/teloxide/teloxide/pull/305#issuecomment-716172103>
+#[cfg_attr(all(teloxide_docsrs, feature = "nightly"), doc(cfg(feature = "cbor-serializer")))]
 pub struct CBOR;
 
 #[cfg(feature = "cbor-serializer")]
-#[cfg_attr(all(docsrs, feature = "nightly"), doc(cfg(feature = "cbor-serializer")))]
+// FIXME(waffle): use `docsrs` here when issue with combine is resolved <https://github.com/teloxide/teloxide/pull/305#issuecomment-716172103>
+#[cfg_attr(all(teloxide_docsrs, feature = "nightly"), doc(cfg(feature = "cbor-serializer")))]
 impl<D> Serializer<D> for CBOR
 where
     D: Serialize + DeserializeOwned,
@@ -56,11 +58,13 @@ where
 ///
 /// [Bincode]: https://github.com/servo/bincode
 #[cfg(feature = "bincode-serializer")]
-#[cfg_attr(all(docsrs, feature = "nightly"), doc(cfg(feature = "bincode-serializer")))]
+// FIXME(waffle): use `docsrs` here when issue with combine is resolved <https://github.com/teloxide/teloxide/pull/305#issuecomment-716172103>
+#[cfg_attr(all(teloxide_docsrs, feature = "nightly"), doc(cfg(feature = "bincode-serializer")))]
 pub struct Bincode;
 
 #[cfg(feature = "bincode-serializer")]
-#[cfg_attr(all(docsrs, feature = "nightly"), doc(cfg(feature = "bincode-serializer")))]
+// FIXME(waffle): use `docsrs` here when issue with combine is resolved <https://github.com/teloxide/teloxide/pull/305#issuecomment-716172103>
+#[cfg_attr(all(teloxide_docsrs, feature = "nightly"), doc(cfg(feature = "bincode-serializer")))]
 impl<D> Serializer<D> for Bincode
 where
     D: Serialize + DeserializeOwned,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,12 @@
 #![allow(clippy::match_bool)]
 #![forbid(unsafe_code)]
 #![cfg_attr(all(feature = "nightly", doctest), feature(external_doc))]
+// we pass "--cfg docsrs" when building docs to add `This is supported on feature="..." only.`
+//
+// To properly build docs of this crate run
+// ```console
+// $ RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --open --all-features
+// ```
 #![cfg_attr(all(docsrs, feature = "nightly"), feature(doc_cfg))]
 
 pub use bot::{Bot, BotBuilder};
@@ -61,9 +67,6 @@ pub mod prelude;
 pub mod requests;
 pub mod types;
 pub mod utils;
-
-#[cfg(feature = "macros")]
-extern crate teloxide_macros;
 
 #[cfg(feature = "macros")]
 #[cfg_attr(all(docsrs, feature = "nightly"), doc(cfg(feature = "macros")))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,9 +45,11 @@
 //
 // To properly build docs of this crate run
 // ```console
-// $ RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --open --all-features
+// FIXME(waffle): use `docsrs` here when issue with combine is resolved <https://github.com/teloxide/teloxide/pull/305#issuecomment-716172103>
+// $ RUSTDOCFLAGS="--cfg teloxide_docsrs" cargo +nightly doc --open --all-features
 // ```
-#![cfg_attr(all(docsrs, feature = "nightly"), feature(doc_cfg))]
+// FIXME(waffle): use `docsrs` here when issue with combine is resolved <https://github.com/teloxide/teloxide/pull/305#issuecomment-716172103>
+#![cfg_attr(all(teloxide_docsrs, feature = "nightly"), feature(doc_cfg))]
 
 pub use bot::{Bot, BotBuilder};
 pub use dispatching::repls::{
@@ -69,7 +71,8 @@ pub mod types;
 pub mod utils;
 
 #[cfg(feature = "macros")]
-#[cfg_attr(all(docsrs, feature = "nightly"), doc(cfg(feature = "macros")))]
+// FIXME(waffle): use `docsrs` here when issue with combine is resolved <https://github.com/teloxide/teloxide/pull/305#issuecomment-716172103>
+#[cfg_attr(all(teloxide_docsrs, feature = "nightly"), doc(cfg(feature = "macros")))]
 pub use teloxide_macros::teloxide;
 
 #[cfg(all(feature = "nightly", doctest))]

--- a/src/net/download.rs
+++ b/src/net/download.rs
@@ -28,6 +28,7 @@ where
 }
 
 #[cfg(feature = "unstable-stream")]
+#[cfg_attr(all(docsrs, feature = "nightly"), doc(cfg(feature = "unstable-stream")))]
 pub async fn download_file_stream(
     client: &Client,
     token: &str,

--- a/src/net/download.rs
+++ b/src/net/download.rs
@@ -28,7 +28,8 @@ where
 }
 
 #[cfg(feature = "unstable-stream")]
-#[cfg_attr(all(docsrs, feature = "nightly"), doc(cfg(feature = "unstable-stream")))]
+// FIXME(waffle): use `docsrs` here when issue with combine is resolved <https://github.com/teloxide/teloxide/pull/305#issuecomment-716172103>
+#[cfg_attr(all(teloxide_docsrs, feature = "nightly"), doc(cfg(feature = "unstable-stream")))]
 pub async fn download_file_stream(
     client: &Client,
     token: &str,

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -1,4 +1,5 @@
 #[cfg(feature = "unstable-stream")]
+#[cfg_attr(all(docsrs, feature = "nightly"), doc(cfg(feature = "unstable-stream")))]
 pub use download::download_file_stream;
 
 pub use self::{

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -1,5 +1,6 @@
 #[cfg(feature = "unstable-stream")]
-#[cfg_attr(all(docsrs, feature = "nightly"), doc(cfg(feature = "unstable-stream")))]
+// FIXME(waffle): use `docsrs` here when issue with combine is resolved <https://github.com/teloxide/teloxide/pull/305#issuecomment-716172103>
+#[cfg_attr(all(teloxide_docsrs, feature = "nightly"), doc(cfg(feature = "unstable-stream")))]
 pub use download::download_file_stream;
 
 pub use self::{

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -15,6 +15,7 @@ pub use crate::{
 };
 
 #[cfg(feature = "frunk")]
+#[cfg_attr(all(docsrs, feature = "nightly"), doc(cfg(feature = "frunk")))]
 pub use crate::utils::UpState;
 
 pub use tokio::sync::mpsc::UnboundedReceiver;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -15,7 +15,8 @@ pub use crate::{
 };
 
 #[cfg(feature = "frunk")]
-#[cfg_attr(all(docsrs, feature = "nightly"), doc(cfg(feature = "frunk")))]
+// FIXME(waffle): use `docsrs` here when issue with combine is resolved <https://github.com/teloxide/teloxide/pull/305#issuecomment-716172103>
+#[cfg_attr(all(teloxide_docsrs, feature = "nightly"), doc(cfg(feature = "frunk")))]
 pub use crate::utils::UpState;
 
 pub use tokio::sync::mpsc::UnboundedReceiver;

--- a/src/utils/command.rs
+++ b/src/utils/command.rs
@@ -50,7 +50,8 @@ use serde::export::Formatter;
 use std::{error::Error, fmt::Display};
 
 #[cfg(feature = "macros")]
-#[cfg_attr(all(docsrs, feature = "nightly"), doc(cfg(feature = "macros")))]
+// FIXME(waffle): use `docsrs` here when issue with combine is resolved <https://github.com/teloxide/teloxide/pull/305#issuecomment-716172103>
+#[cfg_attr(all(teloxide_docsrs, feature = "nightly"), doc(cfg(feature = "macros")))]
 pub use teloxide_macros::BotCommand;
 
 /// An enumeration of bot's commands.

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -9,5 +9,6 @@ mod up_state;
 pub use client_from_env::client_from_env;
 
 #[cfg(feature = "frunk")]
-#[cfg_attr(all(docsrs, feature = "nightly"), doc(cfg(feature = "frunk")))]
+// FIXME(waffle): use `docsrs` here when issue with combine is resolved <https://github.com/teloxide/teloxide/pull/305#issuecomment-716172103>
+#[cfg_attr(all(teloxide_docsrs, feature = "nightly"), doc(cfg(feature = "frunk")))]
 pub use up_state::UpState;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -9,4 +9,5 @@ mod up_state;
 pub use client_from_env::client_from_env;
 
 #[cfg(feature = "frunk")]
+#[cfg_attr(all(docsrs, feature = "nightly"), doc(cfg(feature = "frunk")))]
 pub use up_state::UpState;


### PR DESCRIPTION
Resolves #303 
I tried building the docs both with nightly and stable, however in both cases I get errors for underlying crates:

1. `nightly`
```
RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --open --all-features
```

```
error[E0658]: `#[doc(cfg)]` is experimental
  --> /home/elpiel/.cargo/registry/src/github.com-1ecc6299db9ec823/combine-4.3.2/src/stream/mod.rs:51:20
   |
51 | #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: see issue #43781 <https://github.com/rust-lang/rust/issues/43781> for more information
   = help: add `#![feature(doc_cfg)]` to the crate attributes to enable

error[E0658]: `#[doc(cfg)]` is experimental
  --> /home/elpiel/.cargo/registry/src/github.com-1ecc6299db9ec823/combine-4.3.2/src/stream/decoder.rs:49:20
   |
49 | #[cfg_attr(docsrs, doc(cfg(feature = "std")))]

.... and more
```

2. `stable`
```
RUSTDOCFLAGS="--cfg docsrs" cargo doc --open --all-features
```

```

error[E0554]: `#![feature]` may not be used on the stable release channel
  --> /home/elpiel/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-io-0.3.7/src/lib.rs:29:21
   |
29 | #![cfg_attr(docsrs, feature(doc_cfg))]
```

