### PR TITLE
use built-in webhook support in heroku example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,6 @@ once_cell = "1.9.0"
 serde = "1"
 serde_json = "1"
 tokio = { version = "1.8", features = ["fs", "rt-multi-thread", "macros"] }
-warp = "0.3.0"
 reqwest = "0.10.4"
 chrono = "0.4"
 tokio-stream = "0.1"
@@ -151,6 +150,10 @@ required-features = ["macros"]
 
 [[example]]
 name = "ngrok_ping_pong"
+required-features = ["webhooks-axum"]
+
+[[example]]
+name = "heroku_ping_pong"
 required-features = ["webhooks-axum"]
 
 [[example]]


### PR DESCRIPTION
Originally I wanted to implement non-axum webhooks and use them in this example. But I still didn't, so it's better to use built-in webhook support instead of this monstrosity.

Additionally this example will now be shown in the documentation of `webhooks::axum`, so it will be more discoverable.