### PR TITLE
Simplify release process by using `cargo-release`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,7 @@ edition = "2021"
 license = "MIT"
 homepage = "https://github.com/teloxide/teloxide"
 repository = "https://github.com/teloxide/teloxide"
+
+[workspace.metadata.release]
+tag-message = "Release {{crate_name}} version {{version}}"
+tag-name = "{{prefix}}v{{version}}"

--- a/crates/teloxide-core/Cargo.toml
+++ b/crates/teloxide-core/Cargo.toml
@@ -98,6 +98,14 @@ rustdoc-args = ["--cfg", "docsrs", "-Znormalize-docs"]
 # https://github.com/rust-lang/rust/issues/88791
 cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples"]
 
+[package.metadata.release]
+tag-prefix = "core-"
+enable-features = ["full"]
+pre-release-replacements = [
+    {file="README.md", search="teloxide-core = \"[^\"]+\"", replace="teloxide-core = \"{{version}}\""},
+    {file="src/lib.rs", search="teloxide-core = \"[^\"]+\"", replace="teloxide-core = \"{{version}}\""},
+    {file="CHANGELOG.md", search="## unreleased", replace="## unreleased\n\n## {{version}} - {{date}}", exactly=1},
+]
 
 [[example]]
 name = "self_info"

--- a/crates/teloxide-core/src/lib.rs
+++ b/crates/teloxide-core/src/lib.rs
@@ -5,7 +5,7 @@
 //! asynchronous and built using [`tokio`].
 //!
 //!```toml
-//! teloxide_core = "0.9"
+//! teloxide-core = "0.9"
 //! ```
 //! _Compiler support: requires rustc 1.64+_.
 //!

--- a/crates/teloxide-macros/Cargo.toml
+++ b/crates/teloxide-macros/Cargo.toml
@@ -13,13 +13,17 @@ documentation = "https://docs.rs/teloxide-core/"
 # FIXME: add a simple readme for teloxide-macros
 #readme = "README.md"
 
-
 [lib]
 proc-macro = true
-
 
 [dependencies]
 quote = "1.0.7"
 proc-macro2 = "1.0.19"
 syn = { version = "1.0.13",  features = ["full"] }
 heck = "0.4.0"
+
+[package.metadata.release]
+tag-prefix = "macros-"
+pre-release-replacements = [
+    {file="CHANGELOG.md", search="## unreleased", replace="## unreleased\n\n## {{version}} - {{date}}", exactly=1},
+]

--- a/crates/teloxide/Cargo.toml
+++ b/crates/teloxide/Cargo.toml
@@ -127,6 +127,13 @@ rustdoc-args = ["--cfg", "docsrs"]
 rustc-args = ["--cfg", "dep_docsrs"]
 cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples"]
 
+[package.metadata.release]
+tag-prefix = ""
+enable-features = ["full"]
+pre-release-replacements = [
+  {file="../../README.md", search="teloxide = \\{ version = \"[^\"]+\"", replace="teloxide = { version = \"{{version}}\""},
+  {file="../../CHANGELOG.md", search="## unreleased", replace="## unreleased\n\n## {{version}} - {{date}}", exactly=1},
+]
 
 [[test]]
 name = "redis"


### PR DESCRIPTION
See https://github.com/crate-ci/cargo-release.

If I did everything right, releasing should be as simple as running `cargo release --package <package> <bump>` where `<package>` is the package (`teloxide`, `teloxide-core`, or `teloxide-macros`) and `<bump>` is the bump kind (`patch`, `minor`, `major`, or an exact version).