### PR TITLE
Release `0.7.3`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## unreleased
 
+## 0.7.3 - 2022-04-03
+
+### Fixed
+
+- Update `teloxide-core` to version `0.4.5` to fix a security vulnerability. See more in `teloxide-core` [release notes](https://github.com/teloxide/teloxide-core/releases/tag/v0.4.5).
+
 ## 0.7.2 - 2022-03-23
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "teloxide"
-version = "0.7.2"
+version = "0.7.3"
 edition = "2018"
 description = "An elegant Telegram bots framework for Rust"
 repository = "https://github.com/teloxide/teloxide"
@@ -58,7 +58,7 @@ full = [
 ]
 
 [dependencies]
-teloxide-core = { version = "0.4", default-features = false }
+teloxide-core = { version = "0.4.5", default-features = false }
 teloxide-macros = { version = "0.5.1", optional = true }
 
 serde_json = "1.0"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 > [v0.5 -> v0.6 migration guide >>](MIGRATION_GUIDE.md#05---06)
 
+> `teloxide-core` versions less that `0.4.5` has a low-severity security vulnerability, [see more >>](./CHANGELOG.md#073---2022-04-03)
+
 <div align="center">
   <img src="ICON.png" width="250"/>
   <h1>teloxide</h1>


### PR DESCRIPTION
Prepare a `0.7.3` release with updated `teloxide-core` to bring in the [security fix].

[security fix]: https://github.com/teloxide/teloxide-core/pull/200
