### PR TITLE
Add `PollingBuilder` & friends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Security checks based on `secret_token` param of `set_webhook` to built-in webhooks
-- `dispatching::update_listeners::{polling_builder, PollingBuilder, Polling, PollingStream}`
+- `dispatching::update_listeners::{PollingBuilder, Polling, PollingStream}`
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Security checks based on `secret_token` param of `set_webhook` to built-in webhooks
+- `dispatching::update_listeners::{polling_builder, PollingBuilder, Polling, PollingStream}`
 
 ### Fixed
 
@@ -17,6 +18,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
  - Add the `Key: Clone` requirement for `impl Dispatcher` [**BC**].
+ - `dispatching::update_listeners::{polling_default, polling}` now return a named, `Polling<_>` type
+
+### Deprecated
+
+- `dispatching::update_listeners::polling`
 
 ## 0.9.2 - 2022-06-07
 

--- a/src/dispatching/update_listeners.rs
+++ b/src/dispatching/update_listeners.rs
@@ -43,7 +43,7 @@ mod polling;
 mod stateful_listener;
 
 pub use self::{
-    polling::{polling, polling_default},
+    polling::{polling, polling_builder, polling_default, PollingBuilder},
     stateful_listener::StatefulListener,
 };
 

--- a/src/dispatching/update_listeners.rs
+++ b/src/dispatching/update_listeners.rs
@@ -44,7 +44,7 @@ mod stateful_listener;
 
 #[allow(deprecated)]
 pub use self::{
-    polling::{polling, polling_builder, polling_default, Polling, PollingBuilder, PollingStream},
+    polling::{polling, polling_default, Polling, PollingBuilder, PollingStream},
     stateful_listener::StatefulListener,
 };
 

--- a/src/dispatching/update_listeners.rs
+++ b/src/dispatching/update_listeners.rs
@@ -42,8 +42,9 @@ use crate::{
 mod polling;
 mod stateful_listener;
 
+#[allow(deprecated)]
 pub use self::{
-    polling::{polling, polling_builder, polling_default, PollingBuilder},
+    polling::{polling, polling_builder, polling_default, Polling, PollingBuilder, PollingStream},
     stateful_listener::StatefulListener,
 };
 

--- a/src/dispatching/update_listeners.rs
+++ b/src/dispatching/update_listeners.rs
@@ -126,3 +126,11 @@ pub trait AsUpdateStream<'a, E> {
     /// [`Stream`]: AsUpdateStream::Stream
     fn as_stream(&'a mut self) -> Self::Stream;
 }
+
+#[inline(always)]
+pub(crate) fn assert_update_listener<L, E>(listener: L) -> L
+where
+    L: UpdateListener<E>,
+{
+    listener
+}

--- a/src/dispatching/update_listeners/polling.rs
+++ b/src/dispatching/update_listeners/polling.rs
@@ -24,13 +24,14 @@ use crate::{
 /// Builder for polling update listener.
 ///
 /// Can be created by [`Polling::builder`].
+#[non_exhaustive]
 #[must_use = "`PollingBuilder` is a builder and does nothing unless used"]
 pub struct PollingBuilder<R> {
-    bot: R,
-    timeout: Option<Duration>,
-    limit: Option<u8>,
-    allowed_updates: Option<Vec<AllowedUpdate>>,
-    drop_pending_updates: bool,
+    pub bot: R,
+    pub timeout: Option<Duration>,
+    pub limit: Option<u8>,
+    pub allowed_updates: Option<Vec<AllowedUpdate>>,
+    pub drop_pending_updates: bool,
 }
 
 impl<R> PollingBuilder<R>

--- a/src/dispatching/update_listeners/polling.rs
+++ b/src/dispatching/update_listeners/polling.rs
@@ -130,7 +130,7 @@ where
 }
 
 /// Returns a long polling update listener with some additional options.
-#[deprecated(since = "0.7.0", note = "use `polling_builder` instead")]
+#[deprecated(since = "0.10.0", note = "use `polling_builder` instead")]
 pub fn polling<R>(
     bot: R,
     timeout: Option<Duration>,

--- a/src/dispatching/update_listeners/polling.rs
+++ b/src/dispatching/update_listeners/polling.rs
@@ -71,7 +71,7 @@ where
     }
 
     /// Creates a polling update listener.
-    pub fn build(self) -> impl UpdateListener<R::Err> {
+    pub fn build(self) -> Polling<R> {
         let Self { bot, timeout, limit, allowed_updates } = self;
         polling(bot, timeout, limit, allowed_updates)
     }
@@ -93,7 +93,7 @@ where
 /// ## Notes
 ///
 /// This function will automatically delete a webhook if it was set up.
-pub async fn polling_default<R>(bot: R) -> impl UpdateListener<R::Err>
+pub async fn polling_default<R>(bot: R) -> Polling<R>
 where
     R: Requester + Send + 'static,
     <R as Requester>::GetUpdates: Send,
@@ -198,7 +198,7 @@ pub fn polling<R>(
     timeout: Option<Duration>,
     limit: Option<u8>,
     allowed_updates: Option<Vec<AllowedUpdate>>,
-) -> impl UpdateListener<R::Err>
+) -> Polling<R>
 where
     R: Requester + Send + 'static,
     <R as Requester>::GetUpdates: Send,
@@ -228,7 +228,7 @@ where
     }
 }
 
-struct Polling<B: Requester> {
+pub struct Polling<B: Requester> {
     bot: B,
     timeout: Option<Duration>,
     limit: Option<u8>,
@@ -238,7 +238,7 @@ struct Polling<B: Requester> {
 }
 
 #[pin_project::pin_project]
-struct PollingStream<'a, B: Requester> {
+pub struct PollingStream<'a, B: Requester> {
     /// Parent structure
     polling: &'a mut Polling<B>,
 

--- a/src/dispatching/update_listeners/polling.rs
+++ b/src/dispatching/update_listeners/polling.rs
@@ -22,6 +22,8 @@ use crate::{
 };
 
 /// Builder for polling update listener.
+///
+/// Can be created by [`Polling::builder`].
 pub struct PollingBuilder<R> {
     bot: R,
     timeout: Option<Duration>,
@@ -101,7 +103,7 @@ where
 
 /// Returns a long polling update listener with `timeout` of 10 seconds.
 ///
-/// See also: [`polling_builder`].
+/// See also: [`Polling::builder`].
 ///
 /// ## Notes
 ///

--- a/src/dispatching/update_listeners/polling.rs
+++ b/src/dispatching/update_listeners/polling.rs
@@ -366,8 +366,6 @@ impl<B: Requester> Stream for PollingStream<'_, B> {
 
 #[test]
 fn polling_is_send() {
-    use crate::dispatching::update_listeners::AsUpdateStream;
-
     let bot = crate::Bot::new("TOKEN");
     #[allow(deprecated)]
     let mut polling = polling(bot, None, None, None);

--- a/src/dispatching/update_listeners/polling.rs
+++ b/src/dispatching/update_listeners/polling.rs
@@ -24,6 +24,7 @@ use crate::{
 /// Builder for polling update listener.
 ///
 /// Can be created by [`Polling::builder`].
+#[must_use = "`PollingBuilder` is a builder and does nothing unless used"]
 pub struct PollingBuilder<R> {
     bot: R,
     timeout: Option<Duration>,
@@ -233,6 +234,7 @@ where
 ///
 /// [get_updates]: crate::requests::Requester::get_updates
 /// [`Dispatcher`]: crate::dispatching::Dispatcher
+#[must_use = "`Polling` is an update listener and does nothing unless used"]
 pub struct Polling<B: Requester> {
     bot: B,
     timeout: Option<Duration>,

--- a/src/dispatching/update_listeners/polling.rs
+++ b/src/dispatching/update_listeners/polling.rs
@@ -99,21 +99,6 @@ where
     }
 }
 
-/// Returns a builder for polling update listener.
-pub fn polling_builder<R>(bot: R) -> PollingBuilder<R>
-where
-    R: Requester + Send + 'static,
-    <R as Requester>::GetUpdates: Send,
-{
-    PollingBuilder {
-        bot,
-        timeout: None,
-        limit: None,
-        allowed_updates: None,
-        drop_pending_updates: false,
-    }
-}
-
 /// Returns a long polling update listener with `timeout` of 10 seconds.
 ///
 /// See also: [`polling_builder`].
@@ -126,11 +111,11 @@ where
     R: Requester + Send + 'static,
     <R as Requester>::GetUpdates: Send,
 {
-    polling_builder(bot).timeout(Duration::from_secs(10)).delete_webhook().await.build()
+    Polling::builder(bot).timeout(Duration::from_secs(10)).delete_webhook().await.build()
 }
 
 /// Returns a long polling update listener with some additional options.
-#[deprecated(since = "0.10.0", note = "use `polling_builder` instead")]
+#[deprecated(since = "0.10.0", note = "use `Polling::builder()` instead")]
 pub fn polling<R>(
     bot: R,
     timeout: Option<Duration>,
@@ -141,7 +126,7 @@ where
     R: Requester + Send + 'static,
     <R as Requester>::GetUpdates: Send,
 {
-    let mut builder = polling_builder(bot);
+    let mut builder = Polling::builder(bot);
     builder.timeout = timeout;
     builder.limit = limit;
     builder.allowed_updates = allowed_updates;
@@ -248,6 +233,23 @@ pub struct Polling<B: Requester> {
     drop_pending_updates: bool,
     flag: AsyncStopFlag,
     token: AsyncStopToken,
+}
+
+impl<R> Polling<R>
+where
+    R: Requester + Send + 'static,
+    <R as Requester>::GetUpdates: Send,
+{
+    /// Returns a builder for polling update listener.
+    pub fn builder(bot: R) -> PollingBuilder<R> {
+        PollingBuilder {
+            bot,
+            timeout: None,
+            limit: None,
+            allowed_updates: None,
+            drop_pending_updates: false,
+        }
+    }
 }
 
 #[pin_project::pin_project]

--- a/src/dispatching/update_listeners/polling.rs
+++ b/src/dispatching/update_listeners/polling.rs
@@ -52,10 +52,11 @@ where
     ///
     /// ## Panics
     ///
-    /// If `limit` is greater than 100.
+    /// If `limit` is 0 or greater than 100.
     #[track_caller]
     pub fn limit(self, limit: u8) -> Self {
-        assert!(limit <= 100, "Maximum limit is 100");
+        assert_ne!(limit, 0, "limit can't be 0");
+        assert!(limit <= 100, "maximum limit is 100, can't set limit to `{limit}`");
 
         Self { limit: Some(limit), ..self }
     }


### PR DESCRIPTION
This PR refactors polling update listener & related functions.

Main changes:
- Added `PollingBuilder` that allows to tweak settings more conveniently
- Added support for dropping updates
- Polling stream is now implemented by hand 
- `Polling` is now a named type (instead of `impl UpdateListener`)

These changes make polling more convenient to use and also make it easier for us to add new features to polling (for example we may want to set lower polling timeouts bot during development).