### PR TITLE
Test `#[command(rename = "...")]` custom name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## unreleased
 
+### Fixed
+
+ - Fix `#[command(rename = "...")]` for custom command names ([issue 633](https://github.com/teloxide/teloxide/issues/633)).
+
 ## 0.9.0 - 2022-04-27
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ full = [
 
 [dependencies]
 teloxide-core = { version = "0.6.0", default-features = false }
-teloxide-macros = { version = "0.6.1", optional = true }
+teloxide-macros = { git = "https://github.com/teloxide/teloxide-macros.git", rev = "e344b11dcc0466d1cbbef1139e8cd0646e776188", optional = true }
 
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ full = [
 
 [dependencies]
 teloxide-core = { version = "0.6.0", default-features = false }
-teloxide-macros = { git = "https://github.com/teloxide/teloxide-macros.git", rev = "e344b11dcc0466d1cbbef1139e8cd0646e776188", optional = true }
+teloxide-macros = { version = "0.6.2", optional = true }
 
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/tests/command.rs
+++ b/tests/command.rs
@@ -218,6 +218,8 @@ fn rename_rules() {
         GggGgg,
         #[command(rename = "SCREAMING-KEBAB-CASE")]
         HhhHhh,
+        #[command(rename = "Bar")]
+        Foo,
     }
 
     assert_eq!(DefaultCommands::AaaAaa, DefaultCommands::parse("/aaaaaa", "").unwrap());
@@ -228,9 +230,10 @@ fn rename_rules() {
     assert_eq!(DefaultCommands::FffFff, DefaultCommands::parse("/FFF_FFF", "").unwrap());
     assert_eq!(DefaultCommands::GggGgg, DefaultCommands::parse("/ggg-ggg", "").unwrap());
     assert_eq!(DefaultCommands::HhhHhh, DefaultCommands::parse("/HHH-HHH", "").unwrap());
+    assert_eq!(DefaultCommands::Foo, DefaultCommands::parse("/Bar", "").unwrap());
 
     assert_eq!(
-        "/aaaaaa\n/BBBBBB\n/CccCcc\n/dddDdd\n/eee_eee\n/FFF_FFF\n/ggg-ggg\n/HHH-HHH",
+        "/aaaaaa\n/BBBBBB\n/CccCcc\n/dddDdd\n/eee_eee\n/FFF_FFF\n/ggg-ggg\n/HHH-HHH\n/Bar",
         DefaultCommands::descriptions().to_string()
     );
 }


### PR DESCRIPTION
Don't merge until teloxide-macros v0.6.2. Then we can merge this PR and make a new release teloxide v0.9.1.

Resolves https://github.com/teloxide/teloxide/issues/633.