### PR TITLE
Add `BotCommand::commands()` to use with `set_my_commands()` API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,8 @@ full = [
 [dependencies]
 #teloxide-core = { version = "0.3.3", default-features = false }
 teloxide-core = { git = "https://github.com/teloxide/teloxide-core.git", rev = "3ccb8f0", default-features = false }
-teloxide-macros = { version = "0.4", optional = true }
+#teloxide-macros = { version = "0.4", optional = true }
+teloxide-macros = { git = "https://github.com/teloxide/teloxide-macros.git", rev = "75e0577", optional = true }
 
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/src/utils/command.rs
+++ b/src/utils/command.rs
@@ -204,6 +204,7 @@ pub use teloxide_macros::BotCommand;
 /// [`FromStr`]: https://doc.rust-lang.org/std/str/trait.FromStr.html
 /// [`BotCommand`]: crate::utils::command::BotCommand
 pub trait BotCommand: Sized {
+    fn bot_commands() -> Vec<teloxide_core::types::BotCommand>;
     fn descriptions() -> String;
     fn parse<N>(s: &str, bot_name: N) -> Result<Self, ParseError>
     where

--- a/tests/command.rs
+++ b/tests/command.rs
@@ -196,3 +196,26 @@ fn descriptions_off() {
 
     assert_eq!(DefaultCommands::descriptions(), "/help\n".to_owned());
 }
+
+#[test]
+#[cfg(feature = "macros")]
+fn bot_commands() {
+    #[derive(BotCommand, Debug, PartialEq)]
+    #[command(rename = "lowercase")]
+    enum DefaultCommands {
+        #[command(description = "off")]
+        Start,
+        #[command(description = "stops it all")]
+        Stop,
+        Help,
+    }
+
+    {
+        use teloxide::types::BotCommand;
+
+        assert_eq!(
+            DefaultCommands::bot_commands(),
+            vec![BotCommand::new("/stop", "stops it all"), BotCommand::new("/help", "")]
+        );
+    }
+}


### PR DESCRIPTION
Closes teloxide/teloxide#262

Depends on: https://github.com/teloxide/teloxide-macros/pull/13