### PR TITLE
Stop mentioning `dev` branch in documentation

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,6 @@
 <!--
 Before making this PR, please ensure the following:
 
- - The PR is open to `dev`, NOT `master`.
- - `CHANGELOG.md` is updated (if necessary).
- - Documentation and tests are updated (if necessary).
+- `CHANGELOG.md` is updated (if necessary).
+- Documentation and tests are updated (if necessary).
 -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master, dev ]
+    branches: [ master ]
 
 name: Continuous integration
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Before contributing, please read [our code style](https://github.com/teloxide/teloxide/blob/master/CODE_STYLE.md) and [the license](https://github.com/teloxide/teloxide/blob/master/LICENSE).
 
-To change the source code, fork the `dev` branch of this repository and work inside your own branch. Then send us a PR into `dev` branch and wait for the CI to check everything. However, you'd better check changes first locally:
+To change the source code, fork the `master` branch of this repository and work inside your own branch. Then send us a PR into `master` branch and wait for the CI to check everything. However, you'd better check changes first locally:
 
 ```
 cargo clippy --all --all-features --all-targets


### PR DESCRIPTION
As previously stated, we are switching to developing directly in `master` branch.