### PR TITLE
Uses full qualified names in macros code

### DIFF
--- a/crates/teloxide-macros/src/bot_commands.rs
+++ b/crates/teloxide-macros/src/bot_commands.rs
@@ -50,9 +50,9 @@ fn impl_commands(infos: &[Command]) -> proc_macro2::TokenStream {
     });
 
     quote! {
-        fn bot_commands() -> Vec<teloxide::types::BotCommand> {
+        fn bot_commands() -> ::std::vec::Vec<teloxide::types::BotCommand> {
             use teloxide::types::BotCommand;
-            vec![#(#commands),*]
+            ::std::vec![#(#commands),*]
         }
     }
 }
@@ -91,7 +91,7 @@ fn impl_parse(
     let matching_values = infos.iter().map(|c| c.get_prefixed_command());
 
     quote! {
-         fn parse(s: &str, bot_name: &str) -> Result<Self, teloxide::utils::command::ParseError> {
+         fn parse(s: &str, bot_name: &str) -> ::std::result::Result<Self, teloxide::utils::command::ParseError> {
               // FIXME: we should probably just call a helper function from `teloxide`, instead of parsing command syntax ourselves
               use std::str::FromStr;
               use teloxide::utils::command::ParseError;
@@ -106,9 +106,9 @@ fn impl_parse(
 
               let bot_username = full_command.next();
               match bot_username {
-                  None => {}
-                  Some(username) if username.eq_ignore_ascii_case(bot_name) => {}
-                  Some(n) => return Err(ParseError::WrongBotName(n.to_owned())),
+                  ::std::option::Option::None => {}
+                  ::std::option::Option::Some(username) if username.eq_ignore_ascii_case(bot_name) => {}
+                  ::std::option::Option::Some(n) => return ::std::result::Result::Err(ParseError::WrongBotName(n.to_owned())),
               }
 
               let args = words.next().unwrap_or("").to_owned();
@@ -116,7 +116,7 @@ fn impl_parse(
                    #(
                         #matching_values => Ok(#variants_initialization),
                    )*
-                   _ => Err(ParseError::UnknownCommand(command.to_owned())),
+                   _ => ::std::result::Result::Err(ParseError::UnknownCommand(command.to_owned())),
               }
          }
     }

--- a/crates/teloxide-macros/src/error.rs
+++ b/crates/teloxide-macros/src/error.rs
@@ -10,7 +10,7 @@ pub(crate) fn compile_error<T>(data: T) -> Error
 where
     T: ToTokens,
 {
-    Error(quote! { compile_error! { #data } })
+    Error(quote! { ::std::compile_error! { #data } })
 }
 
 pub(crate) fn compile_error_at(msg: &str, sp: Span) -> Error {

--- a/crates/teloxide-macros/src/fields_parse.rs
+++ b/crates/teloxide-macros/src/fields_parse.rs
@@ -83,17 +83,17 @@ fn create_parser<'a>(
                 let ty = types.next().unwrap();
                 quote! {
                     (
-                        |s: String| {
+                        |s: ::std::string::String| {
                             let res = <#ty>::from_str(&s)
-                                .map_err(|e| ParseError::IncorrectFormat(e.into()))?;
+                                .map_err(|e| teloxide::utils::command::ParseError::IncorrectFormat(e.into()))?;
 
-                            Ok((res,))
+                            ::std::result::Result::Ok((res,))
                         }
                     )
                 }
             }
             _ => {
-                quote! { compile_error!("Default parser works only with exactly 1 field") }
+                quote! { ::std::compile_error!("Default parser works only with exactly 1 field") }
             }
         },
         ParserType::Split { separator } => {
@@ -118,13 +118,13 @@ fn parser_with_separator<'a>(
             (
                 #(
                     {
-                        let s = splitted.next().ok_or(ParseError::TooFewArguments {
+                        let s = splitted.next().ok_or(teloxide::utils::command::ParseError::TooFewArguments {
                             expected: #expected,
                             found: #found,
                             message: format!("Expected but not found arg number {}", #found + 1),
                         })?;
 
-                        <#types>::from_str(s).map_err(|e| ParseError::IncorrectFormat(e.into()))?
+                        <#types>::from_str(s).map_err(|e| teloxide::utils::command::ParseError::IncorrectFormat(e.into()))?
                     }
                 ),*
             )
@@ -133,18 +133,18 @@ fn parser_with_separator<'a>(
 
     let res = quote! {
         (
-            |s: String| {
+            |s: ::std::string::String| {
                 let mut splitted = s.split(#separator);
 
                 let res = #res;
 
                 match splitted.next() {
-                    Some(d) => Err(ParseError::TooManyArguments {
+                    Some(d) => ::std::result::Result::Err(teloxide::utils::command::ParseError::TooManyArguments {
                         expected: #expected,
                         found: #expected + 1,
                         message: format!("Excess argument: {}", d),
                     }),
-                    None => Ok(res)
+                    None => ::std::result::Result::Ok(res)
                 }
             }
         )

--- a/crates/teloxide/Cargo.toml
+++ b/crates/teloxide/Cargo.toml
@@ -64,7 +64,7 @@ full = [
 
 [dependencies]
 teloxide-core = { version = "0.8.0", default-features = false }
-teloxide-macros = { version = "0.7.0", optional = true }
+# teloxide-macros = { version = "0.7.0", optional = true }
 
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
@@ -73,7 +73,7 @@ dptree = "0.3.0"
 
 # These lines are used only for development.
 # teloxide-core = { path = "../teloxide-core", default-features = false }
-# teloxide-macros = { path = "../teloxide-macros", optional = true }
+teloxide-macros = { path = "../teloxide-macros", optional = true }
 # dptree = { git = "https://github.com/teloxide/dptree", rev = "df578e4" }
 
 tokio = { version = "1.8", features = ["fs"] }

--- a/crates/teloxide/tests/command.rs
+++ b/crates/teloxide/tests/command.rs
@@ -252,3 +252,14 @@ fn rename_rules() {
         DefaultCommands::descriptions().to_string()
     );
 }
+
+#[test]
+#[cfg(feature = "macros")]
+fn custom_result() {
+    #[allow(dead_code)]
+    type Result = ();
+
+    #[derive(BotCommands, Debug, PartialEq)]
+    enum DefaultCommands {
+    }
+}


### PR DESCRIPTION
I have this problem, because I usually define a custom `Result` type.

https://doc.rust-lang.org/reference/procedural-macros.html#procedural-macro-hygiene