### PR TITLE
Simplify the implementation of REPLs

### DIFF
--- a/src/dispatching/repls/commands_repl.rs
+++ b/src/dispatching/repls/commands_repl.rs
@@ -91,16 +91,13 @@ pub async fn commands_repl_with_listener<'a, R, Cmd, H, L, ListenerE, E, Args>(
     // commands. See <https://github.com/teloxide/teloxide/issues/557>.
     let ignore_update = |_upd| Box::pin(async {});
 
-    Dispatcher::builder(
-        bot,
-        Update::filter_message().filter_command::<Cmd>().chain(dptree::endpoint(handler)),
-    )
-    .default_handler(ignore_update)
-    .enable_ctrlc_handler()
-    .build()
-    .dispatch_with_listener(
-        listener,
-        LoggingErrorHandler::with_custom_text("An error from the update listener"),
-    )
-    .await;
+    Dispatcher::builder(bot, Update::filter_message().filter_command::<Cmd>().endpoint(handler))
+        .default_handler(ignore_update)
+        .enable_ctrlc_handler()
+        .build()
+        .dispatch_with_listener(
+            listener,
+            LoggingErrorHandler::with_custom_text("An error from the update listener"),
+        )
+        .await;
 }

--- a/src/dispatching/repls/repl.rs
+++ b/src/dispatching/repls/repl.rs
@@ -69,7 +69,7 @@ where
     // messages. See <https://github.com/teloxide/teloxide/issues/557>.
     let ignore_update = |_upd| Box::pin(async {});
 
-    Dispatcher::builder(bot, Update::filter_message().chain(dptree::endpoint(handler)))
+    Dispatcher::builder(bot, Update::filter_message().endpoint(handler))
         .default_handler(ignore_update)
         .enable_ctrlc_handler()
         .build()


### PR DESCRIPTION
People [sometimes](https://t.me/teloxide_ru/1057) just copy-paste the implementation of REPLs in their code when they need a full-blown dispatcher (e.g., to pass dependencies).

This PR eliminates the use of `.chain` by taking advantage of the newly upgraded `dptree`.
