### PR TITLE
Make `StopToken` object safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## unreleased
 
+### Changed
+
+- `StopToken` now accepts self by unique reference, making it object safe (you can now use `dyn StopToken`)
+
 ## 0.10.1 - 2022-07-22
 
 ### Fixed

--- a/src/dispatching/dispatcher.rs
+++ b/src/dispatching/dispatcher.rs
@@ -328,7 +328,7 @@ where
                 }
 
                 if self.state.is_shutting_down() {
-                    if let Some(token) = stop_token.take() {
+                    if let Some(mut token) = stop_token.take() {
                         log::debug!("Start shutting down dispatching...");
                         token.stop();
                     }

--- a/src/dispatching/stop_token.rs
+++ b/src/dispatching/stop_token.rs
@@ -12,7 +12,7 @@ use futures::future::{pending, AbortHandle, Abortable, Pending};
 /// crate::dispatching::update_listeners::UpdateListener::stop_token
 pub trait StopToken {
     /// Stop the listener linked to this token.
-    fn stop(self);
+    fn stop(&mut self);
 }
 
 /// A stop token which does nothing. May be used in prototyping or in cases
@@ -20,7 +20,7 @@ pub trait StopToken {
 pub struct Noop;
 
 impl StopToken for Noop {
-    fn stop(self) {}
+    fn stop(&mut self) {}
 }
 
 /// A stop token which corresponds to [`AsyncStopFlag`].
@@ -50,7 +50,7 @@ impl AsyncStopToken {
 }
 
 impl StopToken for AsyncStopToken {
-    fn stop(self) {
+    fn stop(&mut self) {
         self.0.abort()
     }
 }
@@ -77,3 +77,5 @@ impl Future for AsyncStopFlag {
         })
     }
 }
+
+fn _assert_object_safe(_: &mut dyn StopToken) {}

--- a/src/dispatching/update_listeners/webhooks/axum.rs
+++ b/src/dispatching/update_listeners/webhooks/axum.rs
@@ -46,7 +46,7 @@ where
     let Options { address, .. } = options;
 
     let (mut update_listener, stop_flag, app) = axum_to_router(bot, options).await?;
-    let stop_token = update_listener.stop_token();
+    let mut stop_token = update_listener.stop_token();
 
     tokio::spawn(async move {
         axum::Server::bind(&address)


### PR DESCRIPTION
Originally the idea behind taking `self` by value was that after you call `stop`, there is nothing more to do, calling `stop` again does nothing. So, it made sense to not allow calling `stop` more than once.

However, out API force you to be able to produce arbitrary number of stop tokens (see [`UpdateListener::stop_token`](https://docs.rs/teloxide/0.10.1/teloxide/dispatching/update_listeners/trait.UpdateListener.html#tymethod.stop_token)), so there isn't much gained from taking `self` by value.

Making `StopToken` object safe on the other hand has its merits, see for example https://github.com/PhotonQuantum/teloxide-listener/issues/17.