### PR TITLE
Add `examples/purchase.rs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
  - Implement `GetChatId` for `Update`.
+ - The `dialogue::enter()` function as a shortcut for `dptree::entry().enter_dialogue()`.
 
 ## 0.8.0 - 2022-04-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## unreleased
 
+### Added
+
+ - Implement `GetChatId` for `Update`.
+
 ## 0.8.0 - 2022-04-18
 
 ### Removed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,3 +152,7 @@ required-features = ["macros"]
 [[example]]
 name = "ngrok_ping_pong"
 required-features = ["webhooks-axum"]
+
+[[example]]
+name = "purchase"
+required-features = ["macros"]

--- a/README.md
+++ b/README.md
@@ -334,6 +334,10 @@ Associated links:
  - [Marvin's Marvellous Guide to All Things Webhook](https://core.telegram.org/bots/webhooks)
  - [Using self-signed certificates](https://core.telegram.org/bots/self-signed)
 
+**Q: Can I handle both callback queries and messages within a single dialogue?**
+
+A: Yes, see [`examples/purchase.rs`](examples/purchase.rs).
+
 ## Community bots
 
 Feel free to propose your own bot to our collection!

--- a/examples/purchase.rs
+++ b/examples/purchase.rs
@@ -26,7 +26,7 @@ type HandlerResult = Result<(), Box<dyn std::error::Error + Send + Sync>>;
 pub enum State {
     Start,
     ReceiveFullName,
-    ProductChosen { full_name: String },
+    ReceiveProductChoice { full_name: String },
 }
 
 impl Default for State {
@@ -60,7 +60,7 @@ async fn main() {
             )
             .branch(
                 Update::filter_callback_query().chain(
-                    teloxide::handler![State::ProductChosen { full_name }]
+                    teloxide::handler![State::ReceiveProductChoice { full_name }]
                         .endpoint(receive_product_selection),
                 ),
             )
@@ -107,7 +107,7 @@ async fn receive_full_name(
             );
 
             bot.send_message(msg.chat.id, "Select a product:").reply_markup(products).await?;
-            dialogue.update(State::ProductChosen { full_name }).await?;
+            dialogue.update(State::ReceiveProductChoice { full_name }).await?;
         }
         None => {
             bot.send_message(msg.chat.id, "Please, send me your full name.").await?;

--- a/examples/purchase.rs
+++ b/examples/purchase.rs
@@ -130,9 +130,8 @@ async fn receive_product_selection(
                 format!("{full_name}, product '{product}' has been purchased successfully!"),
             )
             .await?;
+            dialogue.exit().await?;
         }
-
-        dialogue.update(State::Start).await?;
     }
 
     Ok(())

--- a/examples/purchase.rs
+++ b/examples/purchase.rs
@@ -1,0 +1,146 @@
+// This example demonstrates how to deal with messages and callback queries in a
+// single dialogue.
+//
+// # Example
+// ```
+// - /start
+// - Let's start! What's your full name?
+// - John Doe
+// - Select a product:
+//   [Apple, Banana, Orange, Potato]
+// - <A user selects "Banana">
+// - John Doe, product 'Banana' has been purchased successfully!
+// ```
+
+use teloxide::{
+    dispatching::dialogue::{GetChatId, InMemStorage},
+    prelude::*,
+    types::{InlineKeyboardButton, InlineKeyboardMarkup},
+    utils::command::BotCommands,
+};
+
+type MyDialogue = Dialogue<State, InMemStorage<State>>;
+type HandlerResult = Result<(), Box<dyn std::error::Error + Send + Sync>>;
+
+#[derive(Clone)]
+pub enum State {
+    Start,
+    ReceiveFullName,
+    ProductChosen { full_name: String },
+}
+
+impl Default for State {
+    fn default() -> Self {
+        Self::Start
+    }
+}
+
+#[derive(BotCommands, Clone)]
+#[command(rename = "lowercase", description = "These commands are supported:")]
+enum Command {
+    #[command(description = "display this text.")]
+    Help,
+    #[command(description = "start the purchase procedure.")]
+    Start,
+}
+
+#[tokio::main]
+async fn main() {
+    pretty_env_logger::init();
+    log::info!("Starting dialogue_bot...");
+
+    let bot = Bot::from_env().auto_send();
+
+    Dispatcher::builder(
+        bot,
+        dptree::entry()
+            .enter_dialogue::<Update, InMemStorage<State>, State>()
+            .branch(
+                Update::filter_message()
+                    .chain(teloxide::handler![State::ReceiveFullName].endpoint(receive_full_name)),
+            )
+            .branch(
+                Update::filter_callback_query().chain(
+                    teloxide::handler![State::ProductChosen { full_name }]
+                        .endpoint(receive_product_selection),
+                ),
+            )
+            .branch(Update::filter_message().filter_command::<Command>().endpoint(handle_command))
+            .branch(Update::filter_message().endpoint(invalid_state)),
+    )
+    .dependencies(dptree::deps![InMemStorage::<State>::new()])
+    .build()
+    .setup_ctrlc_handler()
+    .dispatch()
+    .await;
+}
+
+async fn handle_command(
+    bot: AutoSend<Bot>,
+    msg: Message,
+    cmd: Command,
+    dialogue: MyDialogue,
+) -> HandlerResult {
+    match cmd {
+        Command::Help => {
+            bot.send_message(msg.chat.id, Command::descriptions().to_string()).await?;
+        }
+        Command::Start => {
+            bot.send_message(msg.chat.id, "Let's start! What's your full name?").await?;
+            dialogue.update(State::ReceiveFullName).await?;
+        }
+    }
+
+    Ok(())
+}
+
+async fn receive_full_name(
+    bot: AutoSend<Bot>,
+    msg: Message,
+    dialogue: MyDialogue,
+) -> HandlerResult {
+    match msg.text().map(ToOwned::to_owned) {
+        Some(full_name) => {
+            let products = InlineKeyboardMarkup::default().append_row(
+                vec!["Apple", "Banana", "Orange", "Potato"].into_iter().map(|product| {
+                    InlineKeyboardButton::callback(product.to_owned(), product.to_owned())
+                }),
+            );
+
+            bot.send_message(msg.chat.id, "Select a product:").reply_markup(products).await?;
+            dialogue.update(State::ProductChosen { full_name }).await?;
+        }
+        None => {
+            bot.send_message(msg.chat.id, "Please, send me your full name.").await?;
+        }
+    }
+
+    Ok(())
+}
+
+async fn receive_product_selection(
+    bot: AutoSend<Bot>,
+    q: CallbackQuery,
+    dialogue: MyDialogue,
+    full_name: String,
+) -> HandlerResult {
+    if let Some(product) = &q.data {
+        if let Some(chat_id) = q.chat_id() {
+            bot.send_message(
+                chat_id,
+                format!("{full_name}, product '{product}' has been purchased successfully!"),
+            )
+            .await?;
+        }
+
+        dialogue.update(State::Start).await?;
+    }
+
+    Ok(())
+}
+
+async fn invalid_state(bot: AutoSend<Bot>, msg: Message) -> HandlerResult {
+    bot.send_message(msg.chat.id, "Unable to handle the message. Type /help to see the usage.")
+        .await?;
+    Ok(())
+}

--- a/examples/purchase.rs
+++ b/examples/purchase.rs
@@ -13,7 +13,7 @@
 // ```
 
 use teloxide::{
-    dispatching::dialogue::{GetChatId, InMemStorage},
+    dispatching::dialogue::{self, GetChatId, InMemStorage},
     prelude::*,
     types::{InlineKeyboardButton, InlineKeyboardMarkup},
     utils::command::BotCommands,
@@ -53,8 +53,7 @@ async fn main() {
 
     Dispatcher::builder(
         bot,
-        dptree::entry()
-            .enter_dialogue::<Update, InMemStorage<State>, State>()
+        dialogue::enter::<Update, InMemStorage<State>, State, _>()
             .branch(
                 Update::filter_message()
                     .chain(teloxide::handler![State::ReceiveFullName].endpoint(receive_full_name)),

--- a/examples/purchase.rs
+++ b/examples/purchase.rs
@@ -56,16 +56,16 @@ async fn main() {
         dialogue::enter::<Update, InMemStorage<State>, State, _>()
             .branch(
                 Update::filter_message()
-                    .chain(teloxide::handler![State::ReceiveFullName].endpoint(receive_full_name)),
+                    .branch(teloxide::handler![State::ReceiveFullName].endpoint(receive_full_name))
+                    .branch(dptree::entry().filter_command::<Command>().endpoint(handle_command))
+                    .branch(dptree::endpoint(invalid_state)),
             )
             .branch(
                 Update::filter_callback_query().chain(
                     teloxide::handler![State::ReceiveProductChoice { full_name }]
                         .endpoint(receive_product_selection),
                 ),
-            )
-            .branch(Update::filter_message().filter_command::<Command>().endpoint(handle_command))
-            .branch(Update::filter_message().endpoint(invalid_state)),
+            ),
     )
     .dependencies(dptree::deps![InMemStorage::<State>::new()])
     .build()

--- a/examples/purchase.rs
+++ b/examples/purchase.rs
@@ -1,5 +1,5 @@
-// This example demonstrates how to deal with messages and callback queries in a
-// single dialogue.
+// This example demonstrates how to deal with messages and callback queries
+// within a single dialogue.
 //
 // # Example
 // ```

--- a/src/dispatching/dialogue/get_chat_id.rs
+++ b/src/dispatching/dialogue/get_chat_id.rs
@@ -1,5 +1,4 @@
-use crate::types::CallbackQuery;
-use teloxide_core::types::{ChatId, Message};
+use crate::types::{CallbackQuery, ChatId, Message, Update};
 
 /// Something that may has a chat ID.
 pub trait GetChatId {
@@ -16,5 +15,11 @@ impl GetChatId for Message {
 impl GetChatId for CallbackQuery {
     fn chat_id(&self) -> Option<ChatId> {
         self.message.as_ref().map(|mes| mes.chat.id)
+    }
+}
+
+impl GetChatId for Update {
+    fn chat_id(&self) -> Option<ChatId> {
+        self.chat().map(|chat| chat.id)
     }
 }


### PR DESCRIPTION
This bot demonstrates how to use callback queries and messages within a single dialogue. Also, implement `GetChatId` for `Update` and add the `dialogue::enter` function.

Resolves https://github.com/teloxide/teloxide/issues/300, https://github.com/teloxide/teloxide/issues/295, https://github.com/teloxide/teloxide/issues/333.