### PR TITLE
Add missing feature gate for `dispatching::repls` import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## unreleased
 
+### Fixed
+
+- Add missing feature gate for `dispatching::repls` import ([issue #770](https://github.com/teloxide/teloxide/issues/770)):
+
 ## 0.11.1 - 2022-10-31
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## unreleased
 
+## 0.11.2 - 2022-11-18
+
 ### Fixed
 
-- Add missing feature gate for `dispatching::repls` import ([issue #770](https://github.com/teloxide/teloxide/issues/770)):
+- Add missing feature gate for `dispatching::repls` import ([issue #770](https://github.com/teloxide/teloxide/issues/770))
 
-## 0.11.1 - 2022-10-31
+## 0.11.1 - 2022-10-31 [yanked]
+
+This release was yanked because it accidentally [breaks backwards compatibility](https://github.com/teloxide/teloxide/issues/770).
 
 ### Added
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "teloxide"
-version = "0.11.1"
+version = "0.11.2"
 edition = "2021"
 description = "An elegant Telegram bots framework for Rust"
 repository = "https://github.com/teloxide/teloxide"

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -1,7 +1,7 @@
 This document describes breaking changes of `teloxide` crate, as well as the ways to update code.
 Note that the list of required changes is not fully exhaustive and it may lack something in rare cases.
 
-## 0.11 -> 0.11.1
+## 0.11 -> 0.11.2
 
 ### teloxide
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-> [v0.11 -> v0.11.1 migration guide >>](MIGRATION_GUIDE.md#011---0111)
+> [v0.11 -> v0.11.2 migration guide >>](MIGRATION_GUIDE.md#011---0112)
 
 <div align="center">
   <img src="./ICON.png" width="250"/>

--- a/src/dispatching.rs
+++ b/src/dispatching.rs
@@ -1,6 +1,6 @@
 //! An update dispatching model based on [`dptree`].
 //!
-//! In teloxide, update dispatching is declarative: it takes the form of a
+//! In `teloxide`, update dispatching is declarative: it takes the form of a
 //! [chain of responsibility] pattern enriched with a number of combinator
 //! functions, which together form an instance of the [`dptree::Handler`] type.
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,7 @@
 #[cfg(feature = "ctrlc_handler")]
 pub use dispatching::repls::{repl, repl_with_listener};
 
+#[cfg(feature = "ctrlc_handler")]
 #[allow(deprecated)]
 pub use dispatching::repls::{commands_repl, commands_repl_with_listener};
 


### PR DESCRIPTION
Resolves https://github.com/teloxide/teloxide/issues/770

Note that I've opened the PR against `master` since this is supposed to be a bugfix for the v0.11.1 release. Please let me know if I should rebase it.