### PR TITLE
Always remove a dialogue in `SqliteStorage::remove_dialogue`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - A storage persistency bug ([issue 304](https://github.com/teloxide/teloxide/issues/304)).
  - Log errors from `Storage::{remove_dialogue, update_dialogue}` in `DialogueDispatcher` ([issue 302](https://github.com/teloxide/teloxide/issues/302)).
  - Mark all the functions of `Storage` as `#[must_use]`.
+ - Try to remove a dialogue in `SqliteStorage::remove_dialogue` even if it does not exist.
 
 ## [0.4.0] - 2021-03-22
 

--- a/src/dispatching/dialogue/storage/sqlite_storage.rs
+++ b/src/dispatching/dialogue/storage/sqlite_storage.rs
@@ -65,13 +65,10 @@ where
         chat_id: i64,
     ) -> BoxFuture<'static, Result<(), Self::Error>> {
         Box::pin(async move {
-            if get_dialogue(&self.pool, chat_id).await?.is_some() {
-                sqlx::query("DELETE FROM teloxide_dialogues WHERE chat_id = ?")
-                    .bind(chat_id)
-                    .execute(&self.pool)
-                    .await?;
-            }
-
+            sqlx::query("DELETE FROM teloxide_dialogues WHERE chat_id = ?")
+                .bind(chat_id)
+                .execute(&self.pool)
+                .await?;
             Ok(())
         })
     }


### PR DESCRIPTION
Remove a dialogue in `SqliteStorage::remove_dialogue` even if it does not exist.
