### PR TITLE
Improve log messages when `^C` is received with `^C` handler setted up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Changed
+
+- Improved log messages when `^C` is received with `^C` handler setted up
+
 ## [0.5.0] - 2021-07-08
 
 ### Added


### PR DESCRIPTION
Now they tell the user to not repeatedly press `^C` since only the first signal actually does anything, all subsequent ones are ignored.

Before:
![2021-07-21_15-02](https://user-images.githubusercontent.com/38225716/126491918-01c3fd77-a42c-4e28-90f8-2083ca281ae5.png)

After:
![2021-07-21_15-45](https://user-images.githubusercontent.com/38225716/126491938-6543c664-c05d-48fb-9ab3-e15d349b4d53.png)
