### PR TITLE
Bump `axum` to `0.6.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## unreleased
 
+### Changed
+
+- Updated `axum` to v0.6.0.
+
 ## Removed
 
 - `rocksdb-storage` feature and associated items (See [PR #761](https://github.com/teloxide/teloxide/pull/761) for reasoning) [**BC**]

--- a/crates/teloxide/Cargo.toml
+++ b/crates/teloxide/Cargo.toml
@@ -94,7 +94,7 @@ sqlx = { version = "0.6", optional = true, default-features = false, features = 
 redis = { version = "0.21", features = ["tokio-comp"], optional = true }
 serde_cbor = { version = "0.11", optional = true }
 bincode = { version = "1.3", optional = true }
-axum = { version = "0.5.13", optional = true }
+axum = { version = "0.6.0", optional = true }
 tower = { version = "0.4.12", optional = true }
 tower-http = { version = "0.3.4", features = ["trace"], optional = true }
 rand = { version = "0.8.5", optional = true }


### PR DESCRIPTION
<!--
Before making this PR, please ensure the following:

 - The PR is open to `dev`, NOT `master`.
 - `CHANGELOG.md` is updated (if necessary).
 - Documentation and tests are updated (if necessary).
-->

Axum now lets users to extract state in a type-safe fashion, so I've removed usage of `Extension`-s and replaced it with `State` extractor. `input: String` was moved to the bottom of the parameter list since it consumes body and must come last.
