### PR TITLE
utils: Change the user_id type to i64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - `Noop` and `AsyncStopToken`stop tokens.
  - `StatefulListener`.
  - Emit not only errors but also warnings and general information from teloxide, when set up by `enable_logging!`.
- - `user_id` should be passed as i64 in `html::user_mention` and `markdown::user_mention`.
+ - Use `i64` instead of `i32` for `user_id` in `html::user_mention` and `markdown::user_mention`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - `Noop` and `AsyncStopToken`stop tokens.
  - `StatefulListener`.
  - Emit not only errors but also warnings and general information from teloxide, when set up by `enable_logging!`.
+ - `user_id` should be passed as i64 in `html::user_mention` and `markdown::user_mention`.
 
 ### Fixed
 

--- a/src/utils/html.rs
+++ b/src/utils/html.rs
@@ -44,7 +44,7 @@ pub fn link(url: &str, text: &str) -> String {
 }
 
 /// Builds an inline user mention link with an anchor.
-pub fn user_mention(user_id: i32, text: &str) -> String {
+pub fn user_mention(user_id: i64, text: &str) -> String {
     link(format!("tg://user?id={}", user_id).as_str(), text)
 }
 

--- a/src/utils/markdown.rs
+++ b/src/utils/markdown.rs
@@ -59,7 +59,7 @@ pub fn link(url: &str, text: &str) -> String {
 }
 
 /// Builds an inline user mention link with an anchor.
-pub fn user_mention(user_id: i32, text: &str) -> String {
+pub fn user_mention(user_id: i64, text: &str) -> String {
     link(format!("tg://user?id={}", user_id).as_str(), text)
 }
 


### PR DESCRIPTION
user_id is of type i64 in User struct (https://github.com/teloxide/teloxide-core/blob/bd104a0a08568810b5850978419dd9c8f6a4b9b5/src/types/user.rs#L10)