### PR TITLE
🧹 fix case sensitive

### DIFF
--- a/src/utils/command.rs
+++ b/src/utils/command.rs
@@ -337,7 +337,7 @@ where
     let command = splited.next()?;
     let bot = splited.next();
     match bot {
-        Some(name) if name == bot_name.as_ref() => {}
+        Some(name) if name.eq_ignore_ascii_case(bot_name.as_ref()) => {}
         None => {}
         _ => return None,
     }


### PR DESCRIPTION
- Change parameter name from `bot_name` to `bot_username` in [`parse_command`](https://github.com/teloxide/teloxide/blob/727edeae1cebde27a5a2136be192921bf6217705/src/utils/command.rs#L296) and [`parse_command_with_prefix`](https://github.com/teloxide/teloxide/blob/727edeae1cebde27a5a2136be192921bf6217705/src/utils/command.rs#L324)
- Fix case sensitive of `bot_username`
- Add test


### Fix this issue
```rust
let result = parse_command("/ban@MyNameBot1 3 hours", "mynamebot1");
assert!(result.is_none());
```