### PR TITLE
Automatically use `path` versions for development

### DIFF
--- a/crates/teloxide-core/Cargo.toml
+++ b/crates/teloxide-core/Cargo.toml
@@ -17,6 +17,8 @@ categories = ["api-bindings", "asynchronous"]
 
 
 [features]
+# NB: When adding features here, don't forget to update teloxide's Cargo.toml
+
 default = ["native-tls"]
 
 rustls = ["reqwest/rustls-tls"]

--- a/crates/teloxide/Cargo.toml
+++ b/crates/teloxide/Cargo.toml
@@ -63,17 +63,15 @@ full = [
 
 
 [dependencies]
-teloxide-core = { version = "0.9.0", default-features = false }
-teloxide-macros = { version = "0.7.1", optional = true }
+teloxide-core = { version = "0.9.0", path = "../teloxide-core", default-features = false }
+teloxide-macros = { version = "0.7.1", path = "../teloxide-macros", optional = true }
 
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 
 dptree = "0.3.0"
 
-# These lines are used only for development.
-# teloxide-core = { path = "../teloxide-core", default-features = false }
-# teloxide-macros = { path = "../teloxide-macros", optional = true }
+# Uncomment this if you want to test teloxide with a specific dptree commit
 # dptree = { git = "https://github.com/teloxide/dptree", rev = "df578e4" }
 
 tokio = { version = "1.8", features = ["fs"] }


### PR DESCRIPTION
Turns out cargo straight up supports this: https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#multiple-locations. This allows us to not uncomment/comment the path deps every time we make a release.