### PR TITLE
Support new UpdateKind types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Allow arbitrary error types to be returned from (sub)transitions ([issue 242](https://github.com/teloxide/teloxide/issues/242)).
  - The `respond` function, a shortcut for `ResponseResult::Ok(())`.
  - The `sqlite-storage` feature -- enables SQLite support.
+ - `Dispatcher::{my_chat_members_handler, chat_members_handler}`
+
+[teloxide-core]: https://github.com/teloxide/teloxide-core
 
 ### Deprecated
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ macros = ["teloxide-macros"]
 nightly = [] # currently used for `README.md` tests and building docs for `docsrs` to add `This is supported on feature="..." only.`
 
 [dependencies]
-teloxide-core = { git = "https://github.com/teloxide/teloxide-core.git", features = ["full"] }
+teloxide-core = { version = "0.2", features = ["full"] }
 
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/examples/dialogue_bot/src/main.rs
+++ b/examples/dialogue_bot/src/main.rs
@@ -46,7 +46,7 @@ async fn handle_message(
     cx: UpdateWithCx<AutoSend<Bot>, Message>,
     dialogue: Dialogue,
 ) -> TransitionOut<Dialogue> {
-    match cx.update.text_owned() {
+    match cx.update.text().map(ToOwned::to_owned) {
         None => {
             cx.answer("Send me a text message.").await?;
             next(dialogue)

--- a/examples/redis_remember_bot/src/main.rs
+++ b/examples/redis_remember_bot/src/main.rs
@@ -52,7 +52,7 @@ async fn handle_message(
     cx: UpdateWithCx<AutoSend<Bot>, Message>,
     dialogue: Dialogue,
 ) -> TransitionOut<Dialogue> {
-    match cx.update.text_owned() {
+    match cx.update.text().map(ToOwned::to_owned) {
         None => {
             cx.answer("Send me a text message.").await?;
             next(dialogue)

--- a/src/dispatching/dispatcher_handler_rx_ext.rs
+++ b/src/dispatching/dispatcher_handler_rx_ext.rs
@@ -34,7 +34,11 @@ where
         Self: Stream<Item = UpdateWithCx<R, Message>>,
         R: Send + 'static,
     {
-        self.filter_map(|cx| async move { cx.update.text_owned().map(|text| (cx, text)) }).boxed()
+        self.filter_map(|cx| async move {
+            let text = cx.update.text().map(ToOwned::to_owned);
+            text.map(move |text| (cx, text))
+        })
+        .boxed()
     }
 
     fn commands<C, N>(self, bot_name: N) -> BoxStream<'static, (UpdateWithCx<R, Message>, C)>

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -15,7 +15,10 @@ pub use crate::{
 pub use teloxide_core::{
     adaptors::AutoSend,
     requests::{Request, ResponseResult},
-    types::Message,
+    types::{
+        CallbackQuery, ChatMemberUpdated, ChosenInlineResult, InlineQuery, Message, Poll,
+        PollAnswer, PreCheckoutQuery, ShippingQuery,
+    },
 };
 
 #[doc(inline)]


### PR DESCRIPTION
 - Re-export all the `UpdateKind` types in `prelude`.
 - Add `Dispatcher::{my_chat_members_handler, chat_members_handler}`.