### PR TITLE
Don't specify features for `tokio`

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ $ rustup override set nightly
 teloxide = { version = "0.9", features = ["macros", "auto-send"] }
 log = "0.4"
 pretty_env_logger = "0.4"
-tokio = { version =  "1.8", features = ["rt-multi-thread", "macros"] }
+tokio = "1.8"
 ```
 
 ## API overview


### PR DESCRIPTION
I tested compiling an empty bot with the following line in `Cargo.toml`:

```toml
tokio = { version =  "1.8", features = ["rt-multi-thread", "macros"] }
```

It took around 30 seconds. Then I changed it to this:

```toml
tokio = "1.8"
```

And the compilation time remained unchanged.

I suggest to simplify the `tokio` dependency at least in `README.md`. It makes no sense to specify exact features of `tokio`, since compilation time is the same.

