### PR TITLE
Do not retry `get_updates` infinitely while stopping polling listener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Require that `AsUpdateStream::Stream` is `Send`
 
+### Fixed
+
+- Infinite retries while stopping polling listener ([issue 496](https://github.com/teloxide/teloxide/issues/496))
+
 ## 0.5.3 - 2021-10-25
 
 ### Fixed


### PR DESCRIPTION
Fixes #496