### PR TITLE
Refactor `Cargo.toml`s

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,6 @@ members = ["crates/*"]
 # The settings below will be applied to all crates in the workspace
 [workspace.package]
 # MSRV (minimal supported Rust version).
-# `1.64` is the version that stabilized `IntoFuture`.
 rust-version = "1.64"
 edition = "2021"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,14 @@
 [workspace]
 members = ["crates/*"]
+
+
+# The settings below will be applied to all crates in the workspace
+[workspace.package]
+# MSRV (minimal supported Rust version).
+# `1.64` is the version that stabilized `IntoFuture`.
+rust-version = "1.64"
+edition = "2021"
+
+license = "MIT"
+homepage = "https://github.com/teloxide/teloxide"
+repository = "https://github.com/teloxide/teloxide"

--- a/crates/teloxide-core/Cargo.toml
+++ b/crates/teloxide-core/Cargo.toml
@@ -1,64 +1,20 @@
 [package]
 name = "teloxide-core"
-description = "Core part of the `teloxide` library - telegram bot API client"
 version = "0.8.0"
-edition = "2021"
+description = "Core part of the `teloxide` library - telegram bot API client"
 
-license = "MIT"
-repository = "https://github.com/teloxide/teloxide-core/"
-homepage = "https://github.com/teloxide/teloxide-core/"
+rust-version.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
 documentation = "https://docs.rs/teloxide-core/"
 readme = "README.md"
 
-keywords = ["telegram", "bot", "tba"]
+keywords = ["teloxide", "telegram", "telegram-bot", "telegram-bot-api", "bot", "TBA"]
 categories = ["api-bindings", "asynchronous"]
 
-exclude = [
-    ".github/*",
-    "netlify.toml",
-]
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[dependencies]
-futures = "0.3.5"
-tokio = { version = "1.12.0", features = ["fs"] }
-tokio-util = { version = "0.7.0", features = ["codec"] }
-pin-project = "1.0.12"
-bytes = "1.0.0"
-reqwest = { version = "0.11.10", features = ["json", "stream", "multipart"], default-features = false }
-url = { version = "2", features = ["serde"] }
-log = "0.4"
-
-serde = { version = "1.0.114", features = ["derive"] }
-serde_json = "1.0.55"
-serde_with_macros = "1.5.2"
-uuid = { version = "1.1.0", features = ["v4"] } # for attaching input files
- 
-derive_more = "0.99.9"
-mime = "0.3.16"
-thiserror = "1.0.20"
-once_cell = "1.5.0"
-takecell = "0.1"
-take_mut = "0.2"
-rc-box = "1.1.1"
-never = "0.1.0"
-chrono = { version = "0.4.19", default-features = false }
-either = "1.6.1"
-bitflags = { version = "1.2" }
-
-vecrem = { version = "0.1", optional = true }
-
-[dev-dependencies]
-pretty_env_logger = "0.4"
-tokio = { version = "1.8.0", features = ["fs", "macros", "macros", "rt-multi-thread"] }
-cool_asserts = "2.0.3"
-
-xshell = "0.2"
-ron = "0.7"
-indexmap = { version = "1.9", features = ["serde-1"] }
-aho-corasick = "0.7"
-itertools = "0.10"
 
 [features]
 default = ["native-tls"]
@@ -90,12 +46,56 @@ auto_send = []
 # All features except nightly and tls-related
 full = ["throttle", "trace_adaptor", "erased", "cache_me", "auto_send"]
 
+
+[dependencies]
+futures = "0.3.5"
+tokio = { version = "1.12.0", features = ["fs"] }
+tokio-util = { version = "0.7.0", features = ["codec"] }
+pin-project = "1.0.12"
+bytes = "1.0.0"
+reqwest = { version = "0.11.10", features = ["json", "stream", "multipart"], default-features = false }
+url = { version = "2", features = ["serde"] }
+log = "0.4"
+
+serde = { version = "1.0.114", features = ["derive"] }
+serde_json = "1.0.55"
+serde_with_macros = "1.5.2"
+uuid = { version = "1.1.0", features = ["v4"] } # for attaching input files
+ 
+derive_more = "0.99.9"
+mime = "0.3.16"
+thiserror = "1.0.20"
+once_cell = "1.5.0"
+takecell = "0.1"
+take_mut = "0.2"
+rc-box = "1.1.1"
+never = "0.1.0"
+chrono = { version = "0.4.19", default-features = false }
+either = "1.6.1"
+bitflags = { version = "1.2" }
+
+vecrem = { version = "0.1", optional = true }
+
+
+[dev-dependencies]
+pretty_env_logger = "0.4"
+tokio = { version = "1.8.0", features = ["fs", "macros", "macros", "rt-multi-thread"] }
+cool_asserts = "2.0.3"
+
+xshell = "0.2"
+ron = "0.7"
+indexmap = { version = "1.9", features = ["serde-1"] }
+aho-corasick = "0.7"
+itertools = "0.10"
+
+
 [package.metadata.docs.rs]
 features = ["full", "nightly", "tokio/macros", "tokio/rt-multi-thread"]
 rustdoc-args = ["--cfg", "docsrs", "-Znormalize-docs"]
 
 # https://github.com/rust-lang/rust/issues/88791
 cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples=examples"]
+
 
 [[example]]
 name = "self_info"

--- a/crates/teloxide-macros/Cargo.toml
+++ b/crates/teloxide-macros/Cargo.toml
@@ -2,13 +2,21 @@
 name = "teloxide-macros"
 version = "0.7.0"
 description = "The teloxide's procedural macros"
-license = "MIT"
-edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+rust-version.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+documentation = "https://docs.rs/teloxide-core/"
+# FIXME: add a simple readme for teloxide-macros
+#readme = "README.md"
+
 
 [lib]
 proc-macro = true
+
 
 [dependencies]
 quote = "1.0.7"

--- a/crates/teloxide/Cargo.toml
+++ b/crates/teloxide/Cargo.toml
@@ -1,15 +1,20 @@
 [package]
 name = "teloxide"
 version = "0.11.3"
-edition = "2021"
 description = "An elegant Telegram bots framework for Rust"
-repository = "https://github.com/teloxide/teloxide"
+
+rust-version.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
 documentation = "https://docs.rs/teloxide/"
 readme = "../../README.md"
-keywords = ["teloxide", "telegram", "telegram-bot", "telegram-bot-api"]
+
+keywords = ["teloxide", "telegram", "telegram-bot", "telegram-bot-api", "bot", "TBA"]
 categories = ["web-programming", "api-bindings", "asynchronous"]
-license = "MIT"
-exclude = ["media", "README.md"]
+
 
 [features]
 default = ["native-tls", "ctrlc_handler", "teloxide-core/default",  "auto-send"]
@@ -56,6 +61,7 @@ full = [
     "erased",
 ]
 
+
 [dependencies]
 teloxide-core = { version = "0.8.0", default-features = false }
 teloxide-macros = { version = "0.7.0", optional = true }
@@ -99,6 +105,7 @@ tower = { version = "0.4.12", optional = true }
 tower-http = { version = "0.3.4", features = ["trace"], optional = true }
 rand = { version = "0.8.5", optional = true }
 
+
 [dev-dependencies]
 rand = "0.8.3"
 pretty_env_logger = "0.4.0"
@@ -109,12 +116,14 @@ reqwest = "0.11.11"
 chrono = "0.4"
 tokio-stream = "0.1"
 
+
 [package.metadata.docs.rs]
 all-features = true
 # FIXME: Add back "-Znormalize-docs" when https://github.com/rust-lang/rust/issues/93703 is fixed
 rustdoc-args = ["--cfg", "docsrs"]
 rustc-args = ["--cfg", "dep_docsrs"]
 cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples=examples"]
+
 
 [[test]]
 name = "redis"
@@ -125,6 +134,7 @@ required-features = ["redis-storage", "cbor-serializer", "bincode-serializer"]
 name = "sqlite"
 path = "tests/sqlite.rs"
 required-features = ["sqlite-storage", "cbor-serializer", "bincode-serializer"]
+
 
 [[example]]
 name = "dialogue"


### PR DESCRIPTION
This is the continuation of https://github.com/teloxide/teloxide/pull/759. I've used the [new workspace inheritance](https://blog.rust-lang.org/2022/09/22/Rust-1.64.0.html#cargo-improvements-workspace-inheritance-and-multi-target-builds) feature to make maintenance of metadata of our packages simpler.