### PR TITLE
Fix compilation with non-default features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## unreleased
 
+### Fixed
+
+- Compilation with non-default features
+
 ## 0.7.0 - 2022-02-09
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,10 @@ license = "MIT"
 exclude = ["media"]
 
 [features]
-default = ["native-tls", "ctrlc_handler", "teloxide-core/default",  "auto-send", "cache-me", "dispatching2"]
+# FIXME: remove "cache-me" that was added by mistake here
+default = ["native-tls", "ctrlc_handler", "teloxide-core/default",  "auto-send", "dispatching2", "cache-me"]
 
-dispatching2 = ["dptree"]
+dispatching2 = ["dptree", "cache-me"]
 
 sqlite-storage = ["sqlx"]
 redis-storage = ["redis"]

--- a/src/dispatching/mod.rs
+++ b/src/dispatching/mod.rs
@@ -52,6 +52,7 @@ pub mod dialogue;
 pub mod stop_token;
 pub mod update_listeners;
 
+#[cfg(feature = "ctrlc_handler")]
 pub(crate) mod repls;
 
 mod dispatcher;

--- a/src/dispatching/repls/commands_repl.rs
+++ b/src/dispatching/repls/commands_repl.rs
@@ -22,6 +22,7 @@ use tokio_stream::wrappers::UnboundedReceiverStream;
 ///
 /// [REPL]: https://en.wikipedia.org/wiki/Read-eval-print_loop
 /// [`Dispatcher`]: crate::dispatching::Dispatcher
+#[cfg(feature = "ctrlc_handler")]
 pub async fn commands_repl<R, Cmd, H, Fut, HandlerE, N>(requester: R, bot_name: N, handler: H)
 where
     Cmd: BotCommand + Send + 'static,
@@ -56,6 +57,7 @@ where
 /// [`Dispatcher`]: crate::dispatching::Dispatcher
 /// [`commands_repl`]: crate::dispatching::repls::commands_repl()
 /// [`UpdateListener`]: crate::dispatching::update_listeners::UpdateListener
+#[cfg(feature = "ctrlc_handler")]
 pub async fn commands_repl_with_listener<'a, R, Cmd, H, Fut, L, ListenerE, HandlerE, N>(
     requester: R,
     bot_name: N,

--- a/src/dispatching/repls/dialogues_repl.rs
+++ b/src/dispatching/repls/dialogues_repl.rs
@@ -23,6 +23,7 @@ use teloxide_core::{requests::Requester, types::Message};
 /// [REPL]: https://en.wikipedia.org/wiki/Read-eval-print_loop
 /// [`Dispatcher`]: crate::dispatching::Dispatcher
 /// [`InMemStorage`]: crate::dispatching::dialogue::InMemStorage
+#[cfg(feature = "ctrlc_handler")]
 pub async fn dialogues_repl<'a, R, H, D, Fut>(requester: R, handler: H)
 where
     H: Fn(UpdateWithCx<R, Message>, D) -> Fut + Send + Sync + 'static,
@@ -55,6 +56,7 @@ where
 /// [`dialogues_repl`]: crate::dispatching::repls::dialogues_repl()
 /// [`UpdateListener`]: crate::dispatching::update_listeners::UpdateListener
 /// [`InMemStorage`]: crate::dispatching::dialogue::InMemStorage
+#[cfg(feature = "ctrlc_handler")]
 pub async fn dialogues_repl_with_listener<'a, R, H, D, Fut, L, ListenerE>(
     requester: R,
     handler: H,

--- a/src/dispatching/repls/repl.rs
+++ b/src/dispatching/repls/repl.rs
@@ -21,6 +21,7 @@ use tokio_stream::wrappers::UnboundedReceiverStream;
 ///
 /// [REPL]: https://en.wikipedia.org/wiki/Read-eval-print_loop
 /// [`Dispatcher`]: crate::dispatching::Dispatcher
+#[cfg(feature = "ctrlc_handler")]
 pub async fn repl<R, H, Fut, E>(requester: R, handler: H)
 where
     H: Fn(UpdateWithCx<R, Message>) -> Fut + Send + Sync + 'static,
@@ -51,6 +52,7 @@ where
 /// [`Dispatcher`]: crate::dispatching::Dispatcher
 /// [`repl`]: crate::dispatching::repls::repl()
 /// [`UpdateListener`]: crate::dispatching::update_listeners::UpdateListener
+#[cfg(feature = "ctrlc_handler")]
 pub async fn repl_with_listener<'a, R, H, Fut, E, L, ListenerE>(
     requester: R,
     handler: H,

--- a/src/dispatching2/mod.rs
+++ b/src/dispatching2/mod.rs
@@ -95,6 +95,7 @@
 //! [chain of responsibility]: https://en.wikipedia.org/wiki/Chain-of-responsibility_pattern
 //! [dependency injection (DI)]: https://en.wikipedia.org/wiki/Dependency_injection
 
+#[cfg(all(feature = "dispatching2", feature = "ctrlc_handler"))]
 pub mod repls;
 
 pub mod dialogue;

--- a/src/dispatching2/repls/mod.rs
+++ b/src/dispatching2/repls/mod.rs
@@ -1,6 +1,5 @@
 //! REPLs for dispatching updates.
 
-//mod dialogues_repl;
 mod commands_repl;
 mod repl;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,12 +61,13 @@
 // https://github.com/rust-lang/rust-clippy/issues/7422
 #![allow(clippy::nonstandard_macro_braces)]
 
+#[cfg(feature = "ctrlc_handler")]
 pub use dispatching::repls::{
     commands_repl, commands_repl_with_listener, dialogues_repl, dialogues_repl_with_listener, repl,
     repl_with_listener,
 };
 
-#[cfg(feature = "dispatching2")]
+#[cfg(all(feature = "dispatching2", feature = "ctrlc_handler"))]
 pub use dispatching2::repls as repls2;
 
 mod logging;


### PR DESCRIPTION
When introducing dispatching v2 we've somehow lost the fact that `repl`s require `ctrlc_handler`, so without default features the compilation failed. Basically we've reintroduced issue #462.

Also we've introduced a similar bug with `cache-me` feature that is required by `dispatching2` feature but wasn't declared as such.