### PR TITLE
Use `RequestError` in REPLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `UpdateListener` now has an associated type `Err` instead of a generic
 - `AsUpdateStream` now has an associated type `StreamErr` instead of a generic
 - Rename `dispatching::stop_token::{AsyncStopToken, AsyncStopFlag}` => `stop::{StopToken, StopFlag}`
+- Replace the generic error type `E` with `RequestError` for REPLs (`repl(_with_listener)`, `commands_repl(_with_listener)`)
+
+### Added
+
+- `requests::ResponseResult` to `prelude`
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ async fn main() {
 
     teloxide::repl(bot, |message: Message, bot: Bot| async move {
         bot.send_dice(message.chat.id).await?;
-        respond(())
+        Ok(())
     })
     .await;
 }
@@ -122,8 +122,6 @@ Commands are strongly typed and defined declaratively, similar to how we define 
 ```rust,no_run
 use teloxide::{prelude::*, utils::command::BotCommands};
 
-use std::error::Error;
-
 #[tokio::main]
 async fn main() {
     pretty_env_logger::init();
@@ -145,11 +143,7 @@ enum Command {
     UsernameAndAge { username: String, age: u8 },
 }
 
-async fn answer(
-    bot: Bot,
-    message: Message,
-    command: Command,
-) -> Result<(), Box<dyn Error + Send + Sync>> {
+async fn answer(bot: Bot, message: Message, command: Command) -> ResponseResult<()> {
     match command {
         Command::Help => {
             bot.send_message(message.chat.id, Command::descriptions().to_string()).await?

--- a/examples/admin.rs
+++ b/examples/admin.rs
@@ -1,4 +1,4 @@
-use std::{error::Error, str::FromStr};
+use std::str::FromStr;
 
 use chrono::Duration;
 use teloxide::{prelude::*, types::ChatPermissions, utils::command::BotCommands};
@@ -63,11 +63,7 @@ async fn main() {
     teloxide::commands_repl(bot, action, Command::ty()).await;
 }
 
-async fn action(
-    bot: Bot,
-    msg: Message,
-    command: Command,
-) -> Result<(), Box<dyn Error + Send + Sync>> {
+async fn action(bot: Bot, msg: Message, command: Command) -> ResponseResult<()> {
     match command {
         Command::Help => {
             bot.send_message(msg.chat.id, Command::descriptions().to_string()).await?;
@@ -81,7 +77,7 @@ async fn action(
 }
 
 // Kick a user with a replied message.
-async fn kick_user(bot: Bot, msg: Message) -> Result<(), Box<dyn Error + Send + Sync>> {
+async fn kick_user(bot: Bot, msg: Message) -> ResponseResult<()> {
     match msg.reply_to_message() {
         Some(replied) => {
             // bot.unban_chat_member can also kicks a user from a group chat.
@@ -95,11 +91,7 @@ async fn kick_user(bot: Bot, msg: Message) -> Result<(), Box<dyn Error + Send + 
 }
 
 // Ban a user with replied message.
-async fn ban_user(
-    bot: Bot,
-    msg: Message,
-    time: Duration,
-) -> Result<(), Box<dyn Error + Send + Sync>> {
+async fn ban_user(bot: Bot, msg: Message, time: Duration) -> ResponseResult<()> {
     match msg.reply_to_message() {
         Some(replied) => {
             bot.kick_chat_member(
@@ -118,11 +110,7 @@ async fn ban_user(
 }
 
 // Mute a user with a replied message.
-async fn mute_user(
-    bot: Bot,
-    msg: Message,
-    time: Duration,
-) -> Result<(), Box<dyn Error + Send + Sync>> {
+async fn mute_user(bot: Bot, msg: Message, time: Duration) -> ResponseResult<()> {
     match msg.reply_to_message() {
         Some(replied) => {
             bot.restrict_chat_member(

--- a/examples/command.rs
+++ b/examples/command.rs
@@ -1,7 +1,5 @@
 use teloxide::{prelude::*, utils::command::BotCommands};
 
-use std::error::Error;
-
 #[tokio::main]
 async fn main() {
     pretty_env_logger::init();
@@ -23,11 +21,7 @@ enum Command {
     UsernameAndAge { username: String, age: u8 },
 }
 
-async fn answer(
-    bot: Bot,
-    message: Message,
-    command: Command,
-) -> Result<(), Box<dyn Error + Send + Sync>> {
+async fn answer(bot: Bot, message: Message, command: Command) -> ResponseResult<()> {
     match command {
         Command::Help => {
             bot.send_message(message.chat.id, Command::descriptions().to_string()).await?

--- a/examples/heroku_ping_pong.rs
+++ b/examples/heroku_ping_pong.rs
@@ -49,7 +49,7 @@ async fn main() {
         bot,
         |msg: Message, bot: Bot| async move {
             bot.send_message(msg.chat.id, "pong").await?;
-            respond(())
+            Ok(())
         },
         listener,
     )

--- a/examples/ngrok_ping_pong.rs
+++ b/examples/ngrok_ping_pong.rs
@@ -20,7 +20,7 @@ async fn main() {
         bot,
         |msg: Message, bot: Bot| async move {
             bot.send_message(msg.chat.id, "pong").await?;
-            respond(())
+            Ok(())
         },
         listener,
     )

--- a/examples/throw_dice.rs
+++ b/examples/throw_dice.rs
@@ -11,7 +11,7 @@ async fn main() {
 
     teloxide::repl(bot, |message: Message, bot: Bot| async move {
         bot.send_dice(message.chat.id).await?;
-        respond(())
+        Ok(())
     })
     .await;
 }

--- a/src/dispatching/repls/commands_repl.rs
+++ b/src/dispatching/repls/commands_repl.rs
@@ -5,6 +5,7 @@ use crate::{
     error_handlers::LoggingErrorHandler,
     types::Update,
     utils::command::BotCommands,
+    RequestError,
 };
 use dptree::di::{DependencyMap, Injectable};
 use std::{fmt::Debug, marker::PhantomData};
@@ -34,13 +35,12 @@ use teloxide_core::requests::Requester;
 /// [REPL]: https://en.wikipedia.org/wiki/Read-eval-print_loop
 /// [`Dispatcher`]: crate::dispatching::Dispatcher
 #[cfg(feature = "ctrlc_handler")]
-pub async fn commands_repl<'a, R, Cmd, H, E, Args>(bot: R, handler: H, cmd: PhantomData<Cmd>)
+pub async fn commands_repl<'a, R, Cmd, H, Args>(bot: R, handler: H, cmd: PhantomData<Cmd>)
 where
     Cmd: BotCommands + Send + Sync + 'static,
-    H: Injectable<DependencyMap, Result<(), E>, Args> + Send + Sync + 'static,
+    H: Injectable<DependencyMap, Result<(), RequestError>, Args> + Send + Sync + 'static,
     R: Requester + Clone + Send + Sync + 'static,
     <R as Requester>::GetUpdates: Send,
-    E: Debug + Send + Sync + 'static,
 {
     let cloned_bot = bot.clone();
 
@@ -78,18 +78,17 @@ where
 /// [`commands_repl`]: crate::dispatching::repls::commands_repl()
 /// [`UpdateListener`]: crate::dispatching::update_listeners::UpdateListener
 #[cfg(feature = "ctrlc_handler")]
-pub async fn commands_repl_with_listener<'a, R, Cmd, H, L, E, Args>(
+pub async fn commands_repl_with_listener<'a, R, Cmd, H, L, Args>(
     bot: R,
     handler: H,
     listener: L,
     _cmd: PhantomData<Cmd>,
 ) where
     Cmd: BotCommands + Send + Sync + 'static,
-    H: Injectable<DependencyMap, Result<(), E>, Args> + Send + Sync + 'static,
+    H: Injectable<DependencyMap, Result<(), RequestError>, Args> + Send + Sync + 'static,
     L: UpdateListener + Send + 'a,
     L::Err: Debug + Send + 'a,
     R: Requester + Clone + Send + Sync + 'static,
-    E: Debug + Send + Sync + 'static,
 {
     use crate::dispatching::Dispatcher;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@
 //!
 //! teloxide::repl(bot, |message: Message, bot: Bot| async move {
 //!     bot.send_dice(message.chat.id).await?;
-//!     respond(())
+//!     Ok(())
 //! })
 //! .await;
 //! # }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,17 +1,20 @@
 //! Commonly used items.
 
-pub use crate::{
-    error_handlers::{LoggingErrorHandler, OnError},
-    respond,
-};
+pub use crate::error_handlers::{LoggingErrorHandler, OnError};
+
+#[allow(deprecated)]
+pub use crate::respond;
 
 pub use crate::dispatching::{
     dialogue::Dialogue, Dispatcher, HandlerExt as _, MessageFilterExt as _, UpdateFilterExt as _,
 };
 
-pub use teloxide_core::types::{
-    CallbackQuery, ChatMemberUpdated, ChosenInlineResult, InlineQuery, Message, Poll, PollAnswer,
-    PreCheckoutQuery, ShippingQuery, Update,
+pub use teloxide_core::{
+    requests::ResponseResult,
+    types::{
+        CallbackQuery, ChatMemberUpdated, ChosenInlineResult, InlineQuery, Message, Poll,
+        PollAnswer, PreCheckoutQuery, ShippingQuery, Update,
+    },
 };
 
 #[cfg(feature = "auto-send")]


### PR DESCRIPTION
Resolves https://github.com/teloxide/teloxide/issues/721.

I didn't deprecate the `respond` function because it turned out that we use it with `dptree`, which cannot deduce an error type. So it's still helpful.
