### PR TITLE
Remove mentions of the removed "frunk" feature

### DIFF
--- a/src/features.txt
+++ b/src/features.txt
@@ -15,7 +15,6 @@
 | `cache-me` | Enables the [`CacheMe`](adaptors::CacheMe) bot adaptor. |
 | `trace-adaptor` | Enables the [`Trace`](adaptors::Trace) bot adaptor. |
 | `erased` | Enables the [`ErasedRequester`](adaptors::ErasedRequester) bot adaptor. |
-| `frunk` | Enables [`teloxide::utils::UpState`]. |
 | `full` | Enables all the features except `nightly`. |
 | `nightly` | Enables nightly-only features (see the [teloxide-core features]). |
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -6,6 +6,3 @@ pub mod markdown;
 pub(crate) mod shutdown_token;
 
 pub use teloxide_core::net::client_from_env;
-
-#[cfg(feature = "frunk")]
-pub use up_state::UpState;


### PR DESCRIPTION
The "frunk" feature was deleted, but it was left in a couple of places, this PR removes it from them too.