### PR TITLE
fix example's Cargo.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ $ rustup override set nightly
  5. Run `cargo new my_bot`, enter the directory and put these lines into your `Cargo.toml`:
 ```toml
 [dependencies]
-teloxide = { version = "0.5", features = ["macros"] }
+teloxide = { version = "0.5", features = ["macros", "auto-send"] }
 log = "0.4"
 pretty_env_logger = "0.4.0"
 tokio = { version =  "1.8", features = ["rt-multi-thread", "macros"] }


### PR DESCRIPTION
It's a one-line change but it took me quite a while to figure out that the feature was missing on cargo.toml