### PR TITLE
Depend on a right `futures` version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Fixed
+
+- Depend on a right `futures` version
+
 ## [0.5.1] - 2021-08-05
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,7 @@ mime = "0.3"
 derive_more = "0.99"
 thiserror = "1.0"
 async-trait = "0.1"
-futures = "0.3"
+futures = "0.3.15"
 pin-project = "1.0"
 serde_with_macros = "1.4"
 


### PR DESCRIPTION
Currently, users are having problems because of older `futures` versions locked in their `Cargo.lock`.