### PR TITLE
Remove reqwest dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Fixed
+
+- Remove `reqwest` dependency. It's not needed after the [teloxide-core] integration.
 ## [0.4.0] - 2021-03-22
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,6 @@ tokio = { version = "1.2", features = ["fs"] }
 tokio-util = "0.6"
 tokio-stream = "0.1"
 
-reqwest = { version = "0.11", features = ["json", "stream"] }
 log = "0.4"
 lockfree = "0.5.1"
 bytes = "1.0"


### PR DESCRIPTION
It's not needed after the teloxide-core integration.