### PR TITLE
Document and check the MSRV in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,7 @@ jobs:
           - stable
           - beta
           - nightly
+          - msrv
     
         include:
           - rust: stable
@@ -65,6 +66,9 @@ jobs:
             features: "--features full"
           - rust: nightly
             toolchain: nightly-2022-01-17
+            features: "--all-features"
+          - rust: msrv
+            toolchain: "1.58.0"
             features: "--all-features"
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
             features: "--all-features"
           - rust: msrv
             toolchain: "1.58.0"
-            features: "--all-features"
+            features: "--features full"
 
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ $ set TELOXIDE_TOKEN=<Your token here>
 $ $env:TELOXIDE_TOKEN=<Your token here>
 
 ```
- 4. Make sure that your Rust compiler is up to date:
+ 4. Make sure that your Rust compiler is up to date (teloxide currently requires rustc at least version 1.58):
 ```bash
 # If you're using stable
 $ rustup update stable


### PR DESCRIPTION
Exavtly what the title says, document that teloxide requires rustc >= 1.58 and add a CI check to make sure MSRV changes don't get unnoticed.