### PR TITLE
Disable `repls2` unhandled update warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Log `UpdateKind::Error` in `teloxide::dispatching2::Dispatcher`.
+- Don't warn about unhandled updates in `repls2` ([issue 557](https://github.com/teloxide/teloxide/issues/557)).
 
 ## 0.7.1 - 2022-03-09
 

--- a/src/dispatching2/repls/commands_repl.rs
+++ b/src/dispatching2/repls/commands_repl.rs
@@ -76,10 +76,15 @@ pub async fn commands_repl_with_listener<'a, R, Cmd, H, L, ListenerE, E, Args>(
 {
     use crate::dispatching2::Dispatcher;
 
+    // Other update types are of no interest to use since this REPL is only for
+    // commands. See <https://github.com/teloxide/teloxide/issues/557>.
+    let ignore_update = |_upd| Box::pin(async {});
+
     let mut dispatcher = Dispatcher::builder(
         bot,
         Update::filter_message().filter_command::<Cmd>().branch(dptree::endpoint(handler)),
     )
+    .default_handler(ignore_update)
     .build();
 
     #[cfg(feature = "ctrlc_handler")]

--- a/src/dispatching2/repls/repl.rs
+++ b/src/dispatching2/repls/repl.rs
@@ -56,9 +56,14 @@ where
 {
     use crate::dispatching2::Dispatcher;
 
+    // Other update types are of no interest to use since this REPL is only for
+    // messages. See <https://github.com/teloxide/teloxide/issues/557>.
+    let ignore_update = |_upd| Box::pin(async {});
+
     #[allow(unused_mut)]
     let mut dispatcher =
         Dispatcher::builder(bot, Update::filter_message().branch(dptree::endpoint(handler)))
+            .default_handler(ignore_update)
             .build();
 
     #[cfg(feature = "ctrlc_handler")]


### PR DESCRIPTION
Closes https://github.com/teloxide/teloxide/issues/557.
