### PR TITLE
Remove the need for `CacheMe` in dispatcher

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,7 @@ license = "MIT"
 exclude = ["media"]
 
 [features]
-# FIXME: remove "cache-me" that was added by mistake here
-default = ["native-tls", "ctrlc_handler", "teloxide-core/default",  "auto-send", "cache-me"]
+default = ["native-tls", "ctrlc_handler", "teloxide-core/default",  "auto-send"]
 
 sqlite-storage = ["sqlx"]
 redis-storage = ["redis"]


### PR DESCRIPTION
<!--
Before making this PR, please ensure the following:

 - The PR is open to `dev`, NOT `master`.
 - `CHANGELOG.md` is updated (if necessary).
 - Documentation and tests are updated (if necessary).
-->
Doesn't change anything for users, just an internal cleanup.