### PR TITLE
More `#[must_use]` functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,52 +9,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 <!-- TODO: use a version once teloxide-macros is released -->
- - Updated `teloxide-macros` see its [changelog](https://github.com/teloxide/teloxide-macros/blob/master/CHANGELOG.md#unreleased) for more
- - `UpdateListener` now has an associated type `Err` instead of a generic
- - `AsUpdateStream` now has an associated type `StreamErr` instead of a generic
- - Rename `dispatching::stop_token::{AsyncStopToken, AsyncStopFlag}` => `stop::{StopToken, StopFlag}`
- - The following functions are now `#[must_use]`:
-   - `BotCommands::ty`.
-   - `CommandDescriptions::{new, global_description, username, username_from_me}`.
-   - `teloxide::filter_command`.
-   - `teloxide::dispatching::dialogue::enter`.
+- Updated `teloxide-macros` see its [changelog](https://github.com/teloxide/teloxide-macros/blob/master/CHANGELOG.md#unreleased) for more
+- `UpdateListener` now has an associated type `Err` instead of a generic
+- `AsUpdateStream` now has an associated type `StreamErr` instead of a generic
+- Rename `dispatching::stop_token::{AsyncStopToken, AsyncStopFlag}` => `stop::{StopToken, StopFlag}`
+- The following functions are now `#[must_use]`:
+  - `BotCommands::ty`.
+  - `CommandDescriptions::{new, global_description, username, username_from_me}`.
+  - `teloxide::filter_command`.
+  - `teloxide::dispatching::dialogue::enter`.
 
 ### Removed
 
- - `dispatching::stop_token::StopToken` trait (all uses are replaced with `stop::StopToken` structure)
- - Some previously deprecated items
-   - `enable_logging!`, `enable_logging_with_filter!`
-   - `HandlerFactory`, `HandlerExt::dispatch_by`
+- `dispatching::stop_token::StopToken` trait (all uses are replaced with `stop::StopToken` structure)
+- Some previously deprecated items
+  - `enable_logging!`, `enable_logging_with_filter!`
+  - `HandlerFactory`, `HandlerExt::dispatch_by`
 
 ## 0.10.1 - 2022-07-22
 
 ### Fixed
 
- - Mark the following functions with `#[must_use]` ([PR 457](https://github.com/teloxide/teloxide/pull/457)):
-   - `TraceStorage::into_inner`.
-   - `AsyncStopToken::new_pair`.
-   - `AsyncStopFlag::is_stopped`.
-   - All from `crate::utils::{html, markdown}`.
- - Rendering of GIFs in lib.rs and crates.io ([PR 681](https://github.com/teloxide/teloxide/pull/681)).
+- Mark the following functions with `#[must_use]` ([PR 457](https://github.com/teloxide/teloxide/pull/457)):
+  - `TraceStorage::into_inner`.
+  - `AsyncStopToken::new_pair`.
+  - `AsyncStopFlag::is_stopped`.
+  - All from `crate::utils::{html, markdown}`.
+- Rendering of GIFs in lib.rs and crates.io ([PR 681](https://github.com/teloxide/teloxide/pull/681)).
 
 ## 0.10.0 - 2022-07-21
 
 ### Added
 
- - Security checks based on `secret_token` param of `set_webhook` to built-in webhooks.
- - `dispatching::update_listeners::{PollingBuilder, Polling, PollingStream}`.
- - `DispatcherBuilder::enable_ctrlc_handler` method.
+- Security checks based on `secret_token` param of `set_webhook` to built-in webhooks.
+- `dispatching::update_listeners::{PollingBuilder, Polling, PollingStream}`.
+- `DispatcherBuilder::enable_ctrlc_handler` method.
 
 ### Fixed
 
- - `Dispatcher` no longer "leaks" memory for every inactive user ([PR 657](https://github.com/teloxide/teloxide/pull/657)).
- - Allow specifying a path to a custom command parser in `parse_with` ([issue 668](https://github.com/teloxide/teloxide/issues/668)).
+- `Dispatcher` no longer "leaks" memory for every inactive user ([PR 657](https://github.com/teloxide/teloxide/pull/657)).
+- Allow specifying a path to a custom command parser in `parse_with` ([issue 668](https://github.com/teloxide/teloxide/issues/668)).
 
 ### Changed
 
- - Add the `Key: Clone` requirement for `impl Dispatcher` [**BC**].
- - `dispatching::update_listeners::{polling_default, polling}` now return a named, `Polling<_>` type.
- - Update teloxide-core to v0.7.0 with Bot API 6.1 support, see [its changelog][core07c] for more information [**BC**].
+- Add the `Key: Clone` requirement for `impl Dispatcher` [**BC**].
+- `dispatching::update_listeners::{polling_default, polling}` now return a named, `Polling<_>` type.
+- Update teloxide-core to v0.7.0 with Bot API 6.1 support, see [its changelog][core07c] for more information [**BC**].
 
 [core07c]: https://github.com/teloxide/teloxide-core/blob/master/CHANGELOG.md#070---2022-07-19
 
@@ -67,24 +67,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
- - Fix Api Unknown error (Can't parse entities) on message created with `utils::markdown::user_mention_or_link` if user full name contaiins some escapable symbols eg '.'
+- Fix Api Unknown error (Can't parse entities) on message created with `utils::markdown::user_mention_or_link` if user full name contaiins some escapable symbols eg '.'
 
 ## 0.9.1 - 2022-05-27
 
 ### Fixed
 
- - Fix `#[command(rename = "...")]` for custom command names ([issue 633](https://github.com/teloxide/teloxide/issues/633)).
+- Fix `#[command(rename = "...")]` for custom command names ([issue 633](https://github.com/teloxide/teloxide/issues/633)).
 
 ## 0.9.0 - 2022-04-27
 
 ### Added
 
- - The `dispatching::filter_command` function (also accessible as `teloxide::filter_command`) as a shortcut for `dptree::entry().filter_command()`.
- - Re-export `dptree::case!` as `teloxide::handler!` (the former is preferred for new code).
+- The `dispatching::filter_command` function (also accessible as `teloxide::filter_command`) as a shortcut for `dptree::entry().filter_command()`.
+- Re-export `dptree::case!` as `teloxide::handler!` (the former is preferred for new code).
 
 ### Changed
 
- - Update teloxide-core to v0.6.0 with [Bot API 6.0] support [**BC**].
+- Update teloxide-core to v0.6.0 with [Bot API 6.0] support [**BC**].
 
 [Bot API 6.0]: https://core.telegram.org/bots/api#april-16-2022
 
@@ -92,46 +92,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
- - Fix the broken `#[derive(DialogueState)]` (function return type `dptree::Handler`).
+- Fix the broken `#[derive(DialogueState)]` (function return type `dptree::Handler`).
 
 ## 0.8.1 - 2022-04-24
 
 ### Added
 
- - Implement `GetChatId` for `Update`.
- - The `dialogue::enter()` function as a shortcut for `dptree::entry().enter_dialogue()`.
+- Implement `GetChatId` for `Update`.
+- The `dialogue::enter()` function as a shortcut for `dptree::entry().enter_dialogue()`.
 
 ## 0.8.0 - 2022-04-18
 
 ### Removed
 
- - The old dispatching system and related stuff: `dispatching`, `utils::UpState`, `prelude`, `repls2`, `crate::{dialogues_repl, dialogues_repl_with_listener}`, and `#[teloxide(subtransition)]` [**BC**].
+- The old dispatching system and related stuff: `dispatching`, `utils::UpState`, `prelude`, `repls2`, `crate::{dialogues_repl, dialogues_repl_with_listener}`, and `#[teloxide(subtransition)]` [**BC**].
 
 ### Added
 
- - The new API for dialogue handlers: `teloxide::handler!` ([issue 567](https://github.com/teloxide/teloxide/issues/567)).
- - Built-in webhooks support via `teloxide::dispatching::update_listeners::webhooks` module.
- - `Dialogue::chat_id` for retrieving a chat ID from a dialogue.
+- The new API for dialogue handlers: `teloxide::handler!` ([issue 567](https://github.com/teloxide/teloxide/issues/567)).
+- Built-in webhooks support via `teloxide::dispatching::update_listeners::webhooks` module.
+- `Dialogue::chat_id` for retrieving a chat ID from a dialogue.
 
 ### Changed
 
- - Updated `teloxide-core` from version `0.4.5` to version [`0.5.0`](https://github.com/teloxide/teloxide-core/releases/tag/v0.5.0) [**BC**]
- - Rename `dispatching2` => `dispatching` [**BC**].
- - Rename `prelude2` => `prelude` [**BC**].
- - Move `update_listeners`, `stop_token`, `IdleShutdownError`, and `ShutdownToken` from the old `dispatching` to the new `dispatching` (previously `dispatching2`).
- - Replace `crate::{commands_repl, commands_repl_with_listener, repl, repl_with_listener}` with those of the new `dispatching` [**BC**].
- - `UpdateListener::StopToken` is now always `Send` [**BC**].
- - Rename `BotCommand` trait to `BotCommands` [**BC**].
- - `BotCommands::descriptions` now returns `CommandDescriptions` instead of `String` [**BC**].
- - Mark `Dialogue::new` as `#[must_use]`.
+- Updated `teloxide-core` from version `0.4.5` to version [`0.5.0`](https://github.com/teloxide/teloxide-core/releases/tag/v0.5.0) [**BC**]
+- Rename `dispatching2` => `dispatching` [**BC**].
+- Rename `prelude2` => `prelude` [**BC**].
+- Move `update_listeners`, `stop_token`, `IdleShutdownError`, and `ShutdownToken` from the old `dispatching` to the new `dispatching` (previously `dispatching2`).
+- Replace `crate::{commands_repl, commands_repl_with_listener, repl, repl_with_listener}` with those of the new `dispatching` [**BC**].
+- `UpdateListener::StopToken` is now always `Send` [**BC**].
+- Rename `BotCommand` trait to `BotCommands` [**BC**].
+- `BotCommands::descriptions` now returns `CommandDescriptions` instead of `String` [**BC**].
+- Mark `Dialogue::new` as `#[must_use]`.
 
 ### Fixed
 
- - Concurrent update handling in the new dispatcher ([issue 536](https://github.com/teloxide/teloxide/issues/536)).
+- Concurrent update handling in the new dispatcher ([issue 536](https://github.com/teloxide/teloxide/issues/536)).
 
 ### Deprecated
 
- - `HandlerFactory` and `HandlerExt::dispatch_by` in favour of `teloxide::handler!`.
+- `HandlerFactory` and `HandlerExt::dispatch_by` in favour of `teloxide::handler!`.
 
 ## 0.7.3 - 2022-04-03
 
@@ -179,8 +179,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
- - `BotCommand::bot_commands` to obtain Telegram API commands ([issue 262](https://github.com/teloxide/teloxide/issues/262)).
- - The `dispatching2` and `prelude2` modules. They presents a new dispatching model based on `dptree`.
+- `BotCommand::bot_commands` to obtain Telegram API commands ([issue 262](https://github.com/teloxide/teloxide/issues/262)).
+- The `dispatching2` and `prelude2` modules. They presents a new dispatching model based on `dptree`.
 
 ### Changed
 
@@ -219,81 +219,83 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
- - `Storage::get_dialogue` to obtain a dialogue indexed by a chat ID.
- - `InMemStorageError` with a single variant `DialogueNotFound` to be returned from `InMemStorage::remove_dialogue`.
- - `RedisStorageError::DialogueNotFound` and `SqliteStorageError::DialogueNotFound` to be returned from `Storage::remove_dialogue`.
- - A way to `shutdown` dispatcher
-   - `Dispatcher::shutdown_token` function.
-   - `ShutdownToken` with a `shutdown` function.
- - `Dispatcher::setup_ctrlc_handler` function ([issue 153](https://github.com/teloxide/teloxide/issues/153)).
- - `IdleShutdownError`
- - Automatic update filtering ([issue 389](https://github.com/teloxide/teloxide/issues/389)).
- - Added reply shortcut to every kind of messages ([PR 404](https://github.com/teloxide/teloxide/pull/404)).
+- `Storage::get_dialogue` to obtain a dialogue indexed by a chat ID.
+- `InMemStorageError` with a single variant `DialogueNotFound` to be returned from `InMemStorage::remove_dialogue`.
+- `RedisStorageError::DialogueNotFound` and `SqliteStorageError::DialogueNotFound` to be returned from `Storage::remove_dialogue`.
+- A way to `shutdown` dispatcher
+  - `Dispatcher::shutdown_token` function.
+  - `ShutdownToken` with a `shutdown` function.
+- `Dispatcher::setup_ctrlc_handler` function ([issue 153](https://github.com/teloxide/teloxide/issues/153)).
+- `IdleShutdownError`
+- Automatic update filtering ([issue 389](https://github.com/teloxide/teloxide/issues/389)).
+- Added reply shortcut to every kind of messages ([PR 404](https://github.com/teloxide/teloxide/pull/404)).
 
 ### Changed
 
- - Do not return a dialogue from `Storage::{remove_dialogue, update_dialogue}`.
- - Return an error from `Storage::remove_dialogue` if a dialogue does not exist.
- - Require `D: Clone` in `dialogues_repl(_with_listener)` and `InMemStorage`.
- - Automatically delete a webhook if it was set up in `update_listeners::polling_default` (thereby making it `async`, [issue 319](https://github.com/teloxide/teloxide/issues/319)).
- - `polling` and `polling_default` now require `R: 'static`
- - Refactor `UpdateListener` trait:
-   - Add a `StopToken` associated type.
-     - It must implement a new `StopToken` trait which has the only function `fn stop(self);`
-   - Add a `stop_token` function that returns `Self::StopToken` and allows stopping the listener later ([issue 166](https://github.com/teloxide/teloxide/issues/166)).
-   - Remove blanked implementation.
-   - Remove `Stream` from super traits.
-   - Add `AsUpdateStream` to super traits.
-     - Add an `AsUpdateStream` trait that allows turning implementors into streams of updates (GAT workaround).
-   - Add a `timeout_hint` function (with a default implementation).
- - `Dispatcher::dispatch` and `Dispatcher::dispatch_with_listener` now require mutable reference to self.
- - Repls can now be stopped by `^C` signal.
- - `Noop` and `AsyncStopToken`stop tokens.
- - `StatefulListener`.
- - Emit not only errors but also warnings and general information from teloxide, when set up by `enable_logging!`.
- - Use `i64` instead of `i32` for `user_id` in `html::user_mention` and `markdown::user_mention`.
- - Updated to `teloxide-core` `v0.3.0` (see it's [changelog](https://github.com/teloxide/teloxide-core/blob/master/CHANGELOG.md#030---2021-07-05) for more)
+- Do not return a dialogue from `Storage::{remove_dialogue, update_dialogue}`.
+- Return an error from `Storage::remove_dialogue` if a dialogue does not exist.
+- Require `D: Clone` in `dialogues_repl(_with_listener)` and `InMemStorage`.
+- Automatically delete a webhook if it was set up in `update_listeners::polling_default` (thereby making it `async`, [issue 319](https://github.com/teloxide/teloxide/issues/319)).
+- `polling` and `polling_default` now require `R: 'static`
+- Refactor `UpdateListener` trait:
+  - Add a `StopToken` associated type.
+    - It must implement a new `StopToken` trait which has the only function `fn stop(self);`
+  - Add a `stop_token` function that returns `Self::StopToken` and allows stopping the listener later ([issue 166](https://github.com/teloxide/teloxide/issues/166)).
+  - Remove blanked implementation.
+  - Remove `Stream` from super traits.
+  - Add `AsUpdateStream` to super traits.
+    - Add an `AsUpdateStream` trait that allows turning implementors into streams of updates (GAT workaround).
+  - Add a `timeout_hint` function (with a default implementation).
+- `Dispatcher::dispatch` and `Dispatcher::dispatch_with_listener` now require mutable reference to self.
+- Repls can now be stopped by `^C` signal.
+- `Noop` and `AsyncStopToken`stop tokens.
+- `StatefulListener`.
+- Emit not only errors but also warnings and general information from teloxide, when set up by `enable_logging!`.
+- Use `i64` instead of `i32` for `user_id` in `html::user_mention` and `markdown::user_mention`.
+- Updated to `teloxide-core` `v0.3.0` (see it's [changelog](https://github.com/teloxide/teloxide-core/blob/master/CHANGELOG.md#030---2021-07-05) for more)
 
 ### Fixed
 
- - Remove the `reqwest` dependency. It's not needed after the [teloxide-core] integration.
- - A storage persistency bug ([issue 304](https://github.com/teloxide/teloxide/issues/304)).
- - Log errors from `Storage::{remove_dialogue, update_dialogue}` in `DialogueDispatcher` ([issue 302](https://github.com/teloxide/teloxide/issues/302)).
- - Mark all the functions of `Storage` as `#[must_use]`.
+- Remove the `reqwest` dependency. It's not needed after the [teloxide-core] integration.
+- A storage persistency bug ([issue 304](https://github.com/teloxide/teloxide/issues/304)).
+- Log errors from `Storage::{remove_dialogue, update_dialogue}` in `DialogueDispatcher` ([issue 302](https://github.com/teloxide/teloxide/issues/302)).
+- Mark all the functions of `Storage` as `#[must_use]`.
 
 ## 0.4.0 - 2021-03-22
 
 ### Added
- - Integrate [teloxide-core].
- - Allow arbitrary error types to be returned from (sub)transitions ([issue 242](https://github.com/teloxide/teloxide/issues/242)).
- - The `respond` function, a shortcut for `ResponseResult::Ok(())`.
- - The `sqlite-storage` feature -- enables SQLite support.
- - `Dispatcher::{my_chat_members_handler, chat_members_handler}`
+
+- Integrate [teloxide-core].
+- Allow arbitrary error types to be returned from (sub)transitions ([issue 242](https://github.com/teloxide/teloxide/issues/242)).
+- The `respond` function, a shortcut for `ResponseResult::Ok(())`.
+- The `sqlite-storage` feature -- enables SQLite support.
+- `Dispatcher::{my_chat_members_handler, chat_members_handler}`
 
 [teloxide-core]: https://github.com/teloxide/teloxide-core
 
 ### Deprecated
 
- - `UpdateWithCx::answer_str`
+- `UpdateWithCx::answer_str`
 
 ### Fixed
 
- - Hide `SubtransitionOutputType` from the docs.
+- Hide `SubtransitionOutputType` from the docs.
 
 ### Changed
- - Export `teloxide_macros::teloxide` in `prelude`.
- - `dispatching::dialogue::serializer::{JSON -> Json, CBOR -> Cbor}`
- - Allow `bot_name` be `N`, where `N: Into<String> + ...` in `commands_repl` & `commands_repl_with_listener`.
- - 'Edit methods' (namely `edit_message_live_location`, `stop_message_live_location`, `edit_message_text`, 
+
+- Export `teloxide_macros::teloxide` in `prelude`.
+- `dispatching::dialogue::serializer::{JSON -> Json, CBOR -> Cbor}`
+- Allow `bot_name` be `N`, where `N: Into<String> + ...` in `commands_repl` & `commands_repl_with_listener`.
+- 'Edit methods' (namely `edit_message_live_location`, `stop_message_live_location`, `edit_message_text`, 
    `edit_message_caption`, `edit_message_media` and `edit_message_reply_markup`) are split into common and inline 
    versions (e.g.: `edit_message_text` and `edit_inline_message_text`). Instead of `ChatOrInlineMessage` common versions
    accept `chat_id: impl Into<ChatId>` and `message_id: i32` whereas inline versions accept 
    `inline_message_id: impl Into<String>`. Also note that return type of inline versions is `True` ([issue 253], [pr 257])
- - `ChatOrInlineMessage` is renamed to `TargetMessage`, it's `::Chat`  variant is renamed to `::Common`, 
+- `ChatOrInlineMessage` is renamed to `TargetMessage`, it's `::Chat`  variant is renamed to `::Common`, 
    `#[non_exhaustive]` annotation is removed from the enum, type of `TargetMessage::Inline::inline_message_id` changed 
    `i32` => `String`. `TargetMessage` now implements `From<String>`, `get_game_high_scores` and `set_game_score` use 
    `Into<TargetMessage>` to accept `String`s. ([issue 253], [pr 257])
- - Remove `ResponseResult` from `prelude`.
+- Remove `ResponseResult` from `prelude`.
 
 [issue 253]: https://github.com/teloxide/teloxide/issues/253
 [pr 257]: https://github.com/teloxide/teloxide/pull/257
@@ -302,75 +304,88 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
- - Failing compilation with `serde::export` ([issue 328](https://github.com/teloxide/teloxide/issues/328)).
+- Failing compilation with `serde::export` ([issue 328](https://github.com/teloxide/teloxide/issues/328)).
 
 ## 0.3.3 - 2020-10-30
 
 ### Fixed
- - The `dice` field from `MessageDice` is public now ([issue 306](https://github.com/teloxide/teloxide/issues/306))
+
+- The `dice` field from `MessageDice` is public now ([issue 306](https://github.com/teloxide/teloxide/issues/306))
 
 ## 0.3.2 - 2020-10-23
 
 ### Added
- - `LoginUrl::new` ([issue 298](https://github.com/teloxide/teloxide/issues/298))
+
+- `LoginUrl::new` ([issue 298](https://github.com/teloxide/teloxide/issues/298))
 
 ## 0.3.1 - 2020-08-25
 
 ### Added
- - `Bot::builder` method ([PR 269](https://github.com/teloxide/teloxide/pull/269)).
+
+- `Bot::builder` method ([PR 269](https://github.com/teloxide/teloxide/pull/269)).
 
 ## 0.3.0 - 2020-07-31
+
 ### Added
- - Support for typed bot commands ([issue 152](https://github.com/teloxide/teloxide/issues/152)).
- - `BotBuilder`, which allows setting a default `ParseMode`.
- - The `Transition`, `Subtransition`, `SubtransitionOutputType` traits.
- - A nicer approach to manage dialogues via `#[derive(Transition)]` + `#[teloxide(subtransition)]` (see [`examples/dialogue_bot`](https://github.com/teloxide/teloxide/tree/af2aa218e7bfc442ab4475023a1c661834f576fc/examples/dialogue_bot)).
- - The `redis-storage` feature -- enables the Redis support.
- - The `cbor-serializer` feature -- enables the `CBOR` serializer for dialogues.
- - The `bincode-serializer` feature -- enables the `Bincode` serializer for dialogues.
- - The `frunk` feature -- enables `teloxide::utils::UpState`, which allows mapping from a structure of `field1, ..., fieldN` to a structure of `field1, ..., fieldN, fieldN+1`.
- - Upgrade to v4.9 Telegram bots API.
- - `teloxide::utils::client_from_env` -- constructs a client from the `TELOXIDE_TOKEN` environmental variable.
- - Import `Transition`, `TransitionIn`, `TransitionOut`, `UpState` to `teloxide::prelude`.
- - Import `repl`, `commands_repl` to `teloxide`.
- - Let users inspect an unknown API error using `ApiErrorKind::Unknown(String)`. All the known API errors are placed into `KnownApiErrorKind`.
- - Setters to all the API types.
- - `teloxide::dispatching::dialogue::serializer` -- various serializers for memory storages. The `Serializer` trait, `Bincode`, `CBOR`, `JSON`.
- - `teloxide::{repl, repl_with_listener, commands_repl, commands_repl_with_listener, dialogues_repl, dialogues_repl_with_listener}`
- - `InputFile::Memory`
- - Option to hide a command from description ([issue 217](https://github.com/teloxide/teloxide/issues/217)).
- - Respect the `TELOXIDE_PROXY` environment variable in `Bot::from_env`.
+
+- Support for typed bot commands ([issue 152](https://github.com/teloxide/teloxide/issues/152)).
+- `BotBuilder`, which allows setting a default `ParseMode`.
+- The `Transition`, `Subtransition`, `SubtransitionOutputType` traits.
+- A nicer approach to manage dialogues via `#[derive(Transition)]` + `#[teloxide(subtransition)]` (see [`examples/dialogue_bot`](https://github.com/teloxide/teloxide/tree/af2aa218e7bfc442ab4475023a1c661834f576fc/examples/dialogue_bot)).
+- The `redis-storage` feature -- enables the Redis support.
+- The `cbor-serializer` feature -- enables the `CBOR` serializer for dialogues.
+- The `bincode-serializer` feature -- enables the `Bincode` serializer for dialogues.
+- The `frunk` feature -- enables `teloxide::utils::UpState`, which allows mapping from a structure of `field1, ..., fieldN` to a structure of `field1, ..., fieldN, fieldN+1`.
+- Upgrade to v4.9 Telegram bots API.
+- `teloxide::utils::client_from_env` -- constructs a client from the `TELOXIDE_TOKEN` environmental variable.
+- Import `Transition`, `TransitionIn`, `TransitionOut`, `UpState` to `teloxide::prelude`.
+- Import `repl`, `commands_repl` to `teloxide`.
+- Let users inspect an unknown API error using `ApiErrorKind::Unknown(String)`. All the known API errors are placed into `KnownApiErrorKind`.
+- Setters to all the API types.
+- `teloxide::dispatching::dialogue::serializer` -- various serializers for memory storages. The `Serializer` trait, `Bincode`, `CBOR`, `JSON`.
+- `teloxide::{repl, repl_with_listener, commands_repl, commands_repl_with_listener, dialogues_repl, dialogues_repl_with_listener}`
+- `InputFile::Memory`
+- Option to hide a command from description ([issue 217](https://github.com/teloxide/teloxide/issues/217)).
+- Respect the `TELOXIDE_PROXY` environment variable in `Bot::from_env`.
 
 ### Deprecated
- - `Bot::{from_env_with_client, new, with_client}`
+
+- `Bot::{from_env_with_client, new, with_client}`
 
 ### Changed
- - `DialogueDispatcherHandlerCx` -> `DialogueWithCx`.
- - `DispatcherHandlerCx` -> `UpdateWithCx`.
- - Now provided description of unknown telegram error, by splitting ApiErrorKind at `ApiErrorKind` and `ApiErrorKindKnown` enums ([issue 199](https://github.com/teloxide/teloxide/issues/199)).
- - Extract `Bot` from `Arc` ([issue 216](https://github.com/teloxide/teloxide/issues/230)).
- - Mark all the API types as `#[non_exhaustive]`.
- - Replace all `mime_type: String` with `MimeWrapper`.
+
+- `DialogueDispatcherHandlerCx` -> `DialogueWithCx`.
+- `DispatcherHandlerCx` -> `UpdateWithCx`.
+- Now provided description of unknown telegram error, by splitting ApiErrorKind at `ApiErrorKind` and `ApiErrorKindKnown` enums ([issue 199](https://github.com/teloxide/teloxide/issues/199)).
+- Extract `Bot` from `Arc` ([issue 216](https://github.com/teloxide/teloxide/issues/230)).
+- Mark all the API types as `#[non_exhaustive]`.
+- Replace all `mime_type: String` with `MimeWrapper`.
 
 ### Fixed
- - Now methods which can send file to Telegram returns `tokio::io::Result<T>`. Early its could panic ([issue 216](https://github.com/teloxide/teloxide/issues/216)).
- - If a bot wasn't triggered for several days, it stops responding ([issue 223](https://github.com/teloxide/teloxide/issues/223)).
+
+- Now methods which can send file to Telegram returns `tokio::io::Result<T>`. Early its could panic ([issue 216](https://github.com/teloxide/teloxide/issues/216)).
+- If a bot wasn't triggered for several days, it stops responding ([issue 223](https://github.com/teloxide/teloxide/issues/223)).
 
 ## 0.2.0 - 2020-02-25
+
 ### Added
- - The functionality to parse commands only with a correct bot's name (breaks backwards compatibility) ([Issue 168](https://github.com/teloxide/teloxide/issues/168)).
- - This `CHANGELOG.md`.
+
+- The functionality to parse commands only with a correct bot's name (breaks backwards compatibility) ([Issue 168](https://github.com/teloxide/teloxide/issues/168)).
+- This `CHANGELOG.md`.
 
 ### Fixed
- - Fix parsing a pinned message ([Issue 167](https://github.com/teloxide/teloxide/issues/167)).
- - Replace `LanguageCode` with `String`, because [the official Telegram documentation](https://core.telegram.org/bots/api#getchat) doesn't specify a concrete version of IETF language tag.
- - Problems with the `poll_type` field ([Issue 178](https://github.com/teloxide/teloxide/issues/178)).
- - Make `polling_default` actually a long polling update listener ([PR 182](https://github.com/teloxide/teloxide/pull/182)).
+
+- Fix parsing a pinned message ([Issue 167](https://github.com/teloxide/teloxide/issues/167)).
+- Replace `LanguageCode` with `String`, because [the official Telegram documentation](https://core.telegram.org/bots/api#getchat) doesn't specify a concrete version of IETF language tag.
+- Problems with the `poll_type` field ([Issue 178](https://github.com/teloxide/teloxide/issues/178)).
+- Make `polling_default` actually a long polling update listener ([PR 182](https://github.com/teloxide/teloxide/pull/182)).
 
 ### Removed
- - [either](https://crates.io/crates/either) from the dependencies in `Cargo.toml`.
- - `teloxide-macros` migrated into [the separate repository](https://github.com/teloxide/teloxide-macros) to easier releases and testing.
+
+- [either](https://crates.io/crates/either) from the dependencies in `Cargo.toml`.
+- `teloxide-macros` migrated into [the separate repository](https://github.com/teloxide/teloxide-macros) to easier releases and testing.
 
 ## 0.1.0 - 2020-02-19
+
 ### Added
- - This project.
+- This project.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,17 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 <!-- TODO: use a version once teloxide-macros is released -->
-- Updated `teloxide-macros` see its [changelog](https://github.com/teloxide/teloxide-macros/blob/master/CHANGELOG.md#unreleased) for more
-- `UpdateListener` now has an associated type `Err` instead of a generic
-- `AsUpdateStream` now has an associated type `StreamErr` instead of a generic
-- Rename `dispatching::stop_token::{AsyncStopToken, AsyncStopFlag}` => `stop::{StopToken, StopFlag}`
+ - Updated `teloxide-macros` see its [changelog](https://github.com/teloxide/teloxide-macros/blob/master/CHANGELOG.md#unreleased) for more
+ - `UpdateListener` now has an associated type `Err` instead of a generic
+ - `AsUpdateStream` now has an associated type `StreamErr` instead of a generic
+ - Rename `dispatching::stop_token::{AsyncStopToken, AsyncStopFlag}` => `stop::{StopToken, StopFlag}`
+ - The following functions are now `#[must_use]`:
+   - `BotCommands::ty`.
+   - `CommandDescriptions::{new, global_description, username, username_from_me}`.
+   - `teloxide::filter_command`.
+   - `teloxide::dispatching::dialogue::enter`.
 
 ### Removed
 
-- `dispatching::stop_token::StopToken` trait (all uses are replaced with `stop::StopToken` structure)
-- Some previously deprecated items
-  - `enable_logging!`, `enable_logging_with_filter!`
-  - `HandlerFactory`, `HandlerExt::dispatch_by`
+ - `dispatching::stop_token::StopToken` trait (all uses are replaced with `stop::StopToken` structure)
+ - Some previously deprecated items
+   - `enable_logging!`, `enable_logging_with_filter!`
+   - `HandlerFactory`, `HandlerExt::dispatch_by`
 
 ## 0.10.1 - 2022-07-22
 

--- a/src/dispatching/dialogue.rs
+++ b/src/dispatching/dialogue.rs
@@ -211,6 +211,7 @@ where
 ///  - `Upd`
 ///
 /// [`HandlerExt::enter_dialogue`]: super::HandlerExt::enter_dialogue
+#[must_use]
 pub fn enter<Upd, S, D, Output>() -> Handler<'static, DependencyMap, Output, DpHandlerDescription>
 where
     S: Storage<D> + ?Sized + Send + Sync + 'static,

--- a/src/dispatching/handler_ext.rs
+++ b/src/dispatching/handler_ext.rs
@@ -82,6 +82,7 @@ where
 ///
 ///  - [`crate::types::Message`]
 ///  - [`crate::types::Me`]
+#[must_use]
 pub fn filter_command<C, Output>() -> Handler<'static, DependencyMap, Output, DpHandlerDescription>
 where
     C: BotCommands + Send + Sync + 'static,

--- a/src/utils/command.rs
+++ b/src/utils/command.rs
@@ -235,6 +235,7 @@ pub trait BotCommands: Sized {
     /// Returns `PhantomData<Self>` that is used as a param of [`commands_repl`]
     ///
     /// [`commands_repl`]: (crate::repls2::commands_repl)
+    #[must_use]
     fn ty() -> PhantomData<Self> {
         PhantomData
     }
@@ -296,11 +297,13 @@ pub struct CommandDescription<'a> {
 
 impl<'a> CommandDescriptions<'a> {
     /// Creates new [`CommandDescriptions`] from a list of command descriptions.
+    #[must_use]
     pub fn new(descriptions: &'a [CommandDescription<'a>]) -> Self {
         Self { global_description: None, descriptions, bot_username: None }
     }
 
     /// Sets the global description of these commands.
+    #[must_use]
     pub fn global_description(self, global_description: &'a str) -> Self {
         Self { global_description: Some(global_description), ..self }
     }
@@ -328,6 +331,7 @@ impl<'a> CommandDescriptions<'a> {
     ///      message"
     /// );
     /// ```
+    #[must_use]
     pub fn username(self, bot_username: &'a str) -> Self {
         Self { bot_username: Some(bot_username), ..self }
     }
@@ -338,6 +342,7 @@ impl<'a> CommandDescriptions<'a> {
     /// method to get the username.
     ///
     /// [`username`]: self::CommandDescriptions::username
+    #[must_use]
     pub fn username_from_me(self, me: &'a Me) -> CommandDescriptions<'a> {
         self.username(me.user.username.as_deref().expect("Bots must have usernames"))
     }


### PR DESCRIPTION
Resolves https://github.com/teloxide/teloxide/issues/453.

The following command:

```
cargo clippy --all-targets --all-features -- -W clippy::must_use_candidate
```

Emits empty result.
