### PR TITLE
Remove `{token}` from webhook url in heroku example

### DIFF
--- a/examples/heroku_ping_pong.rs
+++ b/examples/heroku_ping_pong.rs
@@ -21,7 +21,6 @@
 use std::env;
 
 use teloxide::{dispatching::update_listeners::webhooks, prelude::*};
-use url::Url;
 
 #[tokio::main]
 async fn main() {
@@ -29,7 +28,6 @@ async fn main() {
     log::info!("Starting Heroku ping-pong bot...");
 
     let bot = Bot::from_env().auto_send();
-    let token = bot.inner().token();
 
     // Heroku auto defines a port value
     let port: u16 = env::var("PORT")
@@ -41,7 +39,7 @@ async fn main() {
 
     // Heroku host example: "heroku-ping-pong-bot.herokuapp.com"
     let host = env::var("HOST").expect("HOST env variable is not set");
-    let url = Url::parse(&format!("https://{host}/webhooks/{token}")).unwrap();
+    let url = format!("https://{host}/webhook").parse().unwrap();
 
     let listener = webhooks::axum(bot.clone(), webhooks::Options::new(addr, url))
         .await


### PR DESCRIPTION
We don't need to include bot token in the url for security, since we use `secret_token` parameter/`X-Telegram-Bot-Api-Secret-Token` header to check if the update was sent by telegram.