### PR TITLE
Hide the definitions of endpoints in the doc

### DIFF
--- a/src/dispatching.rs
+++ b/src/dispatching.rs
@@ -104,6 +104,9 @@
 //!
 //! Finally, we define our endpoints like this:
 //!
+//! <details>
+//! <summary>Show the endpoints</summary>
+//!
 //! ```no_run
 //! # use teloxide::{Bot, adaptors::AutoSend};
 //! # use teloxide::types::{Message, CallbackQuery};
@@ -146,6 +149,8 @@
 //!     todo!()
 //! }
 //! ```
+//!
+//! </details>
 //!
 //! Each parameter is supplied as a dependency by teloxide. In particular:
 //!  - `bot: AutoSend<Bot>` comes from the dispatcher (see below);

--- a/src/dispatching.rs
+++ b/src/dispatching.rs
@@ -102,7 +102,7 @@
 //! -- no problem, reuse [`dptree::Handler::filter`], [`dptree::case!`], and
 //! other combinators in the same way!
 //!
-//! Finally, we define our endpoints like this:
+//! Finally, we define our endpoints via simple `async` functions like this:
 //!
 //! <details>
 //! <summary>Show the endpoints</summary>


### PR DESCRIPTION
Makes scrolling a bit easier.
