### PR TITLE
Synchronize places that use update kinds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## unreleased
 
+### Fixed
+
+- Allow `ChatJoinRequest` updates
+
+### Added
+
+- `Update::filter_chat_join_request`
+
 ## 0.12.0 - 2023-01-17
 
 ### Changed

--- a/crates/teloxide-core/CHANGELOG.md
+++ b/crates/teloxide-core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## unreleased
 
+### Fixed 
+
+- `Update::user` now handles channel posts, chat member changes and chat join request updates correctly ([#835][pr835])
+
+[pr835]: https://github.com/teloxide/teloxide/pull/835
+
 ## 0.9.0 - 2023-01-17
 
 ### Changed

--- a/crates/teloxide-core/src/types/update.rs
+++ b/crates/teloxide-core/src/types/update.rs
@@ -62,6 +62,12 @@ impl Update {
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum UpdateKind {
+    // NB: When adding new variants, don't forget to update
+    //     - `AllowedUpdate`
+    //     - `Update::user`
+    //     - `Update::chat`
+    //     - `DpHandlerDescription::full_set`
+    //     - `dispatching/filter_ext.rs`
     /// New incoming message of any kind — text, photo, sticker, etc.
     Message(Message),
 

--- a/crates/teloxide-core/src/types/update.rs
+++ b/crates/teloxide-core/src/types/update.rs
@@ -29,6 +29,13 @@ pub struct Update {
 }
 
 impl Update {
+    // FIXME: rename user => from, add mentioned_users -> impl Iterator<&User>
+
+    /// Returns the user that performed the action that caused this update, if
+    /// known.
+    ///
+    /// This is generally the `from` field (except for `PollAnswer` where it's
+    /// `user` and `Poll` with `Error` which don't have such field at all).
     #[must_use]
     pub fn user(&self) -> Option<&User> {
         use UpdateKind::*;
@@ -52,6 +59,7 @@ impl Update {
         Some(from)
     }
 
+    /// Returns the chat in which is update has happened, if any.
     #[must_use]
     pub fn chat(&self) -> Option<&Chat> {
         use UpdateKind::*;

--- a/crates/teloxide/src/dispatching/filter_ext.rs
+++ b/crates/teloxide/src/dispatching/filter_ext.rs
@@ -103,7 +103,6 @@ macro_rules! define_update_ext {
     }
 }
 
-// May be expanded in the future.
 define_update_ext! {
     (filter_message, UpdateKind::Message, Message),
     (filter_edited_message, UpdateKind::EditedMessage, EditedMessage),
@@ -118,4 +117,5 @@ define_update_ext! {
     (filter_poll_answer, UpdateKind::PollAnswer, PollAnswer),
     (filter_my_chat_member, UpdateKind::MyChatMember, MyChatMember),
     (filter_chat_member, UpdateKind::ChatMember, ChatMember),
+    (filter_chat_join_request, UpdateKind::ChatJoinRequest, ChatJoinRequest),
 }

--- a/crates/teloxide/src/dispatching/handler_description.rs
+++ b/crates/teloxide/src/dispatching/handler_description.rs
@@ -64,6 +64,7 @@ impl EventKind for Kind {
             PollAnswer,
             MyChatMember,
             ChatMember,
+            ChatJoinRequest,
         ]
         .into_iter()
         .map(Kind)

--- a/crates/teloxide/src/dispatching/handler_description.rs
+++ b/crates/teloxide/src/dispatching/handler_description.rs
@@ -50,6 +50,16 @@ impl EventKind for Kind {
     fn full_set() -> HashSet<Self> {
         use AllowedUpdate::*;
 
+        // NB: We need to specify all update kinds by hand, because telegram doesn't
+        //     enable `ChatMember` by default:
+        //
+        //     > A JSON-serialized list of the update types you want your bot to
+        //     > receive. For example, specify [“message”, “edited_channel_post”,
+        //     > “callback_query”] to only receive updates of these types. See Update
+        //     > for a complete list of available update types. Specify an empty list
+        //     > to receive all update types except chat_member (default). If not
+        //     > specified, the previous setting will be used.
+
         [
             Message,
             EditedMessage,

--- a/crates/teloxide/src/dispatching/handler_description.rs
+++ b/crates/teloxide/src/dispatching/handler_description.rs
@@ -21,7 +21,7 @@ impl DpHandlerDescription {
     }
 
     pub(crate) fn allowed_updates(&self) -> Vec<AllowedUpdate> {
-        self.allowed.observed.iter().map(|Kind(x)| x).copied().collect()
+        self.allowed.observed.iter().map(|&Kind(x)| x).collect()
     }
 }
 


### PR DESCRIPTION
- Include `ChatJoinRequest` in the list of allowed updates if necessary
- Add `Update::filter_chat_join_request`
- Make `Update::user` work with more update kinds
- Some documentation improvements
