### PR TITLE
Remove `doc(cfg)` annotations in favour of `feature(doc_auto_cfg)`

### DIFF
--- a/src/dispatching/dialogue/mod.rs
+++ b/src/dispatching/dialogue/mod.rs
@@ -161,11 +161,9 @@ pub use transition::{
 };
 
 #[cfg(feature = "macros")]
-#[cfg_attr(all(docsrs, feature = "nightly"), doc(cfg(feature = "macros")))]
 pub use teloxide_macros::Transition;
 
 #[cfg(feature = "redis-storage")]
-#[cfg_attr(all(docsrs, feature = "nightly"), doc(cfg(feature = "redis-storage")))]
 pub use storage::{RedisStorage, RedisStorageError};
 
 #[cfg(feature = "sqlite-storage")]

--- a/src/dispatching/dialogue/storage/mod.rs
+++ b/src/dispatching/dialogue/storage/mod.rs
@@ -17,7 +17,6 @@ pub use self::{
 };
 
 #[cfg(feature = "redis-storage")]
-#[cfg_attr(all(docsrs, feature = "nightly"), doc(cfg(feature = "redis-storage")))]
 pub use redis_storage::{RedisStorage, RedisStorageError};
 pub use serializer::Serializer;
 use std::sync::Arc;

--- a/src/dispatching/dialogue/storage/serializer.rs
+++ b/src/dispatching/dialogue/storage/serializer.rs
@@ -32,11 +32,9 @@ where
 ///
 /// [CBOR]: https://en.wikipedia.org/wiki/CBOR
 #[cfg(feature = "cbor-serializer")]
-#[cfg_attr(all(docsrs, feature = "nightly"), doc(cfg(feature = "cbor-serializer")))]
 pub struct Cbor;
 
 #[cfg(feature = "cbor-serializer")]
-#[cfg_attr(all(docsrs, feature = "nightly"), doc(cfg(feature = "cbor-serializer")))]
 impl<D> Serializer<D> for Cbor
 where
     D: Serialize + DeserializeOwned,
@@ -56,11 +54,9 @@ where
 ///
 /// [Bincode]: https://github.com/servo/bincode
 #[cfg(feature = "bincode-serializer")]
-#[cfg_attr(all(docsrs, feature = "nightly"), doc(cfg(feature = "bincode-serializer")))]
 pub struct Bincode;
 
 #[cfg(feature = "bincode-serializer")]
-#[cfg_attr(all(docsrs, feature = "nightly"), doc(cfg(feature = "bincode-serializer")))]
 impl<D> Serializer<D> for Bincode
 where
     D: Serialize + DeserializeOwned,

--- a/src/dispatching/dispatcher.rs
+++ b/src/dispatching/dispatcher.rs
@@ -100,7 +100,6 @@ where
     ///
     /// [`shutdown`]: ShutdownToken::shutdown
     #[cfg(feature = "ctrlc_handler")]
-    #[cfg_attr(all(docsrs, feature = "nightly"), doc(cfg(feature = "ctrlc_handler")))]
     #[must_use]
     pub fn setup_ctrlc_handler(self) -> Self {
         let token = self.state.clone();

--- a/src/dispatching2/dialogue/mod.rs
+++ b/src/dispatching2/dialogue/mod.rs
@@ -86,7 +86,6 @@
 //! [`examples/dialogue.rs`]: https://github.com/teloxide/teloxide/blob/master/examples/dialogue.rs
 
 #[cfg(feature = "redis-storage")]
-#[cfg_attr(all(docsrs, feature = "nightly"), doc(cfg(feature = "redis-storage")))]
 pub use crate::dispatching::dialogue::{RedisStorage, RedisStorageError};
 
 #[cfg(feature = "sqlite-storage")]

--- a/src/dispatching2/dispatcher.rs
+++ b/src/dispatching2/dispatcher.rs
@@ -243,7 +243,6 @@ where
     ///
     /// [`shutdown`]: ShutdownToken::shutdown
     #[cfg(feature = "ctrlc_handler")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "ctrlc_handler")))]
     pub fn setup_ctrlc_handler(&mut self) -> &mut Self {
         let token = self.state.clone();
         tokio::spawn(async move {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@
 // ```console
 // $ RUSTFLAGS="--cfg dep_docsrs" RUSTDOCFLAGS="--cfg docsrs -Znormalize-docs" cargo +nightly doc --open --all-features
 // ```
-#![cfg_attr(all(docsrs, feature = "nightly"), feature(doc_cfg))]
+#![cfg_attr(all(docsrs, feature = "nightly"), feature(doc_cfg, doc_auto_cfg))]
 #![forbid(unsafe_code)]
 #![warn(rustdoc::broken_intra_doc_links)]
 #![allow(clippy::match_bool)]
@@ -74,12 +74,10 @@ mod logging;
 // Things from this module is also used for the dispatching2 module.
 pub mod dispatching;
 #[cfg(feature = "dispatching2")]
-#[cfg_attr(all(docsrs, feature = "nightly"), doc(cfg(feature = "dispatching2")))]
 pub mod dispatching2;
 pub mod error_handlers;
 pub mod prelude;
 #[cfg(feature = "dispatching2")]
-#[cfg_attr(all(docsrs, feature = "nightly"), doc(cfg(feature = "dispatching2")))]
 pub mod prelude2;
 pub mod utils;
 
@@ -87,13 +85,10 @@ pub mod utils;
 pub use teloxide_core::*;
 
 #[cfg(feature = "macros")]
-#[cfg_attr(all(docsrs, feature = "nightly"), doc(cfg(feature = "macros")))]
 pub use teloxide_macros as macros;
 
 #[cfg(feature = "dispatching2")]
-#[cfg_attr(all(docsrs, feature = "nightly"), doc(cfg(feature = "dispatching2")))]
 pub use dptree;
-#[cfg_attr(all(docsrs, feature = "nightly"), doc(cfg(feature = "macros")))]
 #[cfg(feature = "macros")]
 pub use teloxide_macros::teloxide;
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -16,7 +16,6 @@ pub use crate::dispatching::{
     Dispatcher, DispatcherHandlerRx, DispatcherHandlerRxExt, UpdateWithCx,
 };
 
-#[cfg_attr(all(docsrs, feature = "nightly"), doc(cfg(feature = "macros")))]
 #[cfg(feature = "macros")]
 pub use crate::teloxide;
 
@@ -32,7 +31,6 @@ pub use crate::adaptors::AutoSend;
 pub use teloxide_core::prelude::*;
 
 #[cfg(feature = "frunk")]
-#[cfg_attr(all(docsrs, feature = "nightly"), doc(cfg(feature = "frunk")))]
 pub use crate::utils::UpState;
 
 pub use tokio::sync::mpsc::UnboundedReceiver;

--- a/src/prelude2.rs
+++ b/src/prelude2.rs
@@ -9,7 +9,6 @@ pub use crate::dispatching2::{
     dialogue::Dialogue, Dispatcher, HandlerExt as _, MessageFilterExt as _, UpdateFilterExt as _,
 };
 
-#[cfg_attr(all(docsrs, feature = "nightly"), doc(cfg(feature = "macros")))]
 #[cfg(feature = "macros")]
 pub use crate::teloxide;
 

--- a/src/utils/command.rs
+++ b/src/utils/command.rs
@@ -53,7 +53,6 @@ use std::{
 
 use std::marker::PhantomData;
 #[cfg(feature = "macros")]
-#[cfg_attr(all(docsrs, feature = "nightly"), doc(cfg(feature = "macros")))]
 pub use teloxide_macros::BotCommand;
 
 /// An enumeration of bot's commands.

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -9,5 +9,4 @@ mod up_state;
 pub use teloxide_core::net::client_from_env;
 
 #[cfg(feature = "frunk")]
-#[cfg_attr(all(docsrs, feature = "nightly"), doc(cfg(feature = "frunk")))]
 pub use up_state::UpState;


### PR DESCRIPTION
Just some internal changes to make code nicer (and maybe also fix docs for places where we've forgot to add `doc(cfg)`)