### PR TITLE
Graceful shutdown & co

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Return an error from `Storage::remove_dialogue` if a dialogue does not exist.
  - Require `D: Clone` in `dialogues_repl(_with_listener)` and `InMemStorage`.
  - Automatically delete a webhook if it was set up in `update_listeners::polling_default` (thereby making it `async`, [issue 319](https://github.com/teloxide/teloxide/issues/319)).
+ - `polling` and `polling_default` now require `R: 'static`
+ - Refactor `UpdateListener` trait:
+   - Add a `stop` function that allows stopping the listener.
+   - Remove blanked implementation.
+   - Remove `Stream` from super traits.
+   - Add `AsUpdateStream` to super traits.
+     - Add an `AsUpdateStream` trait that allows turning implementors into streams of updates (GAT workaround).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - `Storage::get_dialogue` to obtain a dialogue indexed by a chat ID.
  - `InMemStorageError` with a single variant `DialogueNotFound` to be returned from `InMemStorage::remove_dialogue`.
  - `RedisStorageError::DialogueNotFound` and `SqliteStorageError::DialogueNotFound` to be returned from `Storage::remove_dialogue`.
+ - `Dispatcher::shutdown` function.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - `InMemStorageError` with a single variant `DialogueNotFound` to be returned from `InMemStorage::remove_dialogue`.
  - `RedisStorageError::DialogueNotFound` and `SqliteStorageError::DialogueNotFound` to be returned from `Storage::remove_dialogue`.
  - `Dispatcher::shutdown` function.
+ - `Dispatcher::setup_ctrlc_handler` function ([issue 153](https://github.com/teloxide/teloxide/issues/153)).
 
 ### Changed
 
@@ -21,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Automatically delete a webhook if it was set up in `update_listeners::polling_default` (thereby making it `async`, [issue 319](https://github.com/teloxide/teloxide/issues/319)).
  - `polling` and `polling_default` now require `R: 'static`
  - Refactor `UpdateListener` trait:
-   - Add a `stop` function that allows stopping the listener.
+   - Add a `stop` function that allows stopping the listener ([issue 166](https://github.com/teloxide/teloxide/issues/166)).
    - Remove blanked implementation.
    - Remove `Stream` from super traits.
    - Add `AsUpdateStream` to super traits.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - `Storage::get_dialogue` to obtain a dialogue indexed by a chat ID.
  - `InMemStorageError` with a single variant `DialogueNotFound` to be returned from `InMemStorage::remove_dialogue`.
  - `RedisStorageError::DialogueNotFound` and `SqliteStorageError::DialogueNotFound` to be returned from `Storage::remove_dialogue`.
- - `Dispatcher::shutdown` function.
+ - A way to `shutdown` dispatcher
+   - `Dispatcher::shutdown_token` function.
+   - `ShutdownToken` with a `shutdown` function.
  - `Dispatcher::setup_ctrlc_handler` function ([issue 153](https://github.com/teloxide/teloxide/issues/153)).
+ - `IdleShutdownError`
 
 ### Changed
 
@@ -22,11 +25,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Automatically delete a webhook if it was set up in `update_listeners::polling_default` (thereby making it `async`, [issue 319](https://github.com/teloxide/teloxide/issues/319)).
  - `polling` and `polling_default` now require `R: 'static`
  - Refactor `UpdateListener` trait:
-   - Add a `stop` function that allows stopping the listener ([issue 166](https://github.com/teloxide/teloxide/issues/166)).
+   - Add a `StopToken` associated type.
+     - It must implement a new `StopToken` trait which has the only function `fn stop(self);`
+   - Add a `stop_token` function that returns `Self::StopToken` and allows stopping the listener later ([issue 166](https://github.com/teloxide/teloxide/issues/166)).
    - Remove blanked implementation.
    - Remove `Stream` from super traits.
    - Add `AsUpdateStream` to super traits.
      - Add an `AsUpdateStream` trait that allows turning implementors into streams of updates (GAT workaround).
+   - Add a `timeout_hint` function (with a default implementation).
+ - `Dispatcher::dispatch` and `Dispatcher::dispatch_with_listener` now require mutable reference to self.
+ - Repls can now be stopped by `^C` signal.
+ - `Noop` and `AsyncStopToken`stop tokens.
+ - `StatefulListener`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Repls can now be stopped by `^C` signal.
  - `Noop` and `AsyncStopToken`stop tokens.
  - `StatefulListener`.
+ - Emit not only errors but also warnings and general information from teloxide, when set up by `enable_logging!`.
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,8 @@ bincode-serializer = ["bincode"]
 frunk- = ["frunk"]
 macros = ["teloxide-macros"]
 
+ctrlc_handler = ["tokio/signal"]
+
 native-tls = ["teloxide-core/native-tls"]
 rustls = ["teloxide-core/rustls"]
 auto-send = ["teloxide-core/auto_send"]
@@ -51,6 +53,7 @@ full = [
     "bincode-serializer",
     "frunk",
     "macros",
+    "ctrlc_handler",
     "teloxide-core/full",
     "native-tls",
     "rustls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ authors = [
 maintenance = { status = "actively-developed" }
 
 [features]
-default = ["native-tls", "teloxide-core/default"]
+default = ["native-tls", "ctrlc_handler", "teloxide-core/default"]
 
 sqlite-storage = ["sqlx"]
 redis-storage = ["redis"]

--- a/examples/heroku_ping_pong_bot/src/main.rs
+++ b/examples/heroku_ping_pong_bot/src/main.rs
@@ -1,7 +1,7 @@
 // The version of Heroku ping-pong-bot, which uses a webhook to receive updates
 // from Telegram, instead of long polling.
 
-use teloxide::{dispatching::update_listeners, prelude::*, types::Update};
+use teloxide::{dispatching::{update_listeners::{self, StatefulListener}, stop_token::AsyncStopToken}, prelude::*, types::Update};
 
 use std::{convert::Infallible, env, net::SocketAddr};
 use tokio::sync::mpsc;
@@ -20,8 +20,8 @@ async fn handle_rejection(error: warp::Rejection) -> Result<impl warp::Reply, In
     Ok(StatusCode::INTERNAL_SERVER_ERROR)
 }
 
-pub async fn webhook<'a>(bot: AutoSend<Bot>) -> impl update_listeners::UpdateListener<Infallible> {
-    // Heroku defines auto defines a port value
+pub async fn webhook(bot: AutoSend<Bot>) -> impl update_listeners::UpdateListener<Infallible> {
+    // Heroku auto defines a port value
     let teloxide_token = env::var("TELOXIDE_TOKEN").expect("TELOXIDE_TOKEN env variable missing");
     let port: u16 = env::var("PORT")
         .expect("PORT env variable missing")
@@ -48,11 +48,21 @@ pub async fn webhook<'a>(bot: AutoSend<Bot>) -> impl update_listeners::UpdateLis
         })
         .recover(handle_rejection);
 
-    let serve = warp::serve(server);
+    let (stop_token, stop_flag) = AsyncStopToken::new_pair();
 
-    let address = format!("0.0.0.0:{}", port);
-    tokio::spawn(serve.run(address.parse::<SocketAddr>().unwrap()));
-    UnboundedReceiverStream::new(rx)
+    let addr = format!("0.0.0.0:{}", port).parse::<SocketAddr>().unwrap();
+    let server = warp::serve(server);
+    let (_addr, fut) = server.bind_with_graceful_shutdown(addr, stop_flag);
+
+    // You might want to use serve.key_path/serve.cert_path methods here to
+    // setup a self-signed TLS certificate.
+
+    tokio::spawn(fut);
+    let stream = UnboundedReceiverStream::new(rx);
+
+    fn streamf<S, T>(state: &mut (S, T)) -> &mut S { &mut state.0 }
+    
+    StatefulListener::new((stream, stop_token), streamf, |state: &mut (_, AsyncStopToken)| state.1.clone(), None::<for<'a> fn(&'a _) -> _>)
 }
 
 async fn run() {

--- a/examples/heroku_ping_pong_bot/src/main.rs
+++ b/examples/heroku_ping_pong_bot/src/main.rs
@@ -62,7 +62,7 @@ pub async fn webhook(bot: AutoSend<Bot>) -> impl update_listeners::UpdateListene
 
     fn streamf<S, T>(state: &mut (S, T)) -> &mut S { &mut state.0 }
     
-    StatefulListener::new((stream, stop_token), streamf, |state: &mut (_, AsyncStopToken)| state.1.clone(), None::<for<'a> fn(&'a _) -> _>)
+    StatefulListener::new((stream, stop_token), streamf, |state: &mut (_, AsyncStopToken)| state.1.clone())
 }
 
 async fn run() {

--- a/examples/ngrok_ping_pong_bot/src/main.rs
+++ b/examples/ngrok_ping_pong_bot/src/main.rs
@@ -54,7 +54,7 @@ pub async fn webhook(bot: AutoSend<Bot>) -> impl update_listeners::UpdateListene
 
     fn streamf<S, T>(state: &mut (S, T)) -> &mut S { &mut state.0 }
     
-    StatefulListener::new((stream, stop_token), streamf, |state: &mut (_, AsyncStopToken)| state.1.clone(), None::<for<'a> fn(&'a _) -> _>)
+    StatefulListener::new((stream, stop_token), streamf, |state: &mut (_, AsyncStopToken)| state.1.clone())
 }
 
 async fn run() {

--- a/src/dispatching/dispatcher.rs
+++ b/src/dispatching/dispatcher.rs
@@ -28,16 +28,6 @@ use tokio::{
 
 type Tx<Upd, R> = Option<mpsc::UnboundedSender<UpdateWithCx<Upd, R>>>;
 
-#[macro_use]
-mod macros {
-    /// Pushes an update to a queue.
-    macro_rules! send {
-        ($requester:expr, $tx:expr, $update:expr, $variant:expr) => {
-            send($requester, $tx, $update, stringify!($variant));
-        };
-    }
-}
-
 fn send<'a, R, Upd>(requester: &'a R, tx: &'a Tx<R, Upd>, update: Upd, variant: &'static str)
 where
     Upd: Debug,
@@ -355,7 +345,7 @@ where
 
         match res {
             Ok(_) | Err(ShuttingDown) => Ok(()),
-            Err(IsntRunning) => return Err(ShutdownError::IsntRunning),
+            Err(IsntRunning) => Err(ShutdownError::IsntRunning),
             Err(Running) => unreachable!(),
         }
     }
@@ -382,99 +372,77 @@ where
 
             match update.kind {
                 UpdateKind::Message(message) => {
-                    send!(&self.requester, &self.messages_queue, message, UpdateKind::Message);
+                    send(&self.requester, &self.messages_queue, message, "UpdateKind::Message")
                 }
-                UpdateKind::EditedMessage(message) => {
-                    send!(
-                        &self.requester,
-                        &self.edited_messages_queue,
-                        message,
-                        UpdateKind::EditedMessage
-                    );
-                }
-                UpdateKind::ChannelPost(post) => {
-                    send!(
-                        &self.requester,
-                        &self.channel_posts_queue,
-                        post,
-                        UpdateKind::ChannelPost
-                    );
-                }
-                UpdateKind::EditedChannelPost(post) => {
-                    send!(
-                        &self.requester,
-                        &self.edited_channel_posts_queue,
-                        post,
-                        UpdateKind::EditedChannelPost
-                    );
-                }
-                UpdateKind::InlineQuery(query) => {
-                    send!(
-                        &self.requester,
-                        &self.inline_queries_queue,
-                        query,
-                        UpdateKind::InlineQuery
-                    );
-                }
-                UpdateKind::ChosenInlineResult(result) => {
-                    send!(
-                        &self.requester,
-                        &self.chosen_inline_results_queue,
-                        result,
-                        UpdateKind::ChosenInlineResult
-                    );
-                }
-                UpdateKind::CallbackQuery(query) => {
-                    send!(
-                        &self.requester,
-                        &self.callback_queries_queue,
-                        query,
-                        UpdateKind::CallbackQuer
-                    );
-                }
-                UpdateKind::ShippingQuery(query) => {
-                    send!(
-                        &self.requester,
-                        &self.shipping_queries_queue,
-                        query,
-                        UpdateKind::ShippingQuery
-                    );
-                }
-                UpdateKind::PreCheckoutQuery(query) => {
-                    send!(
-                        &self.requester,
-                        &self.pre_checkout_queries_queue,
-                        query,
-                        UpdateKind::PreCheckoutQuery
-                    );
-                }
+                UpdateKind::EditedMessage(message) => send(
+                    &self.requester,
+                    &self.edited_messages_queue,
+                    message,
+                    "UpdateKind::EditedMessage",
+                ),
+                UpdateKind::ChannelPost(post) => send(
+                    &self.requester,
+                    &self.channel_posts_queue,
+                    post,
+                    "UpdateKind::ChannelPost",
+                ),
+                UpdateKind::EditedChannelPost(post) => send(
+                    &self.requester,
+                    &self.edited_channel_posts_queue,
+                    post,
+                    "UpdateKind::EditedChannelPost",
+                ),
+                UpdateKind::InlineQuery(query) => send(
+                    &self.requester,
+                    &self.inline_queries_queue,
+                    query,
+                    "UpdateKind::InlineQuery",
+                ),
+                UpdateKind::ChosenInlineResult(result) => send(
+                    &self.requester,
+                    &self.chosen_inline_results_queue,
+                    result,
+                    "UpdateKind::ChosenInlineResult",
+                ),
+                UpdateKind::CallbackQuery(query) => send(
+                    &self.requester,
+                    &self.callback_queries_queue,
+                    query,
+                    "UpdateKind::CallbackQuer",
+                ),
+                UpdateKind::ShippingQuery(query) => send(
+                    &self.requester,
+                    &self.shipping_queries_queue,
+                    query,
+                    "UpdateKind::ShippingQuery",
+                ),
+                UpdateKind::PreCheckoutQuery(query) => send(
+                    &self.requester,
+                    &self.pre_checkout_queries_queue,
+                    query,
+                    "UpdateKind::PreCheckoutQuery",
+                ),
                 UpdateKind::Poll(poll) => {
-                    send!(&self.requester, &self.polls_queue, poll, UpdateKind::Poll);
+                    send(&self.requester, &self.polls_queue, poll, "UpdateKind::Poll")
                 }
-                UpdateKind::PollAnswer(answer) => {
-                    send!(
-                        &self.requester,
-                        &self.poll_answers_queue,
-                        answer,
-                        UpdateKind::PollAnswer
-                    );
-                }
-                UpdateKind::MyChatMember(chat_member_updated) => {
-                    send!(
-                        &self.requester,
-                        &self.my_chat_members_queue,
-                        chat_member_updated,
-                        UpdateKind::MyChatMember
-                    );
-                }
-                UpdateKind::ChatMember(chat_member_updated) => {
-                    send!(
-                        &self.requester,
-                        &self.chat_members_queue,
-                        chat_member_updated,
-                        UpdateKind::MyChatMember
-                    );
-                }
+                UpdateKind::PollAnswer(answer) => send(
+                    &self.requester,
+                    &self.poll_answers_queue,
+                    answer,
+                    "UpdateKind::PollAnswer",
+                ),
+                UpdateKind::MyChatMember(chat_member_updated) => send(
+                    &self.requester,
+                    &self.my_chat_members_queue,
+                    chat_member_updated,
+                    "UpdateKind::MyChatMember",
+                ),
+                UpdateKind::ChatMember(chat_member_updated) => send(
+                    &self.requester,
+                    &self.chat_members_queue,
+                    chat_member_updated,
+                    "UpdateKind::MyChatMember",
+                ),
             }
         }
     }

--- a/src/dispatching/dispatcher.rs
+++ b/src/dispatching/dispatcher.rs
@@ -287,8 +287,12 @@ where
         // FIXME: replace this by just Duration::ZERO once 1.53 will be released
         const DZERO: Duration = Duration::from_secs(0);
 
-        let shutdown_check_timeout =
-            update_listener.timeout_hint().unwrap_or(DZERO) + MIN_SHUTDOWN_CHECK_TIMEOUT;
+        let shutdown_check_timeout = update_listener.timeout_hint().unwrap_or(DZERO);
+
+        // FIXME: replace this by just saturating_add once 1.53 will be released
+        let shutdown_check_timeout = shutdown_check_timeout
+            .checked_add(MIN_SHUTDOWN_CHECK_TIMEOUT)
+            .unwrap_or(shutdown_check_timeout);
 
         let mut stop_token = Some(update_listener.stop_token());
 

--- a/src/dispatching/dispatcher.rs
+++ b/src/dispatching/dispatcher.rs
@@ -243,7 +243,7 @@ where
     /// `update_listener_error_handler`.
     pub async fn dispatch_with_listener<'a, UListener, ListenerE, Eh>(
         &'a self,
-        update_listener: UListener,
+        mut update_listener: UListener,
         update_listener_error_handler: Arc<Eh>,
     ) where
         UListener: UpdateListener<ListenerE> + 'a,
@@ -251,9 +251,8 @@ where
         ListenerE: Debug,
         R: Requester + Clone,
     {
-        let update_listener = Box::pin(update_listener);
-
         update_listener
+            .as_stream()
             .for_each(move |update| {
                 let update_listener_error_handler = Arc::clone(&update_listener_error_handler);
 

--- a/src/dispatching/dispatcher.rs
+++ b/src/dispatching/dispatcher.rs
@@ -282,8 +282,11 @@ where
 
         const MIN_SHUTDOWN_CHECK_TIMEOUT: Duration = Duration::from_secs(1);
 
+        // FIXME: replace this by just Duration::ZERO once 1.53 will be released
+        const DZERO: Duration = Duration::from_secs(0);
+
         let shutdown_check_timeout =
-            update_listener.timeout_hint().unwrap_or(Duration::ZERO) + MIN_SHUTDOWN_CHECK_TIMEOUT;
+            update_listener.timeout_hint().unwrap_or(DZERO) + MIN_SHUTDOWN_CHECK_TIMEOUT;
 
         if let Err(_) = self.shutdown_state.compare_exchange(IsntRunning, Running) {
             panic!("Dispatching is already running");

--- a/src/dispatching/dispatcher.rs
+++ b/src/dispatching/dispatcher.rs
@@ -104,7 +104,7 @@ where
 
     /// Setup `^C` handler which [`shutdown`]s dispatching.
     ///
-    /// [`shutdown`]: Dispatcher::shutdown
+    /// [`shutdown`]: ShutdownToken::shutdown
     #[cfg(feature = "ctrlc_handler")]
     #[cfg_attr(docsrs, doc(cfg(feature = "ctrlc_handler")))]
     pub fn setup_ctrlc_handler(self) -> Self {
@@ -249,7 +249,7 @@ where
     /// [ctrlc signal], or `update_listener` returning `None`) all handlers will
     /// be gone. As such, to restart listening you need to re-add handlers.
     ///
-    /// [`shutdown`]; ShutdownToken::shutdown
+    /// [`shutdown`]: ShutdownToken::shutdown
     /// [ctrlc signal]: Dispatcher::setup_ctrlc_handler
     pub async fn dispatch(&mut self)
     where
@@ -270,7 +270,7 @@ where
     /// [ctrlc signal], or `update_listener` returning `None`) all handlers will
     /// be gone. As such, to restart listening you need to re-add handlers.
     ///
-    /// [`shutdown`]; ShutdownToken::shutdown
+    /// [`shutdown`]: ShutdownToken::shutdown
     /// [ctrlc signal]: Dispatcher::setup_ctrlc_handler
     pub async fn dispatch_with_listener<'a, UListener, ListenerE, Eh>(
         &'a mut self,

--- a/src/dispatching/dispatcher.rs
+++ b/src/dispatching/dispatcher.rs
@@ -468,20 +468,13 @@ pub struct ShutdownToken {
 impl ShutdownToken {
     /// Tries to shutdown dispatching.
     ///
-    /// Returns error if this dispather isn't dispatching at the moment.
+    /// Returns error if this dispather is idle at the moment.
     ///
     /// If you don't need to wait for shutdown, returned future can be ignored.
-    pub fn shutdown(&self) -> Result<impl Future<Output = ()> + '_, ShutdownError> {
+    pub fn shutdown(&self) -> Result<impl Future<Output = ()> + '_, ()> {
         shutdown_inner(&self.dispatcher_state)
             .map(|()| async move { self.shutdown_notify_back.notified().await })
     }
-}
-
-/// Error occured while trying to shutdown dispatcher.
-#[derive(Debug)]
-pub enum ShutdownError {
-    /// Couldn"t stop dispatcher since it wasn't running.
-    Idle,
 }
 
 struct DispatcherState {

--- a/src/dispatching/dispatcher.rs
+++ b/src/dispatching/dispatcher.rs
@@ -326,7 +326,7 @@ where
             self.shutdown_notify_back.notify_waiters();
             log::info!("Dispatching has been shut down.");
         } else {
-            log::debug!("Dispatching has been stopped (listener returned `None`).");
+            log::info!("Dispatching has been stopped (listener returned `None`).");
         }
 
         self.state.store(Idle);
@@ -489,8 +489,10 @@ impl ShutdownToken {
     /// If you don't need to wait for shutdown, the returned future can be
     /// ignored.
     pub fn shutdown(&self) -> Result<impl Future<Output = ()> + '_, IdleShutdownError> {
-        shutdown_inner(&self.dispatcher_state)
-            .map(|()| async move { self.shutdown_notify_back.notified().await })
+        shutdown_inner(&self.dispatcher_state).map(|()| async move {
+            log::info!("Trying to shutdown the dispatcher...");
+            self.shutdown_notify_back.notified().await
+        })
     }
 }
 

--- a/src/dispatching/dispatcher.rs
+++ b/src/dispatching/dispatcher.rs
@@ -102,7 +102,7 @@ where
         Some(tx)
     }
 
-    /// Setup `^C` handler which [`shutdown`]s dispatching.
+    /// Setup the `^C` handler which [`shutdown`]s dispatching.
     ///
     /// [`shutdown`]: ShutdownToken::shutdown
     #[cfg(feature = "ctrlc_handler")]
@@ -246,11 +246,12 @@ where
     /// errors produced by this listener).
     ///
     /// Please note that after shutting down (either because of [`shutdown`],
-    /// [ctrlc signal], or `update_listener` returning `None`) all handlers will
-    /// be gone. As such, to restart listening you need to re-add handlers.
+    /// [a ctrlc signal], or [`UpdateListener`] returning `None`) all handlers
+    /// will be gone. As such, to restart listening you need to re-add
+    /// handlers.
     ///
     /// [`shutdown`]: ShutdownToken::shutdown
-    /// [ctrlc signal]: Dispatcher::setup_ctrlc_handler
+    /// [a ctrlc signal]: Dispatcher::setup_ctrlc_handler
     pub async fn dispatch(&mut self)
     where
         R: Requester + Clone,
@@ -267,11 +268,12 @@ where
     /// `update_listener_error_handler`.
     ///
     /// Please note that after shutting down (either because of [`shutdown`],
-    /// [ctrlc signal], or `update_listener` returning `None`) all handlers will
-    /// be gone. As such, to restart listening you need to re-add handlers.
+    /// [a ctrlc signal], or [`UpdateListener`] returning `None`) all handlers
+    /// will be gone. As such, to restart listening you need to re-add
+    /// handlers.
     ///
     /// [`shutdown`]: ShutdownToken::shutdown
-    /// [ctrlc signal]: Dispatcher::setup_ctrlc_handler
+    /// [a ctrlc signal]: Dispatcher::setup_ctrlc_handler
     pub async fn dispatch_with_listener<'a, UListener, ListenerE, Eh>(
         &'a mut self,
         mut update_listener: UListener,
@@ -330,7 +332,8 @@ where
         self.state.store(Idle);
     }
 
-    /// Returns shutdown token, which can later be used to shutdown dispatching.
+    /// Returns a shutdown token, which can later be used to shutdown
+    /// dispatching.
     pub fn shutdown_token(&self) -> ShutdownToken {
         ShutdownToken {
             dispatcher_state: Arc::clone(&self.state),
@@ -459,7 +462,7 @@ where
 }
 
 /// This error is returned from [`ShutdownToken::shutdown`] when trying to
-/// shutdown idle dispatcher.
+/// shutdown an idle [`Dispatcher`].
 #[derive(Debug)]
 pub struct IdleShutdownError;
 
@@ -471,7 +474,7 @@ impl fmt::Display for IdleShutdownError {
 
 impl std::error::Error for IdleShutdownError {}
 
-/// A token which can be used to shutdown dispatcher.
+/// A token which used to shutdown [`Dispatcher`].
 #[derive(Clone)]
 pub struct ShutdownToken {
     dispatcher_state: Arc<DispatcherState>,
@@ -481,9 +484,10 @@ pub struct ShutdownToken {
 impl ShutdownToken {
     /// Tries to shutdown dispatching.
     ///
-    /// Returns error if this dispather is idle at the moment.
+    /// Returns an error if the dispatcher is idle at the moment.
     ///
-    /// If you don't need to wait for shutdown, returned future can be ignored.
+    /// If you don't need to wait for shutdown, the returned future can be
+    /// ignored.
     pub fn shutdown(&self) -> Result<impl Future<Output = ()> + '_, IdleShutdownError> {
         shutdown_inner(&self.dispatcher_state)
             .map(|()| async move { self.shutdown_notify_back.notified().await })

--- a/src/dispatching/dispatcher.rs
+++ b/src/dispatching/dispatcher.rs
@@ -113,7 +113,7 @@ where
             loop {
                 tokio::signal::ctrl_c().await.expect("Failed to listen for ^C");
 
-                log::debug!("^C receieved, trying to shutdown dispatcher");
+                log::info!("^C received, trying to shutdown the dispatcher...");
 
                 // If dispatcher wasn't running, then there is nothing to do
                 shutdown_inner(&state).ok();
@@ -310,7 +310,7 @@ where
 
                 if let ShuttingDown = self.state.load() {
                     if let Some(token) = stop_token.take() {
-                        log::debug!("Start shutting down dispatching");
+                        log::debug!("Start shutting down dispatching...");
                         token.stop();
                     }
                 }
@@ -324,9 +324,9 @@ where
 
             // Notify `shutdown`s that we finished
             self.shutdown_notify_back.notify_waiters();
-            log::debug!("Dispatching shut down");
+            log::info!("Dispatching has been shut down.");
         } else {
-            log::debug!("Dispatching stopped (listener returned `None`)");
+            log::debug!("Dispatching has been stopped (listener returned `None`).");
         }
 
         self.state.store(Idle);

--- a/src/dispatching/mod.rs
+++ b/src/dispatching/mod.rs
@@ -46,11 +46,14 @@
 //! [examples/dialogue_bot]: https://github.com/teloxide/teloxide/tree/master/examples/dialogue_bot
 
 pub mod dialogue;
+pub mod stop_token;
+pub mod update_listeners;
+
+pub(crate) mod repls;
+
 mod dispatcher;
 mod dispatcher_handler;
 mod dispatcher_handler_rx_ext;
-pub(crate) mod repls;
-pub mod update_listeners;
 mod update_with_cx;
 
 pub use dispatcher::Dispatcher;

--- a/src/dispatching/mod.rs
+++ b/src/dispatching/mod.rs
@@ -27,7 +27,7 @@
 //! that:
 //!  - You are able to supply [`DialogueDispatcher`] as a handler.
 //!  - You are able to supply functions that accept
-//!    [`tokio::sync::mpsc::UnboundedReceiver`] and return `Future<Output = ()`
+//!    [`tokio::sync::mpsc::UnboundedReceiver`] and return `Future<Output = ()>`
 //!    as a handler.
 //!
 //! Since they implement [`DispatcherHandler`] too.
@@ -56,7 +56,7 @@ mod dispatcher_handler;
 mod dispatcher_handler_rx_ext;
 mod update_with_cx;
 
-pub use dispatcher::Dispatcher;
+pub use dispatcher::{Dispatcher, ShutdownError, ShutdownToken};
 pub use dispatcher_handler::DispatcherHandler;
 pub use dispatcher_handler_rx_ext::DispatcherHandlerRxExt;
 use tokio::sync::mpsc::UnboundedReceiver;

--- a/src/dispatching/mod.rs
+++ b/src/dispatching/mod.rs
@@ -56,7 +56,7 @@ mod dispatcher_handler;
 mod dispatcher_handler_rx_ext;
 mod update_with_cx;
 
-pub use dispatcher::{Dispatcher, ShutdownError, ShutdownToken};
+pub use dispatcher::{Dispatcher, IdleShutdownError, ShutdownToken};
 pub use dispatcher_handler::DispatcherHandler;
 pub use dispatcher_handler_rx_ext::DispatcherHandlerRxExt;
 use tokio::sync::mpsc::UnboundedReceiver;

--- a/src/dispatching/repls/commands_repl.rs
+++ b/src/dispatching/repls/commands_repl.rs
@@ -22,6 +22,7 @@ use tokio_stream::wrappers::UnboundedReceiverStream;
 ///
 /// [REPL]: https://en.wikipedia.org/wiki/Read-eval-print_loop
 /// [`Dispatcher`]: crate::dispatching::Dispatcher
+#[cfg(feature = "ctrlc_handler")]
 pub async fn commands_repl<R, Cmd, H, Fut, HandlerE, N>(requester: R, bot_name: N, handler: H)
 where
     Cmd: BotCommand + Send + 'static,
@@ -56,6 +57,7 @@ where
 /// [`Dispatcher`]: crate::dispatching::Dispatcher
 /// [`commands_repl`]: crate::dispatching::repls::commands_repl()
 /// [`UpdateListener`]: crate::dispatching::update_listeners::UpdateListener
+#[cfg(feature = "ctrlc_handler")]
 pub async fn commands_repl_with_listener<'a, R, Cmd, H, Fut, L, ListenerE, HandlerE, N>(
     requester: R,
     bot_name: N,
@@ -87,6 +89,7 @@ pub async fn commands_repl_with_listener<'a, R, Cmd, H, Fut, L, ListenerE, Handl
                 },
             )
         })
+        .setup_ctrlc_handler()
         .dispatch_with_listener(
             listener,
             LoggingErrorHandler::with_custom_text("An error from the update listener"),

--- a/src/dispatching/repls/dialogues_repl.rs
+++ b/src/dispatching/repls/dialogues_repl.rs
@@ -23,6 +23,7 @@ use teloxide_core::{requests::Requester, types::Message};
 /// [REPL]: https://en.wikipedia.org/wiki/Read-eval-print_loop
 /// [`Dispatcher`]: crate::dispatching::Dispatcher
 /// [`InMemStorage`]: crate::dispatching::dialogue::InMemStorage
+#[cfg(feature = "ctrlc_handler")]
 pub async fn dialogues_repl<'a, R, H, D, Fut>(requester: R, handler: H)
 where
     H: Fn(UpdateWithCx<R, Message>, D) -> Fut + Send + Sync + 'static,
@@ -55,6 +56,7 @@ where
 /// [`dialogues_repl`]: crate::dispatching::repls::dialogues_repl()
 /// [`UpdateListener`]: crate::dispatching::update_listeners::UpdateListener
 /// [`InMemStorage`]: crate::dispatching::dialogue::InMemStorage
+#[cfg(feature = "ctrlc_handler")]
 pub async fn dialogues_repl_with_listener<'a, R, H, D, Fut, L, ListenerE>(
     requester: R,
     handler: H,
@@ -85,6 +87,7 @@ pub async fn dialogues_repl_with_listener<'a, R, H, D, Fut, L, ListenerE>(
                 }
             },
         ))
+        .setup_ctrlc_handler()
         .dispatch_with_listener(
             listener,
             LoggingErrorHandler::with_custom_text("An error from the update listener"),

--- a/src/dispatching/repls/repl.rs
+++ b/src/dispatching/repls/repl.rs
@@ -21,6 +21,7 @@ use tokio_stream::wrappers::UnboundedReceiverStream;
 ///
 /// [REPL]: https://en.wikipedia.org/wiki/Read-eval-print_loop
 /// [`Dispatcher`]: crate::dispatching::Dispatcher
+#[cfg(feature = "ctrlc_handler")]
 pub async fn repl<R, H, Fut, E>(requester: R, handler: H)
 where
     H: Fn(UpdateWithCx<R, Message>) -> Fut + Send + Sync + 'static,
@@ -51,6 +52,7 @@ where
 /// [`Dispatcher`]: crate::dispatching::Dispatcher
 /// [`repl`]: crate::dispatching::repls::repl()
 /// [`UpdateListener`]: crate::dispatching::update_listeners::UpdateListener
+#[cfg(feature = "ctrlc_handler")]
 pub async fn repl_with_listener<'a, R, H, Fut, E, L, ListenerE>(
     requester: R,
     handler: H,
@@ -76,6 +78,7 @@ pub async fn repl_with_listener<'a, R, H, Fut, E, L, ListenerE>(
                 }
             })
         })
+        .setup_ctrlc_handler()
         .dispatch_with_listener(
             listener,
             LoggingErrorHandler::with_custom_text("An error from the update listener"),

--- a/src/dispatching/stop_token.rs
+++ b/src/dispatching/stop_token.rs
@@ -1,0 +1,74 @@
+use std::{future::Future, pin::Pin, task};
+
+use futures::future::{pending, AbortHandle, Abortable, Pending};
+
+/// A stop token allows you to stop listener.
+///
+/// See also: [`UpdateListener::stop_token`].
+///
+/// [`UpdateListener::stop_token`]:
+/// crate::dispatching::update_listeners::UpdateListener::stop_token
+pub trait StopToken {
+    /// Stop the listener linked to this token.
+    fn stop(self);
+}
+
+/// A stop token which does nothing. May be used in prototyping or in cases
+/// where you do not care about graceful shutdowning.
+pub struct Noop;
+
+impl StopToken for Noop {
+    fn stop(self) {}
+}
+
+/// A stop token which corresponds to [`AsyncStopFlag`].
+#[derive(Clone)]
+pub struct AsyncStopToken(AbortHandle);
+
+/// A flag which corresponds to [`AsyncStopToken`].
+///
+/// To know if stop token was used you can either repeatedly call [`is_stopped`]
+/// or use this type as a `Future`.
+///
+/// [`is_stopped`]: AsyncStopFlag::is_stopped
+#[pin_project::pin_project]
+pub struct AsyncStopFlag(#[pin] Abortable<Pending<()>>);
+
+impl AsyncStopToken {
+    /// Create a new token/flag pair.
+    pub fn new_pair() -> (Self, AsyncStopFlag) {
+        let (handle, reg) = AbortHandle::new_pair();
+        let token = Self(handle);
+        let flag = AsyncStopFlag(Abortable::new(pending(), reg));
+
+        (token, flag)
+    }
+}
+
+impl StopToken for AsyncStopToken {
+    fn stop(self) {
+        self.0.abort()
+    }
+}
+
+impl AsyncStopFlag {
+    /// Returns true if stop token linked to `self` was used.
+    pub fn is_stopped(&self) -> bool {
+        self.0.is_aborted()
+    }
+}
+
+/// This future resolves when a stop token was used.
+impl Future for AsyncStopFlag {
+    type Output = ();
+
+    fn poll(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> task::Poll<Self::Output> {
+        self.project().0.poll(cx).map(|res| {
+            debug_assert!(
+                res.is_err(),
+                "Pending Future can't ever be resolved, so Abortable is only resolved when \
+                 canceled"
+            );
+        })
+    }
+}

--- a/src/dispatching/stop_token.rs
+++ b/src/dispatching/stop_token.rs
@@ -1,8 +1,10 @@
+//! A stop token used to stop a listener.
+
 use std::{future::Future, pin::Pin, task};
 
 use futures::future::{pending, AbortHandle, Abortable, Pending};
 
-/// A stop token allows you to stop listener.
+/// A stop token allows you to stop a listener.
 ///
 /// See also: [`UpdateListener::stop_token`].
 ///
@@ -27,8 +29,8 @@ pub struct AsyncStopToken(AbortHandle);
 
 /// A flag which corresponds to [`AsyncStopToken`].
 ///
-/// To know if stop token was used you can either repeatedly call [`is_stopped`]
-/// or use this type as a `Future`.
+/// To know if the stop token was used you can either repeatedly call
+/// [`is_stopped`] or use this type as a `Future`.
 ///
 /// [`is_stopped`]: AsyncStopFlag::is_stopped
 #[pin_project::pin_project]
@@ -52,7 +54,7 @@ impl StopToken for AsyncStopToken {
 }
 
 impl AsyncStopFlag {
-    /// Returns true if stop token linked to `self` was used.
+    /// Returns true if the stop token linked to `self` was used.
     pub fn is_stopped(&self) -> bool {
         self.0.is_aborted()
     }

--- a/src/dispatching/update_listeners.rs
+++ b/src/dispatching/update_listeners.rs
@@ -96,33 +96,30 @@
 //!
 //! [`UpdateListener`]: UpdateListener
 //! [`polling_default`]: polling_default
-//! [`polling`]: polling
+//! [`polling`]: polling()
 //! [`Box::get_updates`]: crate::requests::Requester::get_updates
 //! [getting updates]: https://core.telegram.org/bots/api#getting-updates
 //! [long]: https://en.wikipedia.org/wiki/Push_technology#Long_polling
 //! [short]: https://en.wikipedia.org/wiki/Polling_(computer_science)
 //! [webhook]: https://en.wikipedia.org/wiki/Webhook
 
-use futures::{
-    future::{ready, Either},
-    stream, Stream, StreamExt,
-};
+use futures::Stream;
 
-use std::{convert::TryInto, time::Duration};
-use teloxide_core::{
-    payloads::GetUpdates,
-    requests::{HasPayload, Request, Requester},
-    types::{AllowedUpdate, SemiparsedVec, Update},
-};
+use std::time::Duration;
 
-use crate::dispatching::stop_token::{AsyncStopFlag, AsyncStopToken, StopToken};
+use crate::{dispatching::stop_token::StopToken, types::Update};
+
+mod polling;
+mod stateful_listener;
+
+pub use self::polling::{polling, polling_default};
 
 /// An update listener.
 ///
 /// Implementors of this trait allow getting updates from Telegram.
 ///
 /// Currently Telegram has 2 ways of getting updates -- [polling] and
-/// [webhooks]. Currently, only the former one is implemented (see [`polling`]
+/// [webhooks]. Currently, only the former one is implemented (see [`polling()`]
 /// and [`polling_default`])
 ///
 /// Some functions of this trait are located in the supertrait
@@ -156,7 +153,7 @@ pub trait UpdateListener<E>: for<'a> AsUpdateStream<'a, E> {
     /// Timeout duration hint.
     ///
     /// This hints how often dispatcher should check for shutdown. E.g. for
-    /// [`polling`] this returns the [`timeout`].
+    /// [`polling()`] this returns the [`timeout`].
     ///
     /// [`timeout`]: crate::payloads::GetUpdates::timeout
     ///
@@ -178,215 +175,4 @@ pub trait AsUpdateStream<'a, E> {
     ///
     /// [`Stream`]: AsUpdateStream::Stream
     fn as_stream(&'a mut self) -> Self::Stream;
-}
-
-/// Returns a long polling update listener with `timeout` of 10 seconds.
-///
-/// See also: [`polling`](polling).
-///
-/// ## Notes
-///
-/// This function will automatically delete a webhook if it was set up.
-pub async fn polling_default<R>(requester: R) -> impl UpdateListener<R::Err>
-where
-    R: Requester + 'static,
-    <R as Requester>::GetUpdatesFaultTolerant: Send,
-{
-    delete_webhook_if_setup(&requester).await;
-    polling(requester, Some(Duration::from_secs(10)), None, None)
-}
-
-/// Returns a long/short polling update listener with some additional options.
-///
-/// - `bot`: Using this bot, the returned update listener will receive updates.
-/// - `timeout`: A timeout for polling.
-/// - `limit`: Limits the number of updates to be retrieved at once. Values
-///   between 1—100 are accepted.
-/// - `allowed_updates`: A list the types of updates you want to receive.
-/// See [`GetUpdates`] for defaults.
-///
-/// See also: [`polling_default`](polling_default).
-///
-/// [`GetUpdates`]: crate::payloads::GetUpdates
-pub fn polling<R>(
-    requester: R,
-    timeout: Option<Duration>,
-    limit: Option<u8>,
-    allowed_updates: Option<Vec<AllowedUpdate>>,
-) -> impl UpdateListener<R::Err>
-where
-    R: Requester + 'static,
-    <R as Requester>::GetUpdatesFaultTolerant: Send,
-{
-    struct State<B: Requester> {
-        bot: B,
-        timeout: Option<u32>,
-        limit: Option<u8>,
-        allowed_updates: Option<Vec<AllowedUpdate>>,
-        offset: i32,
-        flag: AsyncStopFlag,
-        token: AsyncStopToken,
-    }
-
-    fn stream<B>(st: &mut State<B>) -> impl Stream<Item = Result<Update, B::Err>> + '_
-    where
-        B: Requester,
-    {
-        stream::unfold(st, move |state| async move {
-            let State { timeout, limit, allowed_updates, bot, offset, flag, .. } = &mut *state;
-
-            if flag.is_stopped() {
-                let mut req = bot.get_updates_fault_tolerant();
-
-                req.payload_mut().0 = GetUpdates {
-                    offset: Some(*offset),
-                    timeout: Some(0),
-                    limit: Some(1),
-                    allowed_updates: allowed_updates.take(),
-                };
-
-                return match req.send().await {
-                    Ok(_) => None,
-                    Err(err) => Some((Either::Left(stream::once(ready(Err(err)))), state)),
-                };
-            }
-
-            let mut req = bot.get_updates_fault_tolerant();
-            req.payload_mut().0 = GetUpdates {
-                offset: Some(*offset),
-                timeout: *timeout,
-                limit: *limit,
-                allowed_updates: allowed_updates.take(),
-            };
-
-            let updates = match req.send().await {
-                Err(err) => return Some((Either::Left(stream::once(ready(Err(err)))), state)),
-                Ok(SemiparsedVec(updates)) => {
-                    // Set offset to the last update's id + 1
-                    if let Some(upd) = updates.last() {
-                        let id: i32 = match upd {
-                            Ok(ok) => ok.id,
-                            Err((value, _)) => value["update_id"]
-                                .as_i64()
-                                .expect("The 'update_id' field must always exist in Update")
-                                .try_into()
-                                .expect("update_id must be i32"),
-                        };
-
-                        *offset = id + 1;
-                    }
-
-                    for update in &updates {
-                        if let Err((value, e)) = update {
-                            log::error!(
-                                "Cannot parse an update.\nError: {:?}\nValue: {}\n\
-                            This is a bug in teloxide-core, please open an issue here: \
-                            https://github.com/teloxide/teloxide-core/issues.",
-                                e,
-                                value
-                            );
-                        }
-                    }
-
-                    updates.into_iter().filter_map(Result::ok).map(Ok)
-                }
-            };
-
-            Some((Either::Right(stream::iter(updates)), state))
-        })
-        .flatten()
-    }
-
-    let (token, flag) = AsyncStopToken::new_pair();
-
-    let state = State {
-        bot: requester,
-        timeout: timeout.map(|t| t.as_secs().try_into().expect("timeout is too big")),
-        limit,
-        allowed_updates,
-        offset: 0,
-        flag,
-        token,
-    };
-
-    let stop = |st: &mut State<_>| st.token.clone();
-
-    let timeout_hint = Some(move |_: &State<_>| timeout);
-
-    StatefulListener { state, stream, stop, timeout_hint }
-}
-
-async fn delete_webhook_if_setup<R>(requester: &R)
-where
-    R: Requester,
-{
-    let webhook_info = match requester.get_webhook_info().send().await {
-        Ok(ok) => ok,
-        Err(e) => {
-            log::error!("Failed to get webhook info: {:?}", e);
-            return;
-        }
-    };
-
-    let is_webhook_setup = !webhook_info.url.is_empty();
-
-    if is_webhook_setup {
-        if let Err(e) = requester.delete_webhook().send().await {
-            log::error!("Failed to delete a webhook: {:?}", e);
-        }
-    }
-}
-
-/// A listener created from `state` and `stream`/`stop` functions.
-struct StatefulListener<St, Assf, Sf, Thf> {
-    /// The state of the listener.
-    state: St,
-
-    /// Function used as `AsUpdateStream::as_stream`.
-    ///
-    /// Must be of type `for<'a> &'a mut St -> impl Stream + 'a` and callable by
-    /// `&mut`.
-    stream: Assf,
-
-    /// Function used as `UpdateListener::stop`.
-    ///
-    /// Must be of type `for<'a> &'a mut St -> impl StopToken`.
-    stop: Sf,
-
-    /// Function used as `UpdateListener::timeout_hint`.
-    ///
-    /// Must be of type `for<'a> &'a St -> Option<Duration>` and callable by
-    /// `&`.
-    timeout_hint: Option<Thf>,
-}
-
-impl<'a, St, Assf, Sf, Thf, Strm, E> AsUpdateStream<'a, E> for StatefulListener<St, Assf, Sf, Thf>
-where
-    (St, Strm): 'a,
-    Assf: FnMut(&'a mut St) -> Strm,
-    Strm: Stream<Item = Result<Update, E>>,
-{
-    type Stream = Strm;
-
-    fn as_stream(&'a mut self) -> Self::Stream {
-        (self.stream)(&mut self.state)
-    }
-}
-
-impl<St, Assf, Sf, Stt, Thf, E> UpdateListener<E> for StatefulListener<St, Assf, Sf, Thf>
-where
-    Self: for<'a> AsUpdateStream<'a, E>,
-    Sf: FnMut(&mut St) -> Stt,
-    Stt: StopToken,
-    Thf: Fn(&St) -> Option<Duration>,
-{
-    type StopToken = Stt;
-
-    fn stop_token(&mut self) -> Stt {
-        (self.stop)(&mut self.state)
-    }
-
-    fn timeout_hint(&self) -> Option<Duration> {
-        self.timeout_hint.as_ref().and_then(|f| f(&self.state))
-    }
 }

--- a/src/dispatching/update_listeners.rs
+++ b/src/dispatching/update_listeners.rs
@@ -219,6 +219,7 @@ where
         // Updates fetched last time.
         //
         // We need to store them here so we can drop stream without loosing state.
+        #[allow(clippy::type_complexity)]
         fetched: Option<
             iter::Map<
                 iter::FilterMap<
@@ -402,7 +403,9 @@ where
     Thf: Fn(&St) -> Option<Duration>,
 {
     fn stop(&mut self) {
-        self.stop.take().map(|stop| stop(&mut self.state));
+        if let Some(stop) = self.stop.take() {
+            stop(&mut self.state)
+        }
     }
 
     fn timeout_hint(&self) -> Option<Duration> {

--- a/src/dispatching/update_listeners.rs
+++ b/src/dispatching/update_listeners.rs
@@ -112,7 +112,10 @@ use crate::{dispatching::stop_token::StopToken, types::Update};
 mod polling;
 mod stateful_listener;
 
-pub use self::polling::{polling, polling_default};
+pub use self::{
+    polling::{polling, polling_default},
+    stateful_listener::StatefulListener,
+};
 
 /// An update listener.
 ///

--- a/src/dispatching/update_listeners.rs
+++ b/src/dispatching/update_listeners.rs
@@ -107,6 +107,7 @@ use futures::{stream, Stream, StreamExt};
 
 use std::{convert::TryInto, iter, time::Duration, vec};
 use teloxide_core::{
+    payloads::GetUpdates,
     requests::{HasPayload, Request, Requester},
     types::{AllowedUpdate, SemiparsedVec, Update},
 };
@@ -251,11 +252,12 @@ where
                     RunningState::Stopping => {
                         let mut req = bot.get_updates_fault_tolerant();
 
-                        let payload = &mut req.payload_mut().0;
-                        payload.offset = Some(*offset);
-                        payload.timeout = *timeout;
-                        payload.limit = Some(1);
-                        payload.allowed_updates = allowed_updates.take();
+                        req.payload_mut().0 = GetUpdates {
+                            offset: Some(*offset),
+                            timeout: *timeout,
+                            limit: Some(1),
+                            allowed_updates: allowed_updates.take(),
+                        };
 
                         return match req.send().await {
                             Ok(_) => {
@@ -268,11 +270,12 @@ where
                 }
 
                 let mut req = bot.get_updates_fault_tolerant();
-                let payload = &mut req.payload_mut().0;
-                payload.offset = Some(*offset);
-                payload.timeout = *timeout;
-                payload.limit = *limit;
-                payload.allowed_updates = allowed_updates.take();
+                req.payload_mut().0 = GetUpdates {
+                    offset: Some(*offset),
+                    timeout: *timeout,
+                    limit: *limit,
+                    allowed_updates: allowed_updates.take(),
+                };
 
                 let updates = match req.send().await {
                     Err(err) => return Some((stream::iter(Some(Err(err))), state)),

--- a/src/dispatching/update_listeners.rs
+++ b/src/dispatching/update_listeners.rs
@@ -132,8 +132,8 @@ use teloxide_core::{
 pub trait UpdateListener<E>: for<'a> AsUpdateStream<'a, E> {
     /// Stop listening for updates.
     ///  
-    /// This function is not guaranteed to have an immidiate effect. That is
-    /// some listners can return updates even after [`stop`] is called (e.g.:
+    /// This function is not guaranteed to have an immediate effect. That is
+    /// some listeners can return updates even after [`stop`] is called (e.g.:
     /// because of buffering).
     ///
     /// [`stop`]: UpdateListener::stop

--- a/src/dispatching/update_listeners.rs
+++ b/src/dispatching/update_listeners.rs
@@ -127,21 +127,19 @@ pub use self::{
 ///
 /// Some functions of this trait are located in the supertrait
 /// ([`AsUpdateStream`]), see also:
-/// - [`Stream`]
-/// - [`as_stream`]
+/// - [`AsUpdateStream::Stream`]
+/// - [`AsUpdateStream::as_stream`]
 ///
 /// [polling]: self#long-polling
 /// [webhooks]: self#webhooks
-/// [`Stream`]: AsUpdateStream::Stream
-/// [`as_stream`]: AsUpdateStream::as_stream
 pub trait UpdateListener<E>: for<'a> AsUpdateStream<'a, E> {
-    /// Type of token which allows ti stop this listener.
+    /// The type of token which allows to stop this listener.
     type StopToken: StopToken;
 
     /// Returns a token which stops this listener.
     ///  
     /// The [`stop`] function of the token is not guaranteed to have an
-    /// immediate effect. That is some listeners can return updates even
+    /// immediate effect. That is, some listeners can return updates even
     /// after [`stop`] is called (e.g.: because of buffering).
     ///
     /// [`stop`]: StopToken::stop
@@ -153,15 +151,15 @@ pub trait UpdateListener<E>: for<'a> AsUpdateStream<'a, E> {
                   the returned token"]
     fn stop_token(&mut self) -> Self::StopToken;
 
-    /// Timeout duration hint.
+    /// The timeout duration hint.
     ///
-    /// This hints how often dispatcher should check for shutdown. E.g. for
+    /// This hints how often dispatcher should check for a shutdown. E.g., for
     /// [`polling()`] this returns the [`timeout`].
     ///
     /// [`timeout`]: crate::payloads::GetUpdates::timeout
     ///
     /// If you are implementing this trait and not sure what to return from this
-    /// function, just leave it with default implementation.
+    /// function, just leave it with the default implementation.
     fn timeout_hint(&self) -> Option<Duration> {
         None
     }
@@ -171,7 +169,7 @@ pub trait UpdateListener<E>: for<'a> AsUpdateStream<'a, E> {
 ///
 /// This trait is a workaround to not require GAT.
 pub trait AsUpdateStream<'a, E> {
-    /// Stream of updates from Telegram.
+    /// The stream of updates from Telegram.
     type Stream: Stream<Item = Result<Update, E>> + 'a;
 
     /// Creates the update [`Stream`].

--- a/src/dispatching/update_listeners/polling.rs
+++ b/src/dispatching/update_listeners/polling.rs
@@ -148,7 +148,7 @@ where
 
     let timeout_hint = Some(move |_: &State<_>| timeout);
 
-    StatefulListener { state, stream, stop, timeout_hint }
+    StatefulListener { state, stream, stop_token: stop, timeout_hint }
 }
 
 async fn delete_webhook_if_setup<R>(requester: &R)

--- a/src/dispatching/update_listeners/polling.rs
+++ b/src/dispatching/update_listeners/polling.rs
@@ -144,11 +144,11 @@ where
         token,
     };
 
-    let stop = |st: &mut State<_>| st.token.clone();
+    let stop_token = |st: &mut State<_>| st.token.clone();
 
     let timeout_hint = Some(move |_: &State<_>| timeout);
 
-    StatefulListener { state, stream, stop_token: stop, timeout_hint }
+    StatefulListener { state, stream, stop_token, timeout_hint }
 }
 
 async fn delete_webhook_if_setup<R>(requester: &R)

--- a/src/dispatching/update_listeners/polling.rs
+++ b/src/dispatching/update_listeners/polling.rs
@@ -1,0 +1,173 @@
+use std::{convert::TryInto, time::Duration};
+
+use futures::{
+    future::{ready, Either},
+    stream::{self, Stream, StreamExt},
+};
+
+use crate::{
+    dispatching::{
+        stop_token::{AsyncStopFlag, AsyncStopToken},
+        update_listeners::{stateful_listener::StatefulListener, UpdateListener},
+    },
+    payloads::GetUpdates,
+    requests::{HasPayload, Request, Requester},
+    types::{AllowedUpdate, SemiparsedVec, Update},
+};
+
+/// Returns a long polling update listener with `timeout` of 10 seconds.
+///
+/// See also: [`polling`](polling).
+///
+/// ## Notes
+///
+/// This function will automatically delete a webhook if it was set up.
+pub async fn polling_default<R>(requester: R) -> impl UpdateListener<R::Err>
+where
+    R: Requester + 'static,
+    <R as Requester>::GetUpdatesFaultTolerant: Send,
+{
+    delete_webhook_if_setup(&requester).await;
+    polling(requester, Some(Duration::from_secs(10)), None, None)
+}
+
+/// Returns a long/short polling update listener with some additional options.
+///
+/// - `bot`: Using this bot, the returned update listener will receive updates.
+/// - `timeout`: A timeout for polling.
+/// - `limit`: Limits the number of updates to be retrieved at once. Values
+///   between 1—100 are accepted.
+/// - `allowed_updates`: A list the types of updates you want to receive.
+/// See [`GetUpdates`] for defaults.
+///
+/// See also: [`polling_default`](polling_default).
+///
+/// [`GetUpdates`]: crate::payloads::GetUpdates
+pub fn polling<R>(
+    requester: R,
+    timeout: Option<Duration>,
+    limit: Option<u8>,
+    allowed_updates: Option<Vec<AllowedUpdate>>,
+) -> impl UpdateListener<R::Err>
+where
+    R: Requester + 'static,
+    <R as Requester>::GetUpdatesFaultTolerant: Send,
+{
+    struct State<B: Requester> {
+        bot: B,
+        timeout: Option<u32>,
+        limit: Option<u8>,
+        allowed_updates: Option<Vec<AllowedUpdate>>,
+        offset: i32,
+        flag: AsyncStopFlag,
+        token: AsyncStopToken,
+    }
+
+    fn stream<B>(st: &mut State<B>) -> impl Stream<Item = Result<Update, B::Err>> + '_
+    where
+        B: Requester,
+    {
+        stream::unfold(st, move |state| async move {
+            let State { timeout, limit, allowed_updates, bot, offset, flag, .. } = &mut *state;
+
+            if flag.is_stopped() {
+                let mut req = bot.get_updates_fault_tolerant();
+
+                req.payload_mut().0 = GetUpdates {
+                    offset: Some(*offset),
+                    timeout: Some(0),
+                    limit: Some(1),
+                    allowed_updates: allowed_updates.take(),
+                };
+
+                return match req.send().await {
+                    Ok(_) => None,
+                    Err(err) => Some((Either::Left(stream::once(ready(Err(err)))), state)),
+                };
+            }
+
+            let mut req = bot.get_updates_fault_tolerant();
+            req.payload_mut().0 = GetUpdates {
+                offset: Some(*offset),
+                timeout: *timeout,
+                limit: *limit,
+                allowed_updates: allowed_updates.take(),
+            };
+
+            let updates = match req.send().await {
+                Err(err) => return Some((Either::Left(stream::once(ready(Err(err)))), state)),
+                Ok(SemiparsedVec(updates)) => {
+                    // Set offset to the last update's id + 1
+                    if let Some(upd) = updates.last() {
+                        let id: i32 = match upd {
+                            Ok(ok) => ok.id,
+                            Err((value, _)) => value["update_id"]
+                                .as_i64()
+                                .expect("The 'update_id' field must always exist in Update")
+                                .try_into()
+                                .expect("update_id must be i32"),
+                        };
+
+                        *offset = id + 1;
+                    }
+
+                    for update in &updates {
+                        if let Err((value, e)) = update {
+                            log::error!(
+                                "Cannot parse an update.\nError: {:?}\nValue: {}\n\
+                            This is a bug in teloxide-core, please open an issue here: \
+                            https://github.com/teloxide/teloxide-core/issues.",
+                                e,
+                                value
+                            );
+                        }
+                    }
+
+                    updates.into_iter().filter_map(Result::ok).map(Ok)
+                }
+            };
+
+            Some((Either::Right(stream::iter(updates)), state))
+        })
+        .flatten()
+    }
+
+    let (token, flag) = AsyncStopToken::new_pair();
+
+    let state = State {
+        bot: requester,
+        timeout: timeout.map(|t| t.as_secs().try_into().expect("timeout is too big")),
+        limit,
+        allowed_updates,
+        offset: 0,
+        flag,
+        token,
+    };
+
+    let stop = |st: &mut State<_>| st.token.clone();
+
+    let timeout_hint = Some(move |_: &State<_>| timeout);
+
+    StatefulListener { state, stream, stop, timeout_hint }
+}
+
+async fn delete_webhook_if_setup<R>(requester: &R)
+where
+    R: Requester,
+{
+    let webhook_info = match requester.get_webhook_info().send().await {
+        Ok(ok) => ok,
+        Err(e) => {
+            log::error!("Failed to get webhook info: {:?}", e);
+            return;
+        }
+    };
+
+    let is_webhook_setup = !webhook_info.url.is_empty();
+
+    if is_webhook_setup {
+        if let Err(e) = requester.delete_webhook().send().await {
+            log::error!("Failed to delete a webhook: {:?}", e);
+        }
+    }
+}

--- a/src/dispatching/update_listeners/stateful_listener.rs
+++ b/src/dispatching/update_listeners/stateful_listener.rs
@@ -4,31 +4,79 @@ use futures::Stream;
 use teloxide_core::types::Update;
 
 use crate::dispatching::{
-    stop_token::StopToken,
+    stop_token::{self, StopToken},
     update_listeners::{AsUpdateStream, UpdateListener},
 };
 
-/// A listener created from `state` and `stream`/`stop` functions.
-pub(crate) struct StatefulListener<St, Assf, Sf, Thf> {
+/// A listener created from functions.
+///
+/// This type allows to turn a stream of updates (+some additional functions)
+/// into an [`UpdateListener`].
+///
+/// For an example of usage see [`polling`]
+///
+/// [`polling`]: crate::dispatching::update_listeners::polling()
+#[non_exhaustive]
+pub struct StatefulListener<St, Assf, Sf, Thf> {
     /// The state of the listener.
-    pub(crate) state: St,
+    pub state: St,
 
-    /// Function used as `AsUpdateStream::as_stream`.
+    /// Function used as [`AsUpdateStream::as_stream`].
     ///
     /// Must be of type `for<'a> &'a mut St -> impl Stream + 'a` and callable by
     /// `&mut`.
-    pub(crate) stream: Assf,
+    pub stream: Assf,
 
-    /// Function used as `UpdateListener::stop`.
+    /// Function used as [`UpdateListener::stop_token`].
     ///
     /// Must be of type `for<'a> &'a mut St -> impl StopToken`.
-    pub(crate) stop: Sf,
+    pub stop_token: Sf,
 
-    /// Function used as `UpdateListener::timeout_hint`.
+    /// Function used as [`UpdateListener::timeout_hint`].
     ///
     /// Must be of type `for<'a> &'a St -> Option<Duration>` and callable by
     /// `&`.
-    pub(crate) timeout_hint: Option<Thf>,
+    pub timeout_hint: Option<Thf>,
+}
+
+impl<St, Assf, Sf, Thf> StatefulListener<St, Assf, Sf, Thf> {
+    /// Creates new stateful listener from it's components.
+    pub fn new(state: St, stream: Assf, stop_token: Sf, timeout_hint: Option<Thf>) -> Self {
+        Self { state, stream, stop_token, timeout_hint }
+    }
+}
+
+impl<S, E>
+    StatefulListener<
+        S,
+        for<'a> fn(&'a mut S) -> &'a mut S,
+        for<'a> fn(&'a mut S) -> stop_token::Noop,
+        for<'a> fn(&'a S) -> Option<Duration>,
+    >
+where
+    S: Stream<Item = Result<Update, E>> + Unpin + 'static,
+{
+    /// Creates a new update listner from a stream of updates which ignore stop
+    /// signals.
+    ///
+    /// It won't be possible to ever stop this listener with stop token.
+    pub fn from_stream_without_graceful_shutdown(stream: S) -> Self {
+        let this = Self {
+            state: stream,
+            stream: |s| s,
+            stop_token: |_| stop_token::Noop,
+            timeout_hint: Some(|_| {
+                // FIXME: replace this by just Duration::MAX once 1.53 releases
+                // be released
+                const NANOS_PER_SEC: u32 = 1_000_000_000;
+                let dmax = Duration::new(u64::MAX, NANOS_PER_SEC - 1);
+
+                Some(dmax)
+            }),
+        };
+
+        assert_update_listener(this)
+    }
 }
 
 impl<'a, St, Assf, Sf, Thf, Strm, E> AsUpdateStream<'a, E> for StatefulListener<St, Assf, Sf, Thf>
@@ -54,10 +102,17 @@ where
     type StopToken = Stt;
 
     fn stop_token(&mut self) -> Stt {
-        (self.stop)(&mut self.state)
+        (self.stop_token)(&mut self.state)
     }
 
     fn timeout_hint(&self) -> Option<Duration> {
         self.timeout_hint.as_ref().and_then(|f| f(&self.state))
     }
+}
+
+fn assert_update_listener<L, E>(l: L) -> L
+where
+    L: UpdateListener<E>,
+{
+    l
 }

--- a/src/dispatching/update_listeners/stateful_listener.rs
+++ b/src/dispatching/update_listeners/stateful_listener.rs
@@ -1,0 +1,63 @@
+use std::time::Duration;
+
+use futures::Stream;
+use teloxide_core::types::Update;
+
+use crate::dispatching::{
+    stop_token::StopToken,
+    update_listeners::{AsUpdateStream, UpdateListener},
+};
+
+/// A listener created from `state` and `stream`/`stop` functions.
+pub(crate) struct StatefulListener<St, Assf, Sf, Thf> {
+    /// The state of the listener.
+    pub(crate) state: St,
+
+    /// Function used as `AsUpdateStream::as_stream`.
+    ///
+    /// Must be of type `for<'a> &'a mut St -> impl Stream + 'a` and callable by
+    /// `&mut`.
+    pub(crate) stream: Assf,
+
+    /// Function used as `UpdateListener::stop`.
+    ///
+    /// Must be of type `for<'a> &'a mut St -> impl StopToken`.
+    pub(crate) stop: Sf,
+
+    /// Function used as `UpdateListener::timeout_hint`.
+    ///
+    /// Must be of type `for<'a> &'a St -> Option<Duration>` and callable by
+    /// `&`.
+    pub(crate) timeout_hint: Option<Thf>,
+}
+
+impl<'a, St, Assf, Sf, Thf, Strm, E> AsUpdateStream<'a, E> for StatefulListener<St, Assf, Sf, Thf>
+where
+    (St, Strm): 'a,
+    Assf: FnMut(&'a mut St) -> Strm,
+    Strm: Stream<Item = Result<Update, E>>,
+{
+    type Stream = Strm;
+
+    fn as_stream(&'a mut self) -> Self::Stream {
+        (self.stream)(&mut self.state)
+    }
+}
+
+impl<St, Assf, Sf, Stt, Thf, E> UpdateListener<E> for StatefulListener<St, Assf, Sf, Thf>
+where
+    Self: for<'a> AsUpdateStream<'a, E>,
+    Sf: FnMut(&mut St) -> Stt,
+    Stt: StopToken,
+    Thf: Fn(&St) -> Option<Duration>,
+{
+    type StopToken = Stt;
+
+    fn stop_token(&mut self) -> Stt {
+        (self.stop)(&mut self.state)
+    }
+
+    fn timeout_hint(&self) -> Option<Duration> {
+        self.timeout_hint.as_ref().and_then(|f| f(&self.state))
+    }
+}

--- a/src/dispatching/update_listeners/stateful_listener.rs
+++ b/src/dispatching/update_listeners/stateful_listener.rs
@@ -10,10 +10,10 @@ use crate::dispatching::{
 
 /// A listener created from functions.
 ///
-/// This type allows to turn a stream of updates (+some additional functions)
+/// This type allows to turn a stream of updates (+ some additional functions)
 /// into an [`UpdateListener`].
 ///
-/// For an example of usage see [`polling`]
+/// For an example of usage, see [`polling`].
 ///
 /// [`polling`]: crate::dispatching::update_listeners::polling()
 #[non_exhaustive]
@@ -21,18 +21,18 @@ pub struct StatefulListener<St, Assf, Sf, Thf> {
     /// The state of the listener.
     pub state: St,
 
-    /// Function used as [`AsUpdateStream::as_stream`].
+    /// The function used as [`AsUpdateStream::as_stream`].
     ///
     /// Must be of type `for<'a> &'a mut St -> impl Stream + 'a` and callable by
     /// `&mut`.
     pub stream: Assf,
 
-    /// Function used as [`UpdateListener::stop_token`].
+    /// The function used as [`UpdateListener::stop_token`].
     ///
     /// Must be of type `for<'a> &'a mut St -> impl StopToken`.
     pub stop_token: Sf,
 
-    /// Function used as [`UpdateListener::timeout_hint`].
+    /// The function used as [`UpdateListener::timeout_hint`].
     ///
     /// Must be of type `for<'a> &'a St -> Option<Duration>` and callable by
     /// `&`.
@@ -40,14 +40,14 @@ pub struct StatefulListener<St, Assf, Sf, Thf> {
 }
 
 impl<St, Assf, Sf> StatefulListener<St, Assf, Sf, for<'a> fn(&'a St) -> Option<Duration>> {
-    /// Creates new stateful listener from it's components.
+    /// Creates a new stateful listener from its components.
     pub fn new(state: St, stream: Assf, stop_token: Sf) -> Self {
         Self { state, stream, stop_token, timeout_hint: None }
     }
 }
 
 impl<St, Assf, Sf, Thf> StatefulListener<St, Assf, Sf, Thf> {
-    /// Creates new stateful listener from it's components.
+    /// Creates a new stateful listener from its components.
     pub fn new_with_timeout_hint(
         state: St,
         stream: Assf,
@@ -68,10 +68,10 @@ impl<S, E>
 where
     S: Stream<Item = Result<Update, E>> + Unpin + 'static,
 {
-    /// Creates a new update listner from a stream of updates which ignore stop
-    /// signals.
+    /// Creates a new update listener from a stream of updates which ignores
+    /// stop signals.
     ///
-    /// It won't be possible to ever stop this listener with stop token.
+    /// It won't be possible to ever stop this listener with a stop token.
     pub fn from_stream_without_graceful_shutdown(stream: S) -> Self {
         let this = Self {
             state: stream,

--- a/src/dispatching/update_listeners/stateful_listener.rs
+++ b/src/dispatching/update_listeners/stateful_listener.rs
@@ -39,9 +39,21 @@ pub struct StatefulListener<St, Assf, Sf, Thf> {
     pub timeout_hint: Option<Thf>,
 }
 
+impl<St, Assf, Sf> StatefulListener<St, Assf, Sf, for<'a> fn(&'a St) -> Option<Duration>> {
+    /// Creates new stateful listener from it's components.
+    pub fn new(state: St, stream: Assf, stop_token: Sf) -> Self {
+        Self { state, stream, stop_token, timeout_hint: None }
+    }
+}
+
 impl<St, Assf, Sf, Thf> StatefulListener<St, Assf, Sf, Thf> {
     /// Creates new stateful listener from it's components.
-    pub fn new(state: St, stream: Assf, stop_token: Sf, timeout_hint: Option<Thf>) -> Self {
+    pub fn new_with_timeout_hint(
+        state: St,
+        stream: Assf,
+        stop_token: Sf,
+        timeout_hint: Option<Thf>,
+    ) -> Self {
         Self { state, stream, stop_token, timeout_hint }
     }
 }

--- a/src/features.txt
+++ b/src/features.txt
@@ -9,6 +9,7 @@
 | `macros` | Re-exports macros from [`teloxide-macros`]. |
 | `native-tls` | Enables the [`native-tls`] TLS implementation (enabled by default). |
 | `rustls` | Enables the [`rustls`] TLS implementation. |
+| `ctrlc_handler` | Enables [`Dispatcher::setup_ctrlc_handler`](dispatching::Dispatcher::setup_ctrlc_handler) function. |
 | `auto-send` | Enables the `AutoSend` bot adaptor. |
 | `cache-me` | Enables the `CacheMe` bot adaptor. |
 | `frunk` | Enables [`teloxide::utils::UpState`]. |

--- a/src/features.txt
+++ b/src/features.txt
@@ -9,7 +9,7 @@
 | `macros` | Re-exports macros from [`teloxide-macros`]. |
 | `native-tls` | Enables the [`native-tls`] TLS implementation (enabled by default). |
 | `rustls` | Enables the [`rustls`] TLS implementation. |
-| `ctrlc_handler` | Enables [`Dispatcher::setup_ctrlc_handler`](dispatching::Dispatcher::setup_ctrlc_handler) function. |
+| `ctrlc_handler` | Enables the [`Dispatcher::setup_ctrlc_handler`](dispatching::Dispatcher::setup_ctrlc_handler) function. |
 | `auto-send` | Enables the `AutoSend` bot adaptor. |
 | `cache-me` | Enables the `CacheMe` bot adaptor. |
 | `frunk` | Enables [`teloxide::utils::UpState`]. |

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,7 @@
 // $ RUSTDOCFLAGS="--cfg docsrs -Znormalize-docs" cargo +nightly doc --open --all-features
 // ```
 #![cfg_attr(all(docsrs, feature = "nightly"), feature(doc_cfg))]
+#![allow(clippy::redundant_pattern_matching)]
 
 pub use dispatching::repls::{
     commands_repl, commands_repl_with_listener, dialogues_repl, dialogues_repl_with_listener, repl,

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,7 +1,7 @@
 /// Enables logging through [pretty-env-logger].
 ///
-/// A logger will **only** print errors from teloxide and **all** logs from
-/// your program.
+/// A logger will **only** print errors, warnings, and general information from
+/// teloxide and **all** logs from your program.
 ///
 /// # Example
 /// ```no_compile
@@ -46,7 +46,7 @@ macro_rules! enable_logging_with_filter {
         pretty_env_logger::formatted_builder()
             .write_style(pretty_env_logger::env_logger::WriteStyle::Auto)
             .filter(Some(&env!("CARGO_PKG_NAME").replace("-", "_")), $filter)
-            .filter(Some("teloxide"), log::LevelFilter::Error)
+            .filter(Some("teloxide"), log::LevelFilter::Info)
             .init();
     };
 }

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -23,8 +23,8 @@ macro_rules! enable_logging {
 /// Enables logging through [pretty-env-logger] with a custom filter for your
 /// program.
 ///
-/// A logger will **only** print errors from teloxide and restrict logs from
-/// your program by the specified filter.
+/// A logger will **only** print errors, warnings, and general information from
+/// teloxide and restrict logs from your program by the specified filter.
 ///
 /// # Example
 /// Allow printing all logs from your program up to [`LevelFilter::Debug`] (i.e.


### PR DESCRIPTION
This PR changes the `UpdateListener` API and adds `Dispatcher::{shutdown, setup_ctrlc_handler}`. This allows for a graceful shutdown.

See commit messages for more.

Resolves #153, resolves #166.