### PR TITLE
Add "GC" for dispatcher workers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `Dispatcher` no longer "leaks" memory for every user
+ - `Dispatcher` no longer "leaks" memory for every inactive user ([PR 657](https://github.com/teloxide/teloxide/pull/657)).
+
+### Changed
+
+ - Add the `Key: Clone` requirement for `impl Dispatcher` [**BC**].
 
 ## 0.9.2 - 2022-06-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## unreleased
 
+### Fixed
+
+- `Dispatcher` no longer "leaks" memory for every user
+
 ## 0.9.2 - 2022-06-07
 
 ### Fixed

--- a/src/dispatching/distribution.rs
+++ b/src/dispatching/distribution.rs
@@ -1,7 +1,7 @@
 use teloxide_core::types::{ChatId, Update};
 
 /// Default distribution key for dispatching.
-#[derive(Debug, Hash, PartialEq, Eq)]
+#[derive(Debug, Hash, PartialEq, Eq, Clone)]
 pub struct DefaultKey(ChatId);
 
 pub(crate) fn default_distribution_function(update: &Update) -> Option<DefaultKey> {


### PR DESCRIPTION
We were leaking workers, this PR tries to fix this.

----

Solution that we ended up using:
- `Dispatcher` tracks the current & maximum number of active workers
- If there are more workers than the maximum number of active workers, `Dispatcher` removes all inactive workers