### PR TITLE
Show `This is supported on feature="..." only.` in docs of reexported teloxide-core items

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ full = [
 ]
 
 [dependencies]
-teloxide-core = { version = "0.3.0", default-features = false }
+teloxide-core = { version = "0.3.1", default-features = false }
 #teloxide-core = { git = "https://github.com/teloxide/teloxide-core.git", rev = "...", default-features = false }
 teloxide-macros = { version = "0.4", optional = true }
 
@@ -106,6 +106,7 @@ tokio = { version = "1.8", features = ["fs", "rt-multi-thread", "macros"] }
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs", "-Znormalize-docs"]
+rustc-args = ["--cfg", "dep_docsrs"]
 
 [[test]]
 name = "redis"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,9 +1,6 @@
 [build] 
 command = "rustup install nightly --profile minimal && cargo +nightly doc --all-features --no-deps && cp -r target/doc _netlify_out"
-environment = { 
-    RUSTFLAGS="--cfg dep_docsrs",    
-    RUSTDOCFLAGS= "--cfg docsrs -Znormalize-docs" 
-} 
+environment = { RUSTFLAGS="--cfg dep_docsrs", RUSTDOCFLAGS= "--cfg docsrs -Znormalize-docs" }
 publish = "_netlify_out" 
 
 [[redirects]]

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,9 @@
 [build] 
 command = "rustup install nightly --profile minimal && cargo +nightly doc --all-features --no-deps && cp -r target/doc _netlify_out"
-environment = { RUSTDOCFLAGS= "--cfg docsrs -Znormalize-docs" } 
+environment = { 
+    RUSTFLAGS="--cfg dep_docsrs",    
+    RUSTDOCFLAGS= "--cfg docsrs -Znormalize-docs" 
+} 
 publish = "_netlify_out" 
 
 [[redirects]]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,12 +46,14 @@
 )]
 #![allow(clippy::match_bool)]
 #![forbid(unsafe_code)]
-// we pass "--cfg docsrs" when building docs to add `This is supported on
+// We pass "--cfg docsrs" when building docs to add `This is supported on
 // feature="..." only.`
+//
+// "--cfg dep_docsrs" is used for the same reason, but for `teloxide-core`.
 //
 // To properly build docs of this crate run
 // ```console
-// $ RUSTDOCFLAGS="--cfg docsrs -Znormalize-docs" cargo +nightly doc --open --all-features
+// $ RUSTFLAGS="--cfg dep_docsrs" RUSTDOCFLAGS="--cfg docsrs -Znormalize-docs" cargo +nightly doc --open --all-features
 // ```
 #![cfg_attr(all(docsrs, feature = "nightly"), feature(doc_cfg))]
 #![allow(clippy::redundant_pattern_matching)]


### PR DESCRIPTION
e.g.:
![image](https://user-images.githubusercontent.com/38225716/124803753-2c6c0d80-df62-11eb-8005-29c9398a63d9.png)
