### PR TITLE
Move the features section to `lib.rs`

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,31 +381,6 @@ async fn handle_message(
 
 The second one produces very strange compiler messages due to the `#[tokio::main]` macro. However, the examples in this README use the second variant for brevity.
 
-## Cargo features
-
-| Feature | Description |
-|----------|----------|
-| `redis-storage` | Enables the [Redis] support.| 
-| `sqlite-storage` | Enables the [Sqlite] support. |
-| `cbor-serializer` | Enables the [CBOR] serializer for dialogues. |
-| `bincode-serializer` | Enables the [Bincode] serializer for dialogues. |
-| `macros` | Re-exports macros from [`teloxide-macros`]. |
-| `native-tls` | Enables the [`native-tls`] TLS implementation (enabled by default). |
-| `rustls` | Enables the [`rustls`] TLS implementation. |
-| `auto-send` | Enables the `AutoSend` bot adaptor. |
-| `cache-me` | Enables the `CacheMe` bot adaptor. |
-| `frunk` | Enables [`teloxide::utils::UpState`]. |
-| `full` | Enables all the features except `nightly`. |
-| `nightly` | Enables nightly-only features (see the [teloxide-core features]). |
-
-[CBOR]: https://en.wikipedia.org/wiki/CBOR
-[Bincode]: https://github.com/servo/bincode
-[`teloxide::utils::UpState`]: https://docs.rs/teloxide/latest/teloxide/utils/trait.UpState.html
-[`teloxide-macros`]: https://github.com/teloxide/teloxide-macros
-[`native-tls`]: https://docs.rs/native-tls
-[`rustls`]: https://docs.rs/rustls
-[teloxide-core features]: https://docs.rs/teloxide-core/latest/teloxide_core/#cargo-features
-
 ## FAQ
 **Q: Where I can ask questions?**
 

--- a/src/features.txt
+++ b/src/features.txt
@@ -1,0 +1,26 @@
+## Cargo features
+
+| Feature | Description |
+|----------|----------|
+| `redis-storage` | Enables the [Redis] storage support for dialogues.|
+| `sqlite-storage` | Enables the [Sqlite] storage support for dialogues. |
+| `cbor-serializer` | Enables the [CBOR] serializer for dialogues. |
+| `bincode-serializer` | Enables the [Bincode] serializer for dialogues. |
+| `macros` | Re-exports macros from [`teloxide-macros`]. |
+| `native-tls` | Enables the [`native-tls`] TLS implementation (enabled by default). |
+| `rustls` | Enables the [`rustls`] TLS implementation. |
+| `auto-send` | Enables the `AutoSend` bot adaptor. |
+| `cache-me` | Enables the `CacheMe` bot adaptor. |
+| `frunk` | Enables [`teloxide::utils::UpState`]. |
+| `full` | Enables all the features except `nightly`. |
+| `nightly` | Enables nightly-only features (see the [teloxide-core features]). |
+
+[Redis]: https://redis.io/
+[Sqlite]: https://www.sqlite.org/
+[CBOR]: https://en.wikipedia.org/wiki/CBOR
+[Bincode]: https://github.com/servo/bincode
+[`teloxide-macros`]: https://github.com/teloxide/teloxide-macros
+[`native-tls`]: https://docs.rs/native-tls
+[`rustls`]: https://docs.rs/rustls
+[`teloxide::utils::UpState`]: utils::UpState
+[teloxide-core features]: https://docs.rs/teloxide-core/latest/teloxide_core/#cargo-features

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,8 +35,12 @@
 //! [`async`/`.await`]: https://rust-lang.github.io/async-book/01_getting_started/01_chapter.html
 //! [Rust]: https://www.rust-lang.org/
 
-// This hack is used to cancel formatting for a Markdown table. See <https://github.com/rust-lang/rustfmt/issues/4210>.
-#![cfg_attr(feature = "nightly", doc = include_str!("features.txt"))]
+// This hack is used to cancel formatting for a Markdown table. See [1], [2], and [3].
+//
+// [1]: https://github.com/rust-lang/rustfmt/issues/4210
+// [2]: https://github.com/rust-lang/rustfmt/issues/4787
+// [3]: https://github.com/rust-lang/rust/issues/82768#issuecomment-803935643
+#![cfg_attr(feature = "nightly", cfg_attr(feature = "nightly", doc = include_str!("features.txt")))]
 // https://github.com/teloxide/teloxide/raw/master/logo.svg doesn't work in html_logo_url, I don't know why.
 #![doc(
     html_logo_url = "https://github.com/teloxide/teloxide/raw/master/ICON.png",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(feature = "nightly", feature(extended_key_value_attributes))]
+
 //! A full-featured framework that empowers you to easily build [Telegram bots]
 //! using the [`async`/`.await`] syntax in [Rust]. It handles all the difficult
 //! stuff so you can focus only on your business logic.
@@ -33,6 +35,8 @@
 //! [`async`/`.await`]: https://rust-lang.github.io/async-book/01_getting_started/01_chapter.html
 //! [Rust]: https://www.rust-lang.org/
 
+// This hack is used to cancel formatting for a Markdown table. See <https://github.com/rust-lang/rustfmt/issues/4210>.
+#![cfg_attr(feature = "nightly", doc = include_str!("features.txt"))]
 // https://github.com/teloxide/teloxide/raw/master/logo.svg doesn't work in html_logo_url, I don't know why.
 #![doc(
     html_logo_url = "https://github.com/teloxide/teloxide/raw/master/ICON.png",


### PR DESCRIPTION
Pros:

 - Consistent with teloxide-core;
 - Documentation is in the right place (`README.md` is meant only for a high-level overview);
 - In comparison with supporting this table both in `README.md` and `lib.rs`, this approach is easier to maintain.