### PR TITLE
Implement concurrent update dispatching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - `BotCommands::descriptions` now returns `CommandDescriptions` instead of `String` [**BC**].
  - Mark `Dialogue::new` as `#[must_use]`.
 
+### Fixed
+
+ - Concurrent update handling in the new dispatcher ([issue 536](https://github.com/teloxide/teloxide/issues/536)).
+
 ### Deprecated
 
  - `HandlerFactory` and `HandlerExt::dispatch_by` in favour of `teloxide::handler!`.

--- a/src/dispatching/dispatcher.rs
+++ b/src/dispatching/dispatcher.rs
@@ -317,20 +317,14 @@ where
 
     let deps = Arc::new(deps);
 
-    tokio::spawn(async move {
-        ReceiverStream::new(rx)
-            .for_each(|update| {
-                let deps = Arc::clone(&deps);
-                let handler = Arc::clone(&handler);
-                let default_handler = Arc::clone(&default_handler);
-                let error_handler = Arc::clone(&error_handler);
+    tokio::spawn(ReceiverStream::new(rx).for_each(move |update| {
+        let deps = Arc::clone(&deps);
+        let handler = Arc::clone(&handler);
+        let default_handler = Arc::clone(&default_handler);
+        let error_handler = Arc::clone(&error_handler);
 
-                async move {
-                    handle_update(update, deps, handler, default_handler, error_handler).await;
-                }
-            })
-            .await;
-    });
+        handle_update(update, deps, handler, default_handler, error_handler)
+    }));
 
     tx
 }
@@ -348,20 +342,14 @@ where
 
     let deps = Arc::new(deps);
 
-    tokio::spawn(async move {
-        ReceiverStream::new(rx)
-            .for_each_concurrent(None, |update| {
-                let deps = Arc::clone(&deps);
-                let handler = Arc::clone(&handler);
-                let default_handler = Arc::clone(&default_handler);
-                let error_handler = Arc::clone(&error_handler);
+    tokio::spawn(ReceiverStream::new(rx).for_each_concurrent(None, move |update| {
+        let deps = Arc::clone(&deps);
+        let handler = Arc::clone(&handler);
+        let default_handler = Arc::clone(&default_handler);
+        let error_handler = Arc::clone(&error_handler);
 
-                async move {
-                    handle_update(update, deps, handler, default_handler, error_handler).await;
-                }
-            })
-            .await;
-    });
+        handle_update(update, deps, handler, default_handler, error_handler)
+    }));
 
     tx
 }

--- a/src/dispatching/dispatcher.rs
+++ b/src/dispatching/dispatcher.rs
@@ -316,7 +316,7 @@ where
 
     tokio::spawn(async move {
         ReceiverStream::new(rx)
-            .for_each_concurrent(None, |update| {
+            .for_each(|update| {
                 let deps = Arc::clone(&deps);
                 let handler = Arc::clone(&handler);
                 let default_handler = Arc::clone(&default_handler);
@@ -347,7 +347,7 @@ where
 
     tokio::spawn(async move {
         ReceiverStream::new(rx)
-            .for_each(|update| {
+            .for_each_concurrent(None, |update| {
                 let deps = Arc::clone(&deps);
                 let handler = Arc::clone(&handler);
                 let default_handler = Arc::clone(&default_handler);

--- a/src/dispatching/dispatcher.rs
+++ b/src/dispatching/dispatcher.rs
@@ -78,9 +78,9 @@ where
         Dispatcher {
             bot: self.bot.clone(),
             dependencies: self.dependencies,
-            handler: Arc::clone(&self.handler),
-            default_handler: Arc::clone(&self.default_handler),
-            error_handler: Arc::clone(&self.error_handler),
+            handler: self.handler,
+            default_handler: self.default_handler,
+            error_handler: self.error_handler,
             allowed_updates: Default::default(),
             state: ShutdownToken::new(),
             workers: HashMap::new(),

--- a/src/dispatching/dispatcher.rs
+++ b/src/dispatching/dispatcher.rs
@@ -100,7 +100,10 @@ pub struct Dispatcher<R, Err> {
 
     handler: Arc<UpdateHandler<Err>>,
     default_handler: Arc<DefaultHandler>,
+
+    // Tokio TX channel parts associated with chat IDs that consume updates sequentially.
     workers: HashMap<i64, WorkerTx>,
+    // The default TX part that consume updates concurrently.
     default_worker: Option<WorkerTx>,
 
     error_handler: Arc<dyn ErrorHandler<Err> + Send + Sync>,

--- a/src/dispatching/dispatcher.rs
+++ b/src/dispatching/dispatcher.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 
 use dptree::di::{DependencyMap, DependencySupplier};
-use futures::{future::BoxFuture, StreamExt};
+use futures::{future::BoxFuture, stream::FuturesUnordered, StreamExt};
 use std::{
     collections::{HashMap, HashSet},
     fmt::Debug,
@@ -233,7 +233,9 @@ where
             .map(|(_chat_id, worker)| worker.handle)
             .chain(self.default_worker.take().map(|worker| worker.handle))
             .collect::<FuturesUnordered<_>>()
-            .for_each(|()| ())
+            .for_each(|res| async {
+                res.expect("Failed to wait for a worker.");
+            })
             .await;
 
         self.state.done();

--- a/src/dispatching/dispatcher.rs
+++ b/src/dispatching/dispatcher.rs
@@ -228,9 +228,10 @@ where
             }
         }
 
-        self.workers.drain()
+        self.workers
+            .drain()
             .map(|(_chat_id, worker)| worker.handle)
-            .chain(self.default_worker.take().map(|worker| worker.handle))        
+            .chain(self.default_worker.take().map(|worker| worker.handle))
             .collect::<FuturesUnordered<_>>()
             .for_each(|()| ())
             .await;


### PR DESCRIPTION
After some hot fucking with `Arc`s, `Box`es, `async`, closures, `Deref`s, and `move`s, I was finally able to implement concurrent handling in the new `Dispatcher`.

I think we can release v0.8.0 after this PR is merged and postpone all the other v0.8.0 issues/PRs.

Related to https://github.com/teloxide/teloxide/issues/571.
Resolves https://github.com/teloxide/teloxide/issues/536.
