### PR TITLE
Refactor `BotCommand` trait & related stuff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
 
 name: Continuous integration
 
+env:
+  RUSTFLAGS: "--cfg CI_REDIS"
+
 jobs:
   style:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `UpdateListener::StopToken` is now always `Send`
+- Rename `BotCommand` trait to `BotCommands`
+- `BotCommands::descriptions` now returns `CommandDescriptions` instead of `String`
 
 ## 0.7.2 - 2022-03-23
 
@@ -26,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Log `UpdateKind::Error` in `teloxide::dispatching2::Dispatcher`.
 - Don't warn about unhandled updates in `repls2` ([issue 557](https://github.com/teloxide/teloxide/issues/557)).
+- `parse_command` and `parse_command_with_prefix` now ignores case of the bot username
 
 ## 0.7.1 - 2022-03-09
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,8 @@ full = [
 
 [dependencies]
 teloxide-core = { version = "0.4", default-features = false }
-teloxide-macros = { version = "0.5.1", optional = true }
+#teloxide-macros = { version = "0.5.1", optional = true }
+teloxide-macros = { git = "https://github.com/teloxide/teloxide-macros", rev = "7e000b9", optional = true }
 
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -125,11 +125,11 @@ Commands are strongly typed and defined declaratively, similar to how we define 
 ([Full](examples/simple_commands.rs))
 
 ```rust,no_run
-use teloxide::{prelude2::*, utils::command::BotCommand};
+use teloxide::{prelude2::*, utils::command::BotCommands};
 
 use std::error::Error;
 
-#[derive(BotCommand, Clone)]
+#[derive(BotCommands, Clone)]
 #[command(rename = "lowercase", description = "These commands are supported:")]
 enum Command {
     #[command(description = "display this text.")]
@@ -146,7 +146,7 @@ async fn answer(
     command: Command,
 ) -> Result<(), Box<dyn Error + Send + Sync>> {
     match command {
-        Command::Help => bot.send_message(message.chat.id, Command::descriptions()).await?,
+        Command::Help => bot.send_message(message.chat.id, Command::descriptions().to_string()).await?,
         Command::Username(username) => {
             bot.send_message(message.chat.id, format!("Your username is @{}.", username)).await?
         }

--- a/examples/admin.rs
+++ b/examples/admin.rs
@@ -132,7 +132,7 @@ async fn action(
 ) -> Result<(), Box<dyn Error + Send + Sync>> {
     match command {
         Command::Help => {
-            bot.send_message(msg.chat.id, Command::descriptions()).await?;
+            bot.send_message(msg.chat.id, Command::descriptions().to_string()).await?;
         }
         Command::Kick => kick_user(bot, msg).await?,
         Command::Ban { time, unit } => ban_user(bot, msg, calc_restrict_time(time, unit)).await?,

--- a/examples/admin.rs
+++ b/examples/admin.rs
@@ -3,7 +3,7 @@ use std::{error::Error, str::FromStr};
 use chrono::Duration;
 use teloxide::{prelude2::*, types::ChatPermissions, utils::command::BotCommands};
 
-// Derive BotCommand to parse text with a command into this enumeration.
+// Derive BotCommands to parse text with a command into this enumeration.
 //
 //  1. rename = "lowercase" turns all the commands into lowercase letters.
 //  2. `description = "..."` specifies a text before all the commands.

--- a/examples/admin.rs
+++ b/examples/admin.rs
@@ -1,7 +1,7 @@
 use std::{error::Error, str::FromStr};
 
 use chrono::Duration;
-use teloxide::{prelude2::*, types::ChatPermissions, utils::command::BotCommand};
+use teloxide::{prelude2::*, types::ChatPermissions, utils::command::BotCommands};
 
 // Derive BotCommand to parse text with a command into this enumeration.
 //
@@ -12,7 +12,7 @@ use teloxide::{prelude2::*, types::ChatPermissions, utils::command::BotCommand};
 // your commands in this format:
 // %GENERAL-DESCRIPTION%
 // %PREFIX%%COMMAND% - %DESCRIPTION%
-#[derive(BotCommand, Clone)]
+#[derive(BotCommands, Clone)]
 #[command(
     rename = "lowercase",
     description = "Use commands in format /%command% %num% %unit%",

--- a/examples/buttons.rs
+++ b/examples/buttons.rs
@@ -50,7 +50,7 @@ async fn message_handler(
         match BotCommands::parse(text, "buttons") {
             Ok(Command::Help) => {
                 // Just send the description of all commands.
-                bot.send_message(m.chat.id, Command::descriptions()).await?;
+                bot.send_message(m.chat.id, Command::descriptions().to_string()).await?;
             }
             Ok(Command::Start) => {
                 // Create a list of buttons and send them.

--- a/examples/buttons.rs
+++ b/examples/buttons.rs
@@ -6,10 +6,10 @@ use teloxide::{
         InlineKeyboardButton, InlineKeyboardMarkup, InlineQueryResultArticle, InputMessageContent,
         InputMessageContentText,
     },
-    utils::command::BotCommand,
+    utils::command::BotCommands,
 };
 
-#[derive(BotCommand)]
+#[derive(BotCommands)]
 #[command(rename = "lowercase", description = "These commands are supported:")]
 enum Command {
     #[command(description = "Display this text")]
@@ -47,7 +47,7 @@ async fn message_handler(
     bot: AutoSend<Bot>,
 ) -> Result<(), Box<dyn Error + Send + Sync>> {
     if let Some(text) = m.text() {
-        match BotCommand::parse(text, "buttons") {
+        match BotCommands::parse(text, "buttons") {
             Ok(Command::Help) => {
                 // Just send the description of all commands.
                 bot.send_message(m.chat.id, Command::descriptions()).await?;

--- a/examples/db_remember.rs
+++ b/examples/db_remember.rs
@@ -9,7 +9,7 @@ use teloxide::{
     macros::DialogueState,
     prelude2::*,
     types::Me,
-    utils::command::BotCommand,
+    utils::command::BotCommands,
 };
 
 type MyDialogue = Dialogue<State, ErasedStorage<State>>;
@@ -32,7 +32,7 @@ impl Default for State {
     }
 }
 
-#[derive(BotCommand)]
+#[derive(BotCommands)]
 #[command(rename = "lowercase", description = "These commands are supported:")]
 pub enum Command {
     #[command(description = "get your number.")]

--- a/examples/dispatching2_features.rs
+++ b/examples/dispatching2_features.rs
@@ -8,7 +8,7 @@ use rand::Rng;
 use teloxide::{
     prelude2::*,
     types::{Dice, Update},
-    utils::command::BotCommand,
+    utils::command::BotCommands,
 };
 
 #[tokio::main]
@@ -101,7 +101,7 @@ struct ConfigParameters {
     maintainer_username: Option<String>,
 }
 
-#[derive(BotCommand, Clone)]
+#[derive(BotCommands, Clone)]
 #[command(rename = "lowercase", description = "Simple commands")]
 enum SimpleCommand {
     #[command(description = "shows this message.")]
@@ -112,7 +112,7 @@ enum SimpleCommand {
     MyId,
 }
 
-#[derive(BotCommand, Clone)]
+#[derive(BotCommands, Clone)]
 #[command(rename = "lowercase", description = "Maintainer commands")]
 enum MaintainerCommands {
     #[command(parse_with = "split", description = "generate a number within range")]

--- a/examples/dispatching2_features.rs
+++ b/examples/dispatching2_features.rs
@@ -128,9 +128,15 @@ async fn simple_commands_handler(
     let text = match cmd {
         SimpleCommand::Help => {
             if msg.from().unwrap().id == cfg.bot_maintainer {
-                format!("{}\n{}", SimpleCommand::descriptions(), MaintainerCommands::descriptions())
+                format!(
+                    "{}\n\n{}",
+                    SimpleCommand::descriptions(),
+                    MaintainerCommands::descriptions()
+                )
+            } else if msg.chat.is_group() || msg.chat.is_supergroup() {
+                SimpleCommand::descriptions().username("USERNAME_BOT").to_string()
             } else {
-                SimpleCommand::descriptions()
+                SimpleCommand::descriptions().to_string()
             }
         }
         SimpleCommand::Maintainer => {

--- a/examples/simple_commands.rs
+++ b/examples/simple_commands.rs
@@ -1,8 +1,8 @@
-use teloxide::{prelude2::*, utils::command::BotCommand};
+use teloxide::{prelude2::*, utils::command::BotCommands};
 
 use std::error::Error;
 
-#[derive(BotCommand, Clone)]
+#[derive(BotCommands, Clone)]
 #[command(rename = "lowercase", description = "These commands are supported:")]
 enum Command {
     #[command(description = "display this text.")]

--- a/examples/simple_commands.rs
+++ b/examples/simple_commands.rs
@@ -19,7 +19,9 @@ async fn answer(
     command: Command,
 ) -> Result<(), Box<dyn Error + Send + Sync>> {
     match command {
-        Command::Help => bot.send_message(message.chat.id, Command::descriptions()).await?,
+        Command::Help => {
+            bot.send_message(message.chat.id, Command::descriptions().to_string()).await?
+        }
         Command::Username(username) => {
             bot.send_message(message.chat.id, format!("Your username is @{}.", username)).await?
         }

--- a/src/dispatching/dispatcher_handler_rx_ext.rs
+++ b/src/dispatching/dispatcher_handler_rx_ext.rs
@@ -1,4 +1,4 @@
-use crate::{dispatching::UpdateWithCx, utils::command::BotCommand};
+use crate::{dispatching::UpdateWithCx, utils::command::BotCommands};
 use futures::{stream::BoxStream, Stream, StreamExt};
 use teloxide_core::types::Message;
 
@@ -21,7 +21,7 @@ pub trait DispatcherHandlerRxExt<R> {
     fn commands<C, N>(self, bot_name: N) -> BoxStream<'static, (UpdateWithCx<R, Message>, C)>
     where
         Self: Stream<Item = UpdateWithCx<R, Message>>,
-        C: BotCommand,
+        C: BotCommands,
         N: Into<String> + Send,
         R: Send + 'static;
 }
@@ -45,7 +45,7 @@ where
     fn commands<C, N>(self, bot_name: N) -> BoxStream<'static, (UpdateWithCx<R, Message>, C)>
     where
         Self: Stream<Item = UpdateWithCx<R, Message>>,
-        C: BotCommand,
+        C: BotCommands,
         N: Into<String> + Send,
         R: Send + 'static,
     {

--- a/src/dispatching/repls/commands_repl.rs
+++ b/src/dispatching/repls/commands_repl.rs
@@ -4,7 +4,7 @@ use crate::{
         DispatcherHandlerRxExt, UpdateWithCx,
     },
     error_handlers::{LoggingErrorHandler, OnError},
-    utils::command::BotCommand,
+    utils::command::BotCommands,
 };
 use futures::StreamExt;
 use std::{fmt::Debug, future::Future, sync::Arc};
@@ -25,7 +25,7 @@ use tokio_stream::wrappers::UnboundedReceiverStream;
 #[cfg(feature = "ctrlc_handler")]
 pub async fn commands_repl<R, Cmd, H, Fut, HandlerE, N>(requester: R, bot_name: N, handler: H)
 where
-    Cmd: BotCommand + Send + 'static,
+    Cmd: BotCommands + Send + 'static,
     H: Fn(UpdateWithCx<R, Message>, Cmd) -> Fut + Send + Sync + 'static,
     Fut: Future<Output = Result<(), HandlerE>> + Send + 'static,
     Result<(), HandlerE>: OnError<HandlerE>,
@@ -64,7 +64,7 @@ pub async fn commands_repl_with_listener<'a, R, Cmd, H, Fut, L, ListenerE, Handl
     handler: H,
     listener: L,
 ) where
-    Cmd: BotCommand + Send + 'static,
+    Cmd: BotCommands + Send + 'static,
     H: Fn(UpdateWithCx<R, Message>, Cmd) -> Fut + Send + Sync + 'static,
     Fut: Future<Output = Result<(), HandlerE>> + Send + 'static,
     L: UpdateListener<ListenerE> + Send + 'a,

--- a/src/dispatching2/handler_ext.rs
+++ b/src/dispatching2/handler_ext.rs
@@ -6,7 +6,7 @@ use crate::{
         HandlerFactory,
     },
     types::{Me, Message},
-    utils::command::BotCommand,
+    utils::command::BotCommands,
 };
 use dptree::{di::DependencyMap, Handler};
 
@@ -23,7 +23,7 @@ pub trait HandlerExt<Output> {
     #[must_use]
     fn filter_command<C>(self) -> Self
     where
-        C: BotCommand + Send + Sync + 'static;
+        C: BotCommands + Send + Sync + 'static;
 
     /// Passes [`Dialogue<D, S>`] and `D` as handler dependencies.
     ///
@@ -62,7 +62,7 @@ where
 {
     fn filter_command<C>(self) -> Self
     where
-        C: BotCommand + Send + Sync + 'static,
+        C: BotCommands + Send + Sync + 'static,
     {
         self.chain(dptree::filter_map(move |message: Message, me: Me| {
             let bot_name = me.user.username.expect("Bots must have a username");

--- a/src/dispatching2/repls/commands_repl.rs
+++ b/src/dispatching2/repls/commands_repl.rs
@@ -3,7 +3,7 @@ use crate::{
     dispatching2::{HandlerExt, UpdateFilterExt},
     error_handlers::LoggingErrorHandler,
     types::Update,
-    utils::command::BotCommand,
+    utils::command::BotCommands,
 };
 use dptree::di::{DependencyMap, Injectable};
 use std::{fmt::Debug, marker::PhantomData};
@@ -27,7 +27,7 @@ use teloxide_core::requests::Requester;
 #[cfg(feature = "ctrlc_handler")]
 pub async fn commands_repl<'a, R, Cmd, H, E, Args>(bot: R, handler: H, cmd: PhantomData<Cmd>)
 where
-    Cmd: BotCommand + Send + Sync + 'static,
+    Cmd: BotCommands + Send + Sync + 'static,
     H: Injectable<DependencyMap, Result<(), E>, Args> + Send + Sync + 'static,
     R: Requester + Clone + Send + Sync + 'static,
     <R as Requester>::GetUpdates: Send,
@@ -67,7 +67,7 @@ pub async fn commands_repl_with_listener<'a, R, Cmd, H, L, ListenerE, E, Args>(
     listener: L,
     _cmd: PhantomData<Cmd>,
 ) where
-    Cmd: BotCommand + Send + Sync + 'static,
+    Cmd: BotCommands + Send + Sync + 'static,
     H: Injectable<DependencyMap, Result<(), E>, Args> + Send + Sync + 'static,
     L: UpdateListener<ListenerE> + Send + 'a,
     ListenerE: Debug + Send + 'a,

--- a/src/utils/command.rs
+++ b/src/utils/command.rs
@@ -52,8 +52,9 @@ use std::{
 };
 
 use std::marker::PhantomData;
+use teloxide_core::types::BotCommand;
 #[cfg(feature = "macros")]
-pub use teloxide_macros::BotCommand;
+pub use teloxide_macros::BotCommands;
 
 /// An enumeration of bot's commands.
 ///
@@ -205,7 +206,7 @@ pub use teloxide_macros::BotCommand;
 ///
 /// [`FromStr`]: https://doc.rust-lang.org/std/str/trait.FromStr.html
 /// [`BotCommand`]: crate::utils::command::BotCommand
-pub trait BotCommand: Sized {
+pub trait BotCommands: Sized {
     /// Parses a command.
     ///
     /// `bot_username` is required to parse commands like
@@ -218,12 +219,12 @@ pub trait BotCommand: Sized {
     /// (for example when `/help` command is used).
     fn descriptions() -> String;
 
-    /// Returns a vector of [`types::BotCommand`] that can be used with
+    /// Returns a vector of [`BotCommand`] that can be used with
     /// [`set_my_commands`].
     ///
-    /// [`types::BotCommand`]: crate::types::BotCommand
+    /// [`BotCommand`]: crate::types::BotCommand
     /// [`set_my_commands`]: crate::requests::Requester::set_my_commands
-    fn bot_commands() -> Vec<crate::types::BotCommand>;
+    fn bot_commands() -> Vec<BotCommand>;
 
     /// Returns `PhantomData<Self>` that is used as a param of [`commands_repl`]
     ///

--- a/src/utils/command.rs
+++ b/src/utils/command.rs
@@ -1,17 +1,18 @@
 //! Command parsers.
 //!
-//! You can either create an `enum` with derived [`BotCommand`], containing
+//! You can either create an `enum` with derived [`BotCommands`], containing
 //! commands of your bot, or use functions, which split input text into a string
 //! command with its arguments.
 //!
-//! # Using BotCommand
+//! # Using BotCommands
+//!
 //! ```
 //! # #[cfg(feature = "macros")] {
-//! use teloxide::utils::command::BotCommand;
+//! use teloxide::utils::command::BotCommands;
 //!
 //! type UnitOfTime = u8;
 //!
-//! #[derive(BotCommand, PartialEq, Debug)]
+//! #[derive(BotCommands, PartialEq, Debug)]
 //! #[command(rename = "lowercase", parse_with = "split")]
 //! enum AdminCommand {
 //!     Mute(UnitOfTime, char),
@@ -24,6 +25,7 @@
 //! ```
 //!
 //! # Using parse_command
+//!
 //! ```
 //! use teloxide::utils::command::parse_command;
 //!
@@ -33,6 +35,7 @@
 //! ```
 //!
 //! # Using parse_command_with_prefix
+//!
 //! ```
 //! use teloxide::utils::command::parse_command_with_prefix;
 //!
@@ -66,11 +69,11 @@ pub use teloxide_macros::BotCommands;
 /// # Example
 /// ```
 /// # #[cfg(feature = "macros")] {
-/// use teloxide::utils::command::BotCommand;
+/// use teloxide::utils::command::BotCommands;
 ///
 /// type UnitOfTime = u8;
 ///
-/// #[derive(BotCommand, PartialEq, Debug)]
+/// #[derive(BotCommands, PartialEq, Debug)]
 /// #[command(rename = "lowercase", parse_with = "split")]
 /// enum AdminCommand {
 ///     Mute(UnitOfTime, char),
@@ -104,9 +107,9 @@ pub use teloxide_macros::BotCommands;
 /// ## Example
 /// ```
 /// # #[cfg(feature = "macros")] {
-/// use teloxide::utils::command::BotCommand;
+/// use teloxide::utils::command::BotCommands;
 ///
-/// #[derive(BotCommand, PartialEq, Debug)]
+/// #[derive(BotCommands, PartialEq, Debug)]
 /// #[command(rename = "lowercase")]
 /// enum Command {
 ///     Text(String),
@@ -124,9 +127,9 @@ pub use teloxide_macros::BotCommands;
 /// ## Example
 /// ```
 /// # #[cfg(feature = "macros")] {
-/// use teloxide::utils::command::BotCommand;
+/// use teloxide::utils::command::BotCommands;
 ///
-/// #[derive(BotCommand, PartialEq, Debug)]
+/// #[derive(BotCommands, PartialEq, Debug)]
 /// #[command(rename = "lowercase", parse_with = "split")]
 /// enum Command {
 ///     Nums(u8, u16, i32),
@@ -144,9 +147,9 @@ pub use teloxide_macros::BotCommands;
 /// ## Example
 /// ```
 /// # #[cfg(feature = "macros")] {
-/// use teloxide::utils::command::BotCommand;
+/// use teloxide::utils::command::BotCommands;
 ///
-/// #[derive(BotCommand, PartialEq, Debug)]
+/// #[derive(BotCommands, PartialEq, Debug)]
 /// #[command(rename = "lowercase", parse_with = "split", separator = "|")]
 /// enum Command {
 ///     Nums(u8, u16, i32),
@@ -177,7 +180,7 @@ pub use teloxide_macros::BotCommands;
 /// ## Example
 /// ```
 /// # #[cfg(feature = "macros")] {
-/// use teloxide::utils::command::{BotCommand, ParseError};
+/// use teloxide::utils::command::{BotCommands, ParseError};
 ///
 /// fn accept_two_digits(input: String) -> Result<(u8,), ParseError> {
 ///     match input.len() {
@@ -189,7 +192,7 @@ pub use teloxide_macros::BotCommands;
 ///     }
 /// }
 ///
-/// #[derive(BotCommand, PartialEq, Debug)]
+/// #[derive(BotCommands, PartialEq, Debug)]
 /// #[command(rename = "lowercase")]
 /// enum Command {
 ///     #[command(parse_with = "accept_two_digits")]
@@ -242,9 +245,9 @@ pub trait BotCommands: Sized {
 pub type PrefixedBotCommand = String;
 pub type BotName = String;
 
-/// Errors returned from [`BotCommand::parse`].
+/// Errors returned from [`BotCommands::parse`].
 ///
-/// [`BotCommand::parse`]: crate::utils::command::BotCommand::parse
+/// [`BotCommands::parse`]: BotCommands::parse
 #[derive(Debug)]
 pub enum ParseError {
     TooFewArguments {
@@ -313,6 +316,8 @@ impl<'a> CommandDescriptions<'a> {
     /// ## Examples
     ///
     /// ```
+    /// use teloxide::utils::command::{CommandDescription, CommandDescriptions};
+    ///
     /// let descriptions = CommandDescriptions::new(&[
     ///     CommandDescription { prefix: "/", command: "start", description: "start this bot" },
     ///     CommandDescription { prefix: "/", command: "help", description: "show this message" },

--- a/src/utils/command.rs
+++ b/src/utils/command.rs
@@ -209,7 +209,7 @@ pub use teloxide_macros::BotCommands;
 /// specific variant.
 ///
 /// [`FromStr`]: https://doc.rust-lang.org/std/str/trait.FromStr.html
-/// [`BotCommand`]: crate::utils::command::BotCommand
+/// [`BotCommands`]: crate::utils::command::BotCommands
 pub trait BotCommands: Sized {
     /// Parses a command.
     ///

--- a/src/utils/command.rs
+++ b/src/utils/command.rs
@@ -455,7 +455,7 @@ impl Display for CommandDescriptions<'_> {
             f.write_str(prefix)?;
             f.write_str(command)?;
 
-            if let Some(username) = self.bot_username.as_deref() {
+            if let Some(username) = self.bot_username {
                 f.write_char('@')?;
                 f.write_str(username)?;
             }

--- a/src/utils/command.rs
+++ b/src/utils/command.rs
@@ -206,14 +206,31 @@ pub use teloxide_macros::BotCommand;
 /// [`FromStr`]: https://doc.rust-lang.org/std/str/trait.FromStr.html
 /// [`BotCommand`]: crate::utils::command::BotCommand
 pub trait BotCommand: Sized {
-    fn descriptions() -> String;
-    fn parse<N>(s: &str, bot_name: N) -> Result<Self, ParseError>
+    /// Parses a command.
+    ///
+    /// `bot_username` is required to parse commands like
+    /// `/cmd@username_of_the_bot`.
+    fn parse<N>(s: &str, bot_username: N) -> Result<Self, ParseError>
     where
         N: Into<String>;
+
+    /// Returns descriptions of the commands suitable to be shown to the user
+    /// (for example when `/help` command is used).
+    fn descriptions() -> String;
+
+    /// Returns a vector of [`types::BotCommand`] that can be used with
+    /// [`set_my_commands`].
+    ///
+    /// [`types::BotCommand`]: crate::types::BotCommand
+    /// [`set_my_commands`]: crate::requests::Requester::set_my_commands
+    fn bot_commands() -> Vec<crate::types::BotCommand>;
+
+    /// Returns `PhantomData<Self>` that is used as a param of [`commands_repl`]
+    ///
+    /// [`commands_repl`]: (crate::repls2::commands_repl)
     fn ty() -> PhantomData<Self> {
         PhantomData
     }
-    fn bot_commands() -> Vec<crate::types::BotCommand>;
 }
 
 pub type PrefixedBotCommand = String;

--- a/src/utils/shutdown_token.rs
+++ b/src/utils/shutdown_token.rs
@@ -13,6 +13,8 @@ use tokio::sync::Notify;
 use crate::dispatching::update_listeners::UpdateListener;
 
 /// A token which used to shutdown [`Dispatcher`].
+///
+/// [`Dispatcher`]: crate::dispatching::Dispatcher
 #[derive(Clone)]
 pub struct ShutdownToken {
     dispatcher_state: Arc<DispatcherState>,
@@ -21,6 +23,8 @@ pub struct ShutdownToken {
 
 /// This error is returned from [`ShutdownToken::shutdown`] when trying to
 /// shutdown an idle [`Dispatcher`].
+///
+/// [`Dispatcher`]: crate::dispatching::Dispatcher
 #[derive(Debug)]
 pub struct IdleShutdownError;
 

--- a/tests/command.rs
+++ b/tests/command.rs
@@ -200,7 +200,7 @@ fn descriptions_off() {
 #[test]
 #[cfg(feature = "macros")]
 fn rename_rules() {
-    #[derive(BotCommand, Debug, PartialEq)]
+    #[derive(BotCommands, Debug, PartialEq)]
     enum DefaultCommands {
         #[command(rename = "lowercase")]
         AaaAaa,
@@ -230,7 +230,7 @@ fn rename_rules() {
     assert_eq!(DefaultCommands::HhhHhh, DefaultCommands::parse("/HHH-HHH", "").unwrap());
 
     assert_eq!(
-        "/aaaaaa\n/BBBBBB\n/CccCcc\n/dddDdd\n/eee_eee\n/FFF_FFF\n/ggg-ggg\n/HHH-HHH\n",
-        DefaultCommands::descriptions()
+        "/aaaaaa\n/BBBBBB\n/CccCcc\n/dddDdd\n/eee_eee\n/FFF_FFF\n/ggg-ggg\n/HHH-HHH",
+        DefaultCommands::descriptions().to_string()
     );
 }

--- a/tests/command.rs
+++ b/tests/command.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::nonstandard_macro_braces)]
 
 #[cfg(feature = "macros")]
-use teloxide::utils::command::{BotCommand, ParseError};
+use teloxide::utils::command::{BotCommands, ParseError};
 
 // We put tests here because macro expand in unit tests in module
 // teloxide::utils::command was a failure
@@ -10,7 +10,7 @@ use teloxide::utils::command::{BotCommand, ParseError};
 #[test]
 #[cfg(feature = "macros")]
 fn parse_command_with_args() {
-    #[derive(BotCommand, Debug, PartialEq)]
+    #[derive(BotCommands, Debug, PartialEq)]
     #[command(rename = "lowercase")]
     enum DefaultCommands {
         Start(String),
@@ -26,7 +26,7 @@ fn parse_command_with_args() {
 #[test]
 #[cfg(feature = "macros")]
 fn parse_command_with_non_string_arg() {
-    #[derive(BotCommand, Debug, PartialEq)]
+    #[derive(BotCommands, Debug, PartialEq)]
     #[command(rename = "lowercase")]
     enum DefaultCommands {
         Start(i32),
@@ -42,7 +42,7 @@ fn parse_command_with_non_string_arg() {
 #[test]
 #[cfg(feature = "macros")]
 fn attribute_prefix() {
-    #[derive(BotCommand, Debug, PartialEq)]
+    #[derive(BotCommands, Debug, PartialEq)]
     #[command(rename = "lowercase")]
     enum DefaultCommands {
         #[command(prefix = "!")]
@@ -59,7 +59,7 @@ fn attribute_prefix() {
 #[test]
 #[cfg(feature = "macros")]
 fn many_attributes() {
-    #[derive(BotCommand, Debug, PartialEq)]
+    #[derive(BotCommands, Debug, PartialEq)]
     #[command(rename = "lowercase")]
     enum DefaultCommands {
         #[command(prefix = "!", description = "desc")]
@@ -74,7 +74,7 @@ fn many_attributes() {
 #[test]
 #[cfg(feature = "macros")]
 fn global_attributes() {
-    #[derive(BotCommand, Debug, PartialEq)]
+    #[derive(BotCommands, Debug, PartialEq)]
     #[command(prefix = "!", rename = "lowercase", description = "Bot commands")]
     enum DefaultCommands {
         #[command(prefix = "/")]
@@ -90,7 +90,7 @@ fn global_attributes() {
 #[test]
 #[cfg(feature = "macros")]
 fn parse_command_with_bot_name() {
-    #[derive(BotCommand, Debug, PartialEq)]
+    #[derive(BotCommands, Debug, PartialEq)]
     #[command(rename = "lowercase")]
     enum DefaultCommands {
         #[command(prefix = "/")]
@@ -107,7 +107,7 @@ fn parse_command_with_bot_name() {
 #[test]
 #[cfg(feature = "macros")]
 fn parse_with_split() {
-    #[derive(BotCommand, Debug, PartialEq)]
+    #[derive(BotCommands, Debug, PartialEq)]
     #[command(rename = "lowercase")]
     #[command(parse_with = "split")]
     enum DefaultCommands {
@@ -124,7 +124,7 @@ fn parse_with_split() {
 #[test]
 #[cfg(feature = "macros")]
 fn parse_with_split2() {
-    #[derive(BotCommand, Debug, PartialEq)]
+    #[derive(BotCommands, Debug, PartialEq)]
     #[command(rename = "lowercase")]
     #[command(parse_with = "split", separator = "|")]
     enum DefaultCommands {
@@ -152,7 +152,7 @@ fn parse_custom_parser() {
             .map_err(|_| ParseError::Custom("First argument must be a integer!".to_owned().into()))
     }
 
-    #[derive(BotCommand, Debug, PartialEq)]
+    #[derive(BotCommands, Debug, PartialEq)]
     #[command(rename = "lowercase")]
     enum DefaultCommands {
         #[command(parse_with = "custom_parse_function")]
@@ -169,7 +169,7 @@ fn parse_custom_parser() {
 #[test]
 #[cfg(feature = "macros")]
 fn parse_named_fields() {
-    #[derive(BotCommand, Debug, PartialEq)]
+    #[derive(BotCommands, Debug, PartialEq)]
     #[command(rename = "lowercase")]
     #[command(parse_with = "split")]
     enum DefaultCommands {
@@ -186,7 +186,7 @@ fn parse_named_fields() {
 #[test]
 #[cfg(feature = "macros")]
 fn descriptions_off() {
-    #[derive(BotCommand, Debug, PartialEq)]
+    #[derive(BotCommands, Debug, PartialEq)]
     #[command(rename = "lowercase")]
     enum DefaultCommands {
         #[command(description = "off")]

--- a/tests/command.rs
+++ b/tests/command.rs
@@ -68,7 +68,7 @@ fn many_attributes() {
     }
 
     assert_eq!(DefaultCommands::Start, DefaultCommands::parse("!start", "").unwrap());
-    assert_eq!(DefaultCommands::descriptions(), "!start - desc\n/help\n");
+    assert_eq!(DefaultCommands::descriptions().to_string(), "!start — desc\n/help");
 }
 
 #[test]
@@ -84,7 +84,7 @@ fn global_attributes() {
 
     assert_eq!(DefaultCommands::Start, DefaultCommands::parse("/start", "MyNameBot").unwrap());
     assert_eq!(DefaultCommands::Help, DefaultCommands::parse("!help", "MyNameBot").unwrap());
-    assert_eq!(DefaultCommands::descriptions(), "Bot commands\n/start\n!help\n");
+    assert_eq!(DefaultCommands::descriptions().to_string(), "Bot commands\n\n/start\n!help");
 }
 
 #[test]
@@ -194,7 +194,7 @@ fn descriptions_off() {
         Help,
     }
 
-    assert_eq!(DefaultCommands::descriptions(), "/help\n".to_owned());
+    assert_eq!(DefaultCommands::descriptions().to_string(), "/help".to_owned());
 }
 
 #[test]

--- a/tests/redis.rs
+++ b/tests/redis.rs
@@ -5,6 +5,7 @@ use std::{
 use teloxide::dispatching::dialogue::{RedisStorage, RedisStorageError, Serializer, Storage};
 
 #[tokio::test]
+#[cfg_attr(not(CI_REDIS), ignore)]
 async fn test_redis_json() {
     let storage = RedisStorage::open(
         "redis://127.0.0.1:7777",
@@ -16,6 +17,7 @@ async fn test_redis_json() {
 }
 
 #[tokio::test]
+#[cfg_attr(not(CI_REDIS), ignore)]
 async fn test_redis_bincode() {
     let storage = RedisStorage::open(
         "redis://127.0.0.1:7778",
@@ -27,6 +29,7 @@ async fn test_redis_bincode() {
 }
 
 #[tokio::test]
+#[cfg_attr(not(CI_REDIS), ignore)]
 async fn test_redis_cbor() {
     let storage = RedisStorage::open(
         "redis://127.0.0.1:7779",

--- a/tests/sqlite.rs
+++ b/tests/sqlite.rs
@@ -1,36 +1,47 @@
 use std::{
     fmt::{Debug, Display},
+    fs,
     sync::Arc,
 };
 use teloxide::dispatching::dialogue::{Serializer, SqliteStorage, SqliteStorageError, Storage};
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_sqlite_json() {
-    let storage =
-        SqliteStorage::open("./test_db1.sqlite", teloxide::dispatching::dialogue::serializer::Json)
-            .await
-            .unwrap();
+    fs::create_dir("./test_db1").unwrap();
+    let storage = SqliteStorage::open(
+        "./test_db1/test_db1.sqlite",
+        teloxide::dispatching::dialogue::serializer::Json,
+    )
+    .await
+    .unwrap();
     test_sqlite(storage).await;
+    fs::remove_dir_all("./test_db1").unwrap();
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_sqlite_bincode() {
+    fs::create_dir("./test_db2").unwrap();
     let storage = SqliteStorage::open(
-        "./test_db2.sqlite",
+        "./test_db2/test_db2.sqlite",
         teloxide::dispatching::dialogue::serializer::Bincode,
     )
     .await
     .unwrap();
     test_sqlite(storage).await;
+    fs::remove_dir_all("./test_db2").unwrap();
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_sqlite_cbor() {
-    let storage =
-        SqliteStorage::open("./test_db3.sqlite", teloxide::dispatching::dialogue::serializer::Cbor)
-            .await
-            .unwrap();
+    fs::create_dir("./test_db3").unwrap();
+    let storage = SqliteStorage::open(
+        "./test_db3/test_db3.sqlite",
+        teloxide::dispatching::dialogue::serializer::Cbor,
+    )
+    .await
+    .unwrap();
     test_sqlite(storage).await;
+    fs::remove_dir_all("./test_db3").unwrap();
 }
 
 type Dialogue = String;


### PR DESCRIPTION
1. Rename `BotCommand` -> `BotCommands`
2. Implement  #531 (closes #531)
3. Some unrelated documentation/test/readme/changelog fixes

Note that this PR also requires changes from https://github.com/teloxide/teloxide-macros/pull/15