### PR TITLE
feat: Add a way to override default telegram api server

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,6 @@
+fn main() {
+    println!(
+        "cargo:rustc-env=TELEGRAM_API_URL={}",
+        option_env!("TELEGRAM_API_URL").unwrap_or("https://api.telegram.org")
+    );
+}

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -13,7 +13,7 @@ mod download;
 mod request;
 mod telegram_response;
 
-const TELEGRAM_API_URL: &str = "https://api.telegram.org";
+const TELEGRAM_API_URL: &str = env!("TELEGRAM_API_URL");
 
 /// Creates URL for making HTTPS requests. See the [Telegram documentation].
 ///


### PR DESCRIPTION
* See: https://core.telegram.org/bots/api#using-a-local-bot-api-server