### PR TITLE
prelude: Add missing feature gate for `dispatching::repls` import

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,6 +152,13 @@ jobs:
           command: check
           args: --examples --features full
 
+      # TODO: prolly move it to a separate step?
+      - name: Check with no default features
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --no-default-features
+
   clippy:
     name: Run linter
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## unreleased
 
+- Add another missing feature gate for `dispatching::repls` import ([issue #770](https://github.com/teloxide/teloxide/issues/770))
+
 ## 0.11.2 - 2022-11-18
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## unreleased
 
+## 0.11.3 - 2022-11-28
+
+### Fixed
+
 - Add another missing feature gate for `dispatching::repls` import ([issue #770](https://github.com/teloxide/teloxide/issues/770))
 
 ## 0.11.2 - 2022-11-18

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "teloxide"
-version = "0.11.2"
+version = "0.11.3"
 edition = "2021"
 description = "An elegant Telegram bots framework for Rust"
 repository = "https://github.com/teloxide/teloxide"

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -1,7 +1,7 @@
 This document describes breaking changes of `teloxide` crate, as well as the ways to update code.
 Note that the list of required changes is not fully exhaustive and it may lack something in rare cases.
 
-## 0.11 -> 0.11.2
+## 0.11 -> 0.11.3
 
 ### teloxide
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-> [v0.11 -> v0.11.2 migration guide >>](MIGRATION_GUIDE.md#011---0112)
+> [v0.11 -> v0.11.3 migration guide >>](MIGRATION_GUIDE.md#011---0113)
 
 <div align="center">
   <img src="./ICON.png" width="250"/>

--- a/src/dispatching/dispatcher.rs
+++ b/src/dispatching/dispatcher.rs
@@ -144,6 +144,9 @@ where
             ctrlc_handler,
         } = self;
 
+        // If the `ctrlc_handler` feature is not enabled, don't emit a warning.
+        let _ = ctrlc_handler;
+
         let dp = Dispatcher {
             bot,
             dependencies,

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -6,9 +6,11 @@ pub use crate::error_handlers::{LoggingErrorHandler, OnError};
 pub use crate::respond;
 
 pub use crate::dispatching::{
-    dialogue::Dialogue, repls::CommandReplExt as _, Dispatcher, HandlerExt as _,
-    MessageFilterExt as _, UpdateFilterExt as _,
+    dialogue::Dialogue, Dispatcher, HandlerExt as _, MessageFilterExt as _, UpdateFilterExt as _,
 };
+
+#[cfg(feature = "ctrlc_handler")]
+pub use crate::dispatching::repls::CommandReplExt as _;
 
 pub use teloxide_core::{
     requests::ResponseResult,


### PR DESCRIPTION
looks like I missed another instance of the #770 issue when I worked on #771... 🙈 

This PR fixes a similar issue in the `prelude` module :)