### PR TITLE
Avoid ending punctuation in short list items

### DIFF
--- a/CODE_STYLE.md
+++ b/CODE_STYLE.md
@@ -42,7 +42,31 @@ Good:
 pub fn make_request(url: &str) -> String { ... }
 ```
 
- 2. Also, link resources in your comments when possible:
+ 2. Do not use ending punctuation in short list items (usually containing just one phrase or sentence). Bad:
+
+```md
+ - Handle different kinds of Update.
+ - Pass dependencies to handlers.
+ - Disable a default Ctrl-C handling.
+```
+
+Bad:
+
+```md
+ - Handle different kinds of Update;
+ - Pass dependencies to handlers;
+ - Disable a default Ctrl-C handling.
+```
+
+Good:
+
+```md
+ - Handle different kinds of Update
+ - Pass dependencies to handlers
+ - Disable a default Ctrl-C handling
+```
+
+ 3. Link resources in your comments when possible:
 
 ```rust
 /// Download a file from Telegram.

--- a/src/dispatching.rs
+++ b/src/dispatching.rs
@@ -153,12 +153,12 @@
 //! </details>
 //!
 //! Each parameter is supplied as a dependency by teloxide. In particular:
-//!  - `bot: AutoSend<Bot>` comes from the dispatcher (see below);
-//!  - `msg: Message` comes from [`Update::filter_message`];
-//!  - `q: CallbackQuery` comes from [`Update::filter_callback_query`];
-//!  - `dialogue: MyDialogue` comes from [`dialogue::enter`];
+//!  - `bot: AutoSend<Bot>` comes from the dispatcher (see below)
+//!  - `msg: Message` comes from [`Update::filter_message`]
+//!  - `q: CallbackQuery` comes from [`Update::filter_callback_query`]
+//!  - `dialogue: MyDialogue` comes from [`dialogue::enter`]
 //!  - `full_name: String` comes from `dptree::case![State::ReceiveProductChoice
-//!    { full_name }]`.
+//!    { full_name }]`
 //!
 //! Inside `main`, we plug the schema into [`Dispatcher`] like this:
 //!
@@ -199,13 +199,13 @@
 //! bit more complicated setup.
 //!
 //! Here are things that dispatching can do, but REPLs can't:
-//!  - Handle different kinds of [`Update`];
-//!  - [Pass dependencies] to handlers;
-//!  - Disable a [default Ctrl-C handling];
-//!  - Control your [default] and [error] handlers;
-//!  - Use [dialogues].
-//!  - Use [`dptree`]-related functionality.
-//!  - Probably more.
+//!  - Handle different kinds of [`Update`]
+//!  - [Pass dependencies] to handlers
+//!  - Disable a [default Ctrl-C handling]
+//!  - Control your [default] and [error] handlers
+//!  - Use [dialogues]
+//!  - Use [`dptree`]-related functionality
+//!  - Probably more
 //!
 //! Thus, REPLs are good for simple bots and rapid prototyping, but for more
 //! involved scenarios, we recommend using dispatching over REPLs.

--- a/src/dispatching/repls/commands_repl.rs
+++ b/src/dispatching/repls/commands_repl.rs
@@ -29,7 +29,7 @@ use teloxide_core::requests::Requester;
 ///
 /// ## Dependency requirements
 ///
-///  - Those of [`HandlerExt::filter_command`].
+///  - Those of [`HandlerExt::filter_command`]
 ///
 /// [REPL]: https://en.wikipedia.org/wiki/Read-eval-print_loop
 /// [`Dispatcher`]: crate::dispatching::Dispatcher
@@ -72,7 +72,7 @@ where
 ///
 /// ## Dependency requirements
 ///
-///  - Those of [`HandlerExt::filter_command`].
+///  - Those of [`HandlerExt::filter_command`]
 ///
 /// [`Dispatcher`]: crate::dispatching::Dispatcher
 /// [`commands_repl`]: crate::dispatching::repls::commands_repl()


### PR DESCRIPTION
We discussed this issue previously and came to the conclusion that using punctuation in short list items is erroneous and disturbing. Therefore, I changed our `CODING_STYLE.md` and the documentation accordingly.
