### PR TITLE
Make the default and error handlers `Send + Sync`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## unreleased
 
+### Changed
+
+- Make `DispatcherBuilder::{default_handler, error_handler}` accept a handler that implements `Send + Sync` ([PR 517](https://github.com/teloxide/teloxide/pull/517)).
+
 ## 0.6.1 - 2022-02-06
 
 ### Fixed

--- a/src/dispatching2/dispatcher.rs
+++ b/src/dispatching2/dispatcher.rs
@@ -22,7 +22,7 @@ pub struct DispatcherBuilder<R, Err> {
     dependencies: DependencyMap,
     handler: UpdateHandler<Err>,
     default_handler: DefaultHandler,
-    error_handler: Arc<dyn ErrorHandler<Err>>,
+    error_handler: Arc<dyn ErrorHandler<Err> + Send + Sync>,
 }
 
 impl<R, Err> DispatcherBuilder<R, Err>
@@ -36,7 +36,7 @@ where
     #[must_use]
     pub fn default_handler<H, Fut>(self, handler: H) -> Self
     where
-        H: Fn(Arc<Update>) -> Fut + 'static,
+        H: Fn(Arc<Update>) -> Fut + Send + Sync + 'static,
         Fut: Future<Output = ()> + Send + 'static,
     {
         let handler = Arc::new(handler);
@@ -54,7 +54,7 @@ where
     ///
     /// By default, it is [`LoggingErrorHandler`].
     #[must_use]
-    pub fn error_handler(self, handler: Arc<dyn ErrorHandler<Err>>) -> Self {
+    pub fn error_handler(self, handler: Arc<dyn ErrorHandler<Err> + Send + Sync>) -> Self {
         Self { error_handler: handler, ..self }
     }
 
@@ -90,7 +90,7 @@ pub struct Dispatcher<R, Err> {
 
     handler: UpdateHandler<Err>,
     default_handler: DefaultHandler,
-    error_handler: Arc<dyn ErrorHandler<Err>>,
+    error_handler: Arc<dyn ErrorHandler<Err> + Send + Sync>,
     // TODO: respect allowed_udpates
     allowed_updates: HashSet<AllowedUpdate>,
 
@@ -103,7 +103,7 @@ pub struct Dispatcher<R, Err> {
 /// A handler that processes updates from Telegram.
 pub type UpdateHandler<Err> = dptree::Handler<'static, DependencyMap, Result<(), Err>>;
 
-type DefaultHandler = Box<dyn Fn(Arc<Update>) -> BoxFuture<'static, ()>>;
+type DefaultHandler = Box<dyn Fn(Arc<Update>) -> BoxFuture<'static, ()> + Send + Sync>;
 
 impl<R, Err> Dispatcher<R, Err>
 where

--- a/src/dispatching2/dispatcher.rs
+++ b/src/dispatching2/dispatcher.rs
@@ -272,3 +272,27 @@ where
         self.state.clone()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::convert::Infallible;
+
+    use teloxide_core::Bot;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_tokio_spawn() {
+        tokio::spawn(async {
+            // Just check that this code compiles.
+            if false {
+                Dispatcher::<_, Infallible>::builder(Bot::new(""), dptree::entry())
+                    .build()
+                    .dispatch()
+                    .await;
+            }
+        })
+        .await
+        .unwrap();
+    }
+}


### PR DESCRIPTION
Reduces the pain in the ass when trying to use the dispatcher in `tokio::spawn` or similar.
Discussion: https://t.me/teloxide/6529.