### PR TITLE
fix: escape user full name for mention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## unreleased
 
+### Fixed
+
+ - Fix Api Unknown error (Can't parse entities) on message created with `utils::markdown::user_mention_or_link` if user full name contaiins some escapable symbols eg '.'
+
 ## 0.9.1 - 2022-05-27
 
 ### Fixed

--- a/src/utils/markdown.rs
+++ b/src/utils/markdown.rs
@@ -124,7 +124,7 @@ pub fn escape_code(s: &str) -> String {
 pub fn user_mention_or_link(user: &User) -> String {
     match user.mention() {
         Some(mention) => mention,
-        None => link(user.url().as_str(), &user.full_name()),
+        None => link(user.url().as_str(), &escape(&user.full_name())),
     }
 }
 


### PR DESCRIPTION
<!--
Before making this PR, please ensure the following:

 - The PR is open to `dev`, NOT `master`.
 - `CHANGELOG.md` is updated (if necessary).
 - Documentation and tests are updated (if necessary).
-->
Fix Api Unknown error (Can't parse entities) on message created with `utils::markdown::user_mention_or_link` if user full name contaiins some escapable symbols eg '.'