### PR TITLE
Deprecate `enable_logging!` in favour of configuring logging yourself

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
-- `enable_logging!` macro
+- `enable_logging!` and `enable_logging_with_filter!` macros
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `ErasedStorage`, a storage with an erased error type.
 - Allow the storage generic `S` be `?Sized` in `Dialogue` and `HandlerExt::enter_dialogue`.
 
+### Deprecated
+
+- `enable_logging!` macro
+
 ### Fixed
 
 - Log `UpdateKind::Error` in `teloxide::dispatching2::Dispatcher`.

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ use teloxide::prelude2::*;
 
 #[tokio::main]
 async fn main() {
-    teloxide::enable_logging!();
+    pretty_env_logger::init();
     log::info!("Starting dices_bot...");
 
     let bot = Bot::from_env().auto_send();
@@ -164,7 +164,7 @@ async fn answer(
 
 #[tokio::main]
 async fn main() {
-    teloxide::enable_logging!();
+    pretty_env_logger::init();
     log::info!("Starting simple_commands_bot...");
 
     let bot = Bot::from_env().auto_send();
@@ -218,7 +218,7 @@ impl Default for State {
 
 #[tokio::main]
 async fn main() {
-    teloxide::enable_logging!();
+    pretty_env_logger::init();
     log::info!("Starting dialogue_bot...");
 
     let bot = Bot::from_env().auto_send();
@@ -337,15 +337,6 @@ A: teloxide doesn't provide a special API for working with webhooks due to their
 Associated links:
  - [Marvin's Marvellous Guide to All Things Webhook](https://core.telegram.org/bots/webhooks)
  - [Using self-signed certificates](https://core.telegram.org/bots/self-signed)
-
-**Q: Can I use different loggers?**
-
-A: Yes. You can setup any logger, for example [fern]. teloxide has no specific requirements as it depends only on [log]. Remember that [`enable_logging!`] and [`enable_logging_with_filter!`] are just **optional** utilities.
-
-[fern]: https://crates.io/crates/fern
-[log]: https://crates.io/crates/log
-[`enable_logging!`]: https://docs.rs/teloxide/latest/teloxide/macro.enable_logging.html
-[`enable_logging_with_filter!`]: https://docs.rs/teloxide/latest/teloxide/macro.enable_logging_with_filter.html
 
 ## Community bots
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,7 +1,7 @@
 # Usage
 
 ```
-$ cargo run --features="full" --example <example-name>
+$ RUST_LOF=info cargo run --features="full" --example <example-name>
 ```
 
 Don't forget to initialise the `TELOXIDE_TOKEN` environmental variable.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,7 +1,7 @@
 # Usage
 
 ```
-$ RUST_LOF=info cargo run --features="full" --example <example-name>
+$ RUST_LOG=info cargo run --features="full" --example <example-name>
 ```
 
 Don't forget to initialise the `TELOXIDE_TOKEN` environmental variable.

--- a/examples/admin.rs
+++ b/examples/admin.rs
@@ -144,7 +144,7 @@ async fn action(
 
 #[tokio::main]
 async fn main() {
-    teloxide::enable_logging!();
+    pretty_env_logger::init();
     log::info!("Starting admin_bot...");
 
     let bot = teloxide::Bot::from_env().auto_send();

--- a/examples/buttons.rs
+++ b/examples/buttons.rs
@@ -114,7 +114,7 @@ async fn callback_handler(
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
-    teloxide::enable_logging!();
+    pretty_env_logger::init();
     log::info!("Starting bot...");
 
     let bot = Bot::from_env().auto_send();

--- a/examples/db_remember.rs
+++ b/examples/db_remember.rs
@@ -43,6 +43,9 @@ pub enum Command {
 
 #[tokio::main]
 async fn main() {
+    pretty_env_logger::init();
+    log::info!("Starting db_remember_bot...");
+
     let bot = Bot::from_env().auto_send();
 
     let storage: MyStorage = if std::env::var("DB_REMEMBER_REDIS").is_ok() {

--- a/examples/dialogue.rs
+++ b/examples/dialogue.rs
@@ -41,7 +41,7 @@ impl Default for State {
 
 #[tokio::main]
 async fn main() {
-    teloxide::enable_logging!();
+    pretty_env_logger::init();
     log::info!("Starting dialogue_bot...");
 
     let bot = Bot::from_env().auto_send();

--- a/examples/dices.rs
+++ b/examples/dices.rs
@@ -4,7 +4,7 @@ use teloxide::prelude2::*;
 
 #[tokio::main]
 async fn main() {
-    teloxide::enable_logging!();
+    pretty_env_logger::init();
     log::info!("Starting dices_bot...");
 
     let bot = Bot::from_env().auto_send();

--- a/examples/dispatching2_features.rs
+++ b/examples/dispatching2_features.rs
@@ -13,7 +13,7 @@ use teloxide::{
 
 #[tokio::main]
 async fn main() {
-    teloxide::enable_logging!();
+    pretty_env_logger::init();
     log::info!("Starting dispatching2_features_bot...");
 
     let bot = Bot::from_env().auto_send();

--- a/examples/heroku_ping_pong.rs
+++ b/examples/heroku_ping_pong.rs
@@ -36,7 +36,7 @@ use reqwest::{StatusCode, Url};
 
 #[tokio::main]
 async fn main() {
-    teloxide::enable_logging!();
+    pretty_env_logger::init();
     log::info!("Starting heroku_ping_pong_bot...");
 
     let bot = Bot::from_env().auto_send();

--- a/examples/inline.rs
+++ b/examples/inline.rs
@@ -8,7 +8,7 @@ use teloxide::{
 
 #[tokio::main]
 async fn main() {
-    teloxide::enable_logging!();
+    pretty_env_logger::init();
     log::info!("Starting inline_bot...");
 
     let bot = Bot::from_env().auto_send();

--- a/examples/ngrok_ping_pong.rs
+++ b/examples/ngrok_ping_pong.rs
@@ -19,7 +19,7 @@ use reqwest::{StatusCode, Url};
 
 #[tokio::main]
 async fn main() {
-    teloxide::enable_logging!();
+    pretty_env_logger::init();
     log::info!("Starting heroku_ping_pong_bot...");
 
     let bot = Bot::from_env().auto_send();

--- a/examples/shared_state.rs
+++ b/examples/shared_state.rs
@@ -9,7 +9,7 @@ static MESSAGES_TOTAL: Lazy<AtomicU64> = Lazy::new(AtomicU64::default);
 
 #[tokio::main]
 async fn main() {
-    teloxide::enable_logging!();
+    pretty_env_logger::init();
     log::info!("Starting shared_state_bot...");
 
     let bot = Bot::from_env().auto_send();

--- a/examples/simple_commands.rs
+++ b/examples/simple_commands.rs
@@ -37,7 +37,7 @@ async fn answer(
 
 #[tokio::main]
 async fn main() {
-    teloxide::enable_logging!();
+    pretty_env_logger::init();
     log::info!("Starting simple_commands_bot...");
 
     let bot = Bot::from_env().auto_send();

--- a/src/dispatching/dialogue/mod.rs
+++ b/src/dispatching/dialogue/mod.rs
@@ -80,7 +80,7 @@
 //!
 //! #[tokio::main]
 //! async fn main() {
-//!     teloxide::enable_logging!();
+//!     pretty_env_logger::init();
 //!     log::info!("Starting dialogue_bot!");
 //!
 //!     let bot = Bot::from_env().auto_send();

--- a/src/dispatching2/mod.rs
+++ b/src/dispatching2/mod.rs
@@ -38,7 +38,7 @@
 //!
 //! # #[tokio::main]
 //! # async fn main() {
-//! teloxide::enable_logging!();
+//! pretty_env_logger::init();
 //! log::info!("Starting shared_state_bot...");
 //!
 //! let bot = Bot::from_env().auto_send();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 //!
 //! # #[tokio::main]
 //! # async fn main() {
-//! teloxide::enable_logging!();
+//! pretty_env_logger::init();
 //! log::info!("Starting dices_bot...");
 //!
 //! let bot = Bot::from_env().auto_send();

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -10,8 +10,10 @@
 ///
 /// [pretty-env-logger]: https://crates.io/crates/pretty_env_logger
 #[macro_export]
+#[deprecated = "Choose logging implementation yourself"]
 macro_rules! enable_logging {
     () => {
+        #[allow(deprecated)]
         teloxide::enable_logging_with_filter!(log::LevelFilter::Trace);
     };
 }
@@ -39,6 +41,7 @@ macro_rules! enable_logging {
 /// [pretty-env-logger]: https://crates.io/crates/pretty_env_logger
 /// [`LevelFilter::Debug`]: https://docs.rs/log/0.4.10/log/enum.LevelFilter.html
 #[macro_export]
+#[deprecated = "Choose logging implementation yourself"]
 macro_rules! enable_logging_with_filter {
     ($filter:expr) => {
         pretty_env_logger::formatted_builder()


### PR DESCRIPTION
`enable_logging!` is confusing and in code seems like "magic" even though it really just calls into `pretty_env_logger`.
IMO initialising logging is a better way to enable logging.