### PR TITLE
Try out merge queue (new github feature)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  merge_group:
 
 name: Continuous integration
 


### PR DESCRIPTION
see https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue

This should fix the issue of non-syntactically conflicting PRs (well, not _this_ but rather the build queue, that does not work without _this_).