### PR TITLE
Fix the `teloxide::handler!` docs

### DIFF
--- a/src/dispatching/dialogue/mod.rs
+++ b/src/dispatching/dialogue/mod.rs
@@ -203,8 +203,8 @@ where
 ///  - For `State::MyVariant(param,)` and `State::MyVariant { param, }`, the
 ///    payload is `(param,)`.
 ///  - For `State::MyVariant(param1, ..., paramN)` and `State::MyVariant {
-///    param1, ..., paramN }`, the payload is `(param1, ..., paramN)` (where `N`
-///    > 1).
+///    param1, ..., paramN }`, the payload is `(param1, ..., paramN)` (where
+///    `N`>1).
 ///
 /// ## Dependency requirements
 ///


### PR DESCRIPTION
Previously it looked like this:

![Screenshot from 2022-04-18 22-45-35](https://user-images.githubusercontent.com/40539574/163842392-8eb0bf3f-29de-43f3-a6c5-128df9681d39.png)
