### PR TITLE
Add `ApiError::RequestEntityTooLarge`

### DIFF
--- a/crates/teloxide-core/src/errors.rs
+++ b/crates/teloxide-core/src/errors.rs
@@ -740,6 +740,18 @@ pub enum ApiError {
     #[serde(rename = "Bad Request: invalid file id")]
     #[error("Bad Request: invalid file id")]
     FileIdInvalid,
+    
+    /// Occurs when bot tries to upload a file which is larger than 50 MB using multipart/form-data.
+    ///
+    /// May happen in methods:
+    /// 1. [`SendVideo`]
+    /// 2. [`SendDocument`]
+    ///
+    /// [`SendVideo`]: crate::payloads::SendVideo
+    /// [`SendDocument`]: crate::payloads::SendDocument
+    #[serde(rename = "Request Entity Too Large")]
+    #[error("Request Entity Too Large")]
+    RequestEntityTooLarge,
 
     /// Error which is not known to `teloxide`.
     ///


### PR DESCRIPTION
Occurs when bot tries to upload a file which is larger than 50 MB using multipart/form-data.

See #786 
