### PR TITLE
Pin tooling in the CI to a specific version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: nightly-2021-10-24
           override: true
           components: rustfmt
 
@@ -34,7 +34,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: nightly-2021-10-24
           override: true
           components: clippy
 


### PR DESCRIPTION
Both Clippy and Rustfmt are pinned to the current latest version (2021-10-24)