### PR TITLE
crates.io no longer shows badges

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,9 +21,6 @@ authors = [
         "Alexey Fedechkin <aleksey-fedechkin@rambler.ru>"
 ]
 
-[badges]
-maintenance = { status = "actively-developed" }
-
 [features]
 default = ["native-tls", "ctrlc_handler", "teloxide-core/default",  "auto-send"]
 


### PR DESCRIPTION
[crates.io](https://crates.io) previously displayed badges next to a crate on its website, but that functionality has been removed. Packages should place badges in its README file which will be displayed on [crates.io](https://crates.io) (see [the `readme` field](https://doc.rust-lang.org/cargo/reference/manifest.html#the-readme-field)).

From note at [Cargo Manifest Format](https://doc.rust-lang.org/cargo/reference/manifest.html#the-badges-section)