### PR TITLE
fix split parser for tuple struct with len <2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Allow `ChatJoinRequest` updates
-- Fix `split` parser for tuple variants with len < 2 ([issue #834](https://github.com/teloxide/teloxide/issues/834))
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Allow `ChatJoinRequest` updates
+- Fix `split` parser for tuple variants with len < 2 ([issue #834](https://github.com/teloxide/teloxide/issues/834))
 
 ### Added
 

--- a/crates/teloxide-macros/CHANGELOG.md
+++ b/crates/teloxide-macros/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## unreleased
 
+### Fixed
+
+- Fix `split` parser for tuple variants with len < 2 ([issue #834](https://github.com/teloxide/teloxide/issues/834))
+
 ## 0.7.1 - 2023-01-17
 
 ### Fixed

--- a/crates/teloxide-macros/src/fields_parse.rs
+++ b/crates/teloxide-macros/src/fields_parse.rs
@@ -138,10 +138,13 @@ fn parser_with_separator<'a>(
 
                 let res = #res;
 
+                if !s.is_empty() && splitted.count() {
+                }
+
                 match splitted.next() {
                     Some(d) if !s.is_empty() => ::std::result::Result::Err(teloxide::utils::command::ParseError::TooManyArguments {
                         expected: #expected,
-                        found: #expected + 1,
+                        found: #expected + 1 + splitted.count(),
                         message: format!("Excess argument: {}", d),
                     }),
                     _ => ::std::result::Result::Ok(res)

--- a/crates/teloxide-macros/src/fields_parse.rs
+++ b/crates/teloxide-macros/src/fields_parse.rs
@@ -138,9 +138,6 @@ fn parser_with_separator<'a>(
 
                 let res = #res;
 
-                if !s.is_empty() && splitted.count() {
-                }
-
                 match splitted.next() {
                     Some(d) if !s.is_empty() => ::std::result::Result::Err(teloxide::utils::command::ParseError::TooManyArguments {
                         expected: #expected,

--- a/crates/teloxide-macros/src/fields_parse.rs
+++ b/crates/teloxide-macros/src/fields_parse.rs
@@ -125,8 +125,8 @@ fn parser_with_separator<'a>(
                         })?;
 
                         <#types>::from_str(s).map_err(|e| teloxide::utils::command::ParseError::IncorrectFormat(e.into()))?
-                    }
-                ),*
+                    },
+                )*
             )
         }
     };
@@ -139,12 +139,12 @@ fn parser_with_separator<'a>(
                 let res = #res;
 
                 match splitted.next() {
-                    Some(d) => ::std::result::Result::Err(teloxide::utils::command::ParseError::TooManyArguments {
+                    Some(d) if !s.is_empty() => ::std::result::Result::Err(teloxide::utils::command::ParseError::TooManyArguments {
                         expected: #expected,
                         found: #expected + 1,
                         message: format!("Excess argument: {}", d),
                     }),
-                    None => ::std::result::Result::Ok(res)
+                    _ => ::std::result::Result::Ok(res)
                 }
             }
         )

--- a/crates/teloxide/tests/command.rs
+++ b/crates/teloxide/tests/command.rs
@@ -117,7 +117,7 @@ fn parse_with_split() {
 
     assert_eq!(
         DefaultCommands::Start(10, "hello".to_string()),
-        DefaultCommands::parse("/start 10 hello", "").unwrap()
+        DefaultCommands::parse("/start 10 hello", "").unwrap(),
     );
 }
 
@@ -136,6 +136,34 @@ fn parse_with_split2() {
         DefaultCommands::Start(10, "hello".to_string()),
         DefaultCommands::parse("/start 10|hello", "").unwrap()
     );
+}
+
+#[test]
+#[cfg(feature = "macros")]
+fn parse_with_split3() {
+    #[derive(BotCommands, Debug, PartialEq)]
+    #[command(rename_rule = "lowercase")]
+    #[command(parse_with = "split")]
+    enum DefaultCommands {
+        Start(u8),
+        Help,
+    }
+
+    assert_eq!(DefaultCommands::Start(10), DefaultCommands::parse("/start 10", "").unwrap(),);
+}
+
+#[test]
+#[cfg(feature = "macros")]
+fn parse_with_split4() {
+    #[derive(BotCommands, Debug, PartialEq)]
+    #[command(rename_rule = "lowercase")]
+    #[command(parse_with = "split")]
+    enum DefaultCommands {
+        Start(),
+        Help,
+    }
+
+    assert_eq!(DefaultCommands::Start(), DefaultCommands::parse("/start", "").unwrap(),);
 }
 
 #[test]


### PR DESCRIPTION
fixes #834 