### PR TITLE
Remove "rustc version" from issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -18,8 +18,3 @@ Instead, this happened: _explanation_
 ## Meta
 
 - `teloxide` version: <!-- (e.g.: `0.3.1`) -->
-- rustc version:
-  ```
-  <version>
-  ```
-  <!-- use `rustc --version --verbose` to get it -->

--- a/.github/ISSUE_TEMPLATE/parse-error.md
+++ b/.github/ISSUE_TEMPLATE/parse-error.md
@@ -19,11 +19,6 @@ When using `<...>` method I've got  `RequestError::InvalidJson` error with the f
 ## Meta
 
 - `teloxide` version: <!-- (e.g.: `0.3.1`) -->
-- rustc version:
-  ```
-  <version>
-  ```
-  <!-- use `rustc --version --verbose` to get it -->
 
 ### Additional context
 

--- a/.github/ISSUE_TEMPLATE/unknown-telegram-error.md
+++ b/.github/ISSUE_TEMPLATE/unknown-telegram-error.md
@@ -19,11 +19,6 @@ When using `<...>` method I've got  `ApiError::Unknown` error with the following
 ## Meta
 
 - `teloxide` version: <!-- (e.g.: `0.3.1`) -->
-- rustc version:
-  ```
-  <version>
-  ```
-  <!-- use `rustc --version --verbose` to get it -->
 
 ### Additional context
 


### PR DESCRIPTION
There wasn't even a single time rustc version mattered in our issues.