### PR TITLE
Changed command for windows tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@
 $ export TELOXIDE_TOKEN=<Your token here>
 
 # Windows
-$ set TELOXIDE_TOKEN=<Your token here>
+$ $env:TELOXIDE_TOKEN=<Your token here>
 ```
  4. Make sure that your Rust compiler is up to date:
 ```bash


### PR DESCRIPTION
Earlier the command was `set TELOXIDE_TOKEN=<Your Token Here>`. This has been changed to `$env:TELOXIDE_TOKEN=<Your token here>`. I couldn't get the first example to work.