### PR TITLE
Derive Display Trait for MessageId type

### DIFF
--- a/crates/teloxide-core/src/types/message_id.rs
+++ b/crates/teloxide-core/src/types/message_id.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 /// A unique message identifier.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, derive_more::Display, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(from = "MessageIdRaw", into = "MessageIdRaw")]
 pub struct MessageId(pub i32);
 


### PR DESCRIPTION
This PR simply adds the `Display` trait for the `teloxide::types::MessageId` type using `derive_more`, as described in https://github.com/teloxide/teloxide/issues/760