### PR TITLE
Add docstring to Message::from

### DIFF
--- a/crates/teloxide-core/src/types/message.rs
+++ b/crates/teloxide-core/src/types/message.rs
@@ -620,6 +620,7 @@ mod getters {
     /// [Message]: crate::types::Message
     /// [telegram docs]: https://core.telegram.org/bots/api#message
     impl Message {
+        /// Returns the user who sent the message.
         #[must_use]
         pub fn from(&self) -> Option<&User> {
             match &self.kind {


### PR DESCRIPTION
When I was trying to figure out how to get the user from a Message struct, I completely overlooked the `from` function because I thought it was similar to Rust's `From` and `Into` traits (ie create Message `from` some other struct). Some documentation would help this.