### PR TITLE
Support setting the help message of commands with `/// ...`

### DIFF
--- a/crates/teloxide-macros/CHANGELOG.md
+++ b/crates/teloxide-macros/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix `split` parser for tuple variants with len < 2 ([issue #834](https://github.com/teloxide/teloxide/issues/834))
 
 ### Added
-
+- Now you can use `/// doc comment` for the command help message ([PR #861](https://github.com/teloxide/teloxide/pull/861)).
 - Now you can use `#[command(hide)]` to hide a command from the help message ([PR #862](https://github.com/teloxide/teloxide/pull/862))
 
 ### Deprecated

--- a/crates/teloxide-macros/src/attr.rs
+++ b/crates/teloxide-macros/src/attr.rs
@@ -7,15 +7,15 @@ use syn::{
     Attribute, Ident, Lit, Path, Token,
 };
 
-pub(crate) fn fold_attrs<'a, A, R>(
-    attrs: impl Iterator<Item = &'a Attribute>,
+pub(crate) fn fold_attrs<A, R>(
+    attrs: impl Iterator<Item = Attribute>,
     filter: fn(&Attribute) -> bool,
     parse: impl Fn(Attr) -> Result<R>,
     init: A,
     f: impl Fn(A, R) -> Result<A>,
 ) -> Result<A> {
     attrs
-        .filter(|&a| filter(a))
+        .filter(filter)
         .flat_map(|attribute| {
             // FIXME: don't allocate here
             let attrs = match attribute.parse_args_with(|input: &ParseBuffer| {

--- a/crates/teloxide-macros/src/attr.rs
+++ b/crates/teloxide-macros/src/attr.rs
@@ -15,11 +15,15 @@ pub(crate) fn fold_attrs<A, R>(
     f: impl Fn(A, R) -> Result<A>,
 ) -> Result<A> {
     attrs
-    .iter()
-    .filter(|&a| filter(a))
+        .iter()
+        .filter(|&a| filter(a))
         .flat_map(|attribute| {
-            let Some(key) = attribute.path.get_ident().cloned()
-                else { return vec![Err(compile_error_at("expected an ident", attribute.path.span()))] };
+            let Some(key) = attribute.path.get_ident().cloned() else {
+                return vec![Err(compile_error_at(
+                    "expected an ident",
+                    attribute.path.span(),
+                ))];
+            };
 
             match (|input: ParseStream<'_>| Attrs::parse_with_key(input, key))
                 .parse(attribute.tokens.clone().into())

--- a/crates/teloxide-macros/src/attr.rs
+++ b/crates/teloxide-macros/src/attr.rs
@@ -7,15 +7,14 @@ use syn::{
     Attribute, Ident, Lit, Path, Token,
 };
 
-pub(crate) fn fold_attrs<A, R>(
-    attrs: &[Attribute],
+pub(crate) fn fold_attrs<'a, A, R>(
+    attrs: impl Iterator<Item = &'a Attribute>,
     filter: fn(&Attribute) -> bool,
     parse: impl Fn(Attr) -> Result<R>,
     init: A,
     f: impl Fn(A, R) -> Result<A>,
 ) -> Result<A> {
     attrs
-        .iter()
         .filter(|&a| filter(a))
         .flat_map(|attribute| {
             // FIXME: don't allocate here

--- a/crates/teloxide-macros/src/bot_commands.rs
+++ b/crates/teloxide-macros/src/bot_commands.rs
@@ -76,7 +76,7 @@ fn impl_descriptions(infos: &[Command], global: &CommandEnum) -> proc_macro2::To
         }
     });
 
-    let global_description = match global.description.as_deref() {
+    let global_description = match global.description.as_ref().map(|(d, _)| d) {
         Some(gd) => quote! { .global_description(#gd) },
         None => quote! {},
     };

--- a/crates/teloxide-macros/src/command.rs
+++ b/crates/teloxide-macros/src/command.rs
@@ -9,7 +9,8 @@ pub(crate) struct Command {
     /// Prefix of this command, for example "/".
     pub prefix: String,
     /// Description for the command.
-    pub description: Option<(String, Span)>,
+    /// The bool is true if the description contains a doc comment.
+    pub description: Option<(String, bool, Span)>,
     /// Name of the command, with all renames already applied.
     pub name: String,
     /// Parser for arguments of this command.
@@ -61,7 +62,7 @@ impl Command {
     }
 
     pub fn description(&self) -> Option<&str> {
-        self.description.as_ref().map(|(d, _span)| &**d)
+        self.description.as_ref().map(|(d, ..)| &**d)
     }
 
     pub(crate) fn description_is_enabled(&self) -> bool {
@@ -70,6 +71,6 @@ impl Command {
     }
 
     pub(crate) fn deprecated_description_off_span(&self) -> Option<Span> {
-        self.description.as_ref().filter(|(d, _)| d == "off").map(|&(_, span)| span)
+        self.description.as_ref().filter(|(d, ..)| d == "off").map(|&(.., span)| span)
     }
 }

--- a/crates/teloxide-macros/src/command.rs
+++ b/crates/teloxide-macros/src/command.rs
@@ -65,12 +65,19 @@ impl Command {
         self.description.as_ref().map(|(d, ..)| &**d)
     }
 
+    pub fn contains_doc_comment(&self) -> bool {
+        self.description.as_ref().map(|(_, is_doc, ..)| *is_doc).unwrap_or(false)
+    }
+
     pub(crate) fn description_is_enabled(&self) -> bool {
         // FIXME: remove the first, `== "off"`, check eventually
-        self.description() != Some("off") && !self.hidden
+        !((self.description() == Some("off") && !self.contains_doc_comment()) || self.hidden)
     }
 
     pub(crate) fn deprecated_description_off_span(&self) -> Option<Span> {
-        self.description.as_ref().filter(|(d, ..)| d == "off").map(|&(.., span)| span)
+        self.description
+            .as_ref()
+            .filter(|(d, ..)| d == "off" && !self.description_is_enabled())
+            .map(|&(.., span)| span)
     }
 }

--- a/crates/teloxide-macros/src/command.rs
+++ b/crates/teloxide-macros/src/command.rs
@@ -77,7 +77,7 @@ impl Command {
     pub(crate) fn deprecated_description_off_span(&self) -> Option<Span> {
         self.description
             .as_ref()
-            .filter(|(d, ..)| d == "off" && !self.description_is_enabled())
+            .filter(|(d, ..)| d == "off" && !self.contains_doc_comment())
             .map(|&(.., span)| span)
     }
 }

--- a/crates/teloxide-macros/src/command_attr.rs
+++ b/crates/teloxide-macros/src/command_attr.rs
@@ -99,7 +99,7 @@ impl CommandAttrs {
                             d.strip_prefix(' ').unwrap_or(&d),
                             attr.sp,
                         );
-                        if is_doc {
+                        if is_doc && matches!(this.description, Some((_, false, _))) {
                             if let Some((_, is_doc, _)) = &mut this.description {
                                 *is_doc = true;
                             }

--- a/crates/teloxide-macros/src/command_attr.rs
+++ b/crates/teloxide-macros/src/command_attr.rs
@@ -79,12 +79,12 @@ impl CommandAttrs {
 
                 fn join_string(
                     opt: &mut Option<(String, Span)>,
-                    new_str: String,
+                    new_str: &str,
                     sp: Span,
                 ) -> Result<()> {
                     match opt {
                         slot @ None => {
-                            *slot = Some((new_str, sp));
+                            *slot = Some((new_str.to_owned(), sp));
                             Ok(())
                         }
                         Some((old_str, _)) => {
@@ -96,7 +96,12 @@ impl CommandAttrs {
 
                 match attr.kind {
                     Prefix(p) => insert(&mut this.prefix, p, attr.sp),
-                    Description(d) => join_string(&mut this.description, d, attr.sp),
+                    Description(d) => join_string(
+                        &mut this.description,
+                        // Sometimes doc comments include a space before them, this removes it
+                        d.strip_prefix(' ').unwrap_or(&d),
+                        attr.sp,
+                    ),
                     RenameRule(r) => insert(&mut this.rename_rule, r, attr.sp),
                     Rename(r) => insert(&mut this.rename, r, attr.sp),
                     ParseWith(p) => insert(&mut this.parser, p, attr.sp),

--- a/crates/teloxide-macros/src/command_attr.rs
+++ b/crates/teloxide-macros/src/command_attr.rs
@@ -56,7 +56,7 @@ impl CommandAttrs {
         use CommandAttrKind::*;
 
         fold_attrs(
-            attributes.iter().cloned(),
+            attributes,
             |attr| is_command_attribute(attr) || is_doc_comment(attr),
             CommandAttr::parse,
             Self {

--- a/crates/teloxide-macros/src/command_attr.rs
+++ b/crates/teloxide-macros/src/command_attr.rs
@@ -99,7 +99,7 @@ impl CommandAttrs {
                             d.strip_prefix(' ').unwrap_or(&d),
                             attr.sp,
                         );
-                        if is_doc && matches!(this.description, Some((_, false, _))) {
+                        if is_doc {
                             if let Some((_, is_doc, _)) = &mut this.description {
                                 *is_doc = true;
                             }

--- a/crates/teloxide-macros/src/command_attr.rs
+++ b/crates/teloxide-macros/src/command_attr.rs
@@ -154,7 +154,7 @@ pub(crate) fn parse_doc_comment(attr: &Attribute) -> Option<String> {
         if let syn::Meta::NameValue(syn::MetaNameValue { lit: syn::Lit::Str(s), .. }) =
             attr.parse_meta().ok()?
         {
-            return Some(s.value().trim().replace(r"\n", "\n"));
+            return Some(s.value().trim().to_owned());
         }
     }
     None

--- a/crates/teloxide-macros/src/command_attr.rs
+++ b/crates/teloxide-macros/src/command_attr.rs
@@ -144,7 +144,7 @@ fn is_command_attribute(a: &Attribute) -> bool {
 
 pub(crate) fn is_doc_comment(a: &Attribute) -> bool {
     match a.path.get_ident() {
-        Some(ident) => ident == "doc",
+        Some(ident) => ident == "doc" && a.tokens.to_string().starts_with("= \""),
         _ => false,
     }
 }

--- a/crates/teloxide-macros/src/command_attr.rs
+++ b/crates/teloxide-macros/src/command_attr.rs
@@ -50,39 +50,35 @@ impl CommandAttrs {
     pub fn from_attributes(attributes: &[Attribute]) -> Result<Self> {
         use CommandAttrKind::*;
         // Convert the `doc` attribute into `command(description = "...")`
-        let attributes = attributes
-            .iter()
-            .map(|attr| {
-                if attr.path.is_ident("doc") {
-                    // Extract the token literal from the doc attribute.
-                    let description = attr
-                        .tokens
-                        .clone()
-                        .into_iter()
-                        .nth(1)
-                        .map(|t| {
-                            // remove first and last quotes only, is expected to be a string literal
-                            let mut s = t.to_string();
-                            s.remove(0);
-                            s.pop();
-                            s.trim().replace(r"\\n", "\n")
-                        })
-                        .unwrap_or_default();
-                    // Convert the doc attribute into a command description attribute.
-                    let sp = attr.span();
-                    let attr = Attribute::parse_outer
-                        .parse2(quote_spanned!(sp => #[command(description = #description)]))
-                        .unwrap();
-                    // SAFETY: `parse_outer` always returns a single attribute.
-                    attr.into_iter().next().unwrap()
-                } else {
-                    attr.clone()
-                }
-            })
-            .collect::<Vec<_>>();
+        let attributes = attributes.iter().map(|attr| {
+            if attr.path.is_ident("doc") {
+                // Extract the token literal from the doc attribute.
+                let description = attr
+                    .tokens
+                    .clone()
+                    .into_iter()
+                    .nth(1)
+                    .map(|t| {
+                        // remove first and last quotes only, is expected to be a string literal
+                        let mut s = t.to_string();
+                        s.remove(0);
+                        s.pop();
+                        s.trim().replace(r"\\n", "\n")
+                    })
+                    .unwrap_or_default();
+                // Convert the doc attribute into a command description attribute.
+                let sp = attr.span();
+                let attr = Attribute::parse_outer
+                    .parse2(quote_spanned!(sp => #[command(description = #description)]))
+                    .unwrap();
+                attr.into_iter().next().unwrap()
+            } else {
+                attr.clone()
+            }
+        });
 
         fold_attrs(
-            attributes.iter(),
+            attributes,
             is_command_attribute,
             CommandAttr::parse,
             Self {

--- a/crates/teloxide-macros/src/command_enum.rs
+++ b/crates/teloxide-macros/src/command_enum.rs
@@ -5,7 +5,8 @@ use crate::{
 
 pub(crate) struct CommandEnum {
     pub prefix: String,
-    pub description: Option<String>,
+    /// The bool is true if the description contains a doc comment
+    pub description: Option<(String, bool)>,
     pub rename_rule: RenameRule,
     pub parser_type: ParserType,
 }
@@ -37,7 +38,7 @@ impl CommandEnum {
 
         Ok(Self {
             prefix: prefix.map(|(p, _)| p).unwrap_or_else(|| "/".to_owned()),
-            description: description.map(|(d, _)| d),
+            description: description.map(|(d, is_doc, _)| (d, is_doc)),
             rename_rule: rename_rule.map(|(rr, _)| rr).unwrap_or(RenameRule::Identity),
             parser_type: parser,
         })

--- a/crates/teloxide/examples/admin.rs
+++ b/crates/teloxide/examples/admin.rs
@@ -12,21 +12,19 @@ use teloxide::{prelude::*, types::ChatPermissions, utils::command::BotCommands};
 // your commands in this format:
 // %GENERAL-DESCRIPTION%
 // %PREFIX%%COMMAND% - %DESCRIPTION%
+
+/// Use commands in format /%command% %num% %unit%
 #[derive(BotCommands, Clone)]
-#[command(
-    rename_rule = "lowercase",
-    description = "Use commands in format /%command% %num% %unit%",
-    parse_with = "split"
-)]
+#[command(rename_rule = "lowercase", parse_with = "split")]
 enum Command {
-    #[command(description = "kick user from chat.")]
+    /// Kick user from chat.
     Kick,
-    #[command(description = "ban user in chat.")]
+    /// Ban user in chat.
     Ban {
         time: u64,
         unit: UnitOfTime,
     },
-    #[command(description = "mute user in chat.")]
+    /// Mute user in chat.
     Mute {
         time: u64,
         unit: UnitOfTime,

--- a/crates/teloxide/examples/buttons.rs
+++ b/crates/teloxide/examples/buttons.rs
@@ -9,12 +9,13 @@ use teloxide::{
     utils::command::BotCommands,
 };
 
+/// These commands are supported:
 #[derive(BotCommands)]
-#[command(rename_rule = "lowercase", description = "These commands are supported:")]
+#[command(rename_rule = "lowercase")]
 enum Command {
-    #[command(description = "Display this text")]
+    /// Display this text
     Help,
-    #[command(description = "Start")]
+    /// Start
     Start,
 }
 

--- a/crates/teloxide/examples/command.rs
+++ b/crates/teloxide/examples/command.rs
@@ -10,14 +10,16 @@ async fn main() {
     Command::repl(bot, answer).await;
 }
 
+/// These commands are supported:
 #[derive(BotCommands, Clone)]
-#[command(rename_rule = "lowercase", description = "These commands are supported:")]
+#[command(rename_rule = "lowercase")]
 enum Command {
-    #[command(description = "display this text.")]
+    /// Display this text.
     Help,
-    #[command(description = "handle a username.")]
+    /// Handle a username.
     Username(String),
-    #[command(description = "handle a username and an age.", parse_with = "split")]
+    /// Handle a username and an age.
+    #[command(parse_with = "split")]
     UsernameAndAge { username: String, age: u8 },
 }
 

--- a/crates/teloxide/examples/db_remember.rs
+++ b/crates/teloxide/examples/db_remember.rs
@@ -21,12 +21,13 @@ pub enum State {
     GotNumber(i32),
 }
 
+/// These commands are supported:
 #[derive(Clone, BotCommands)]
-#[command(rename_rule = "lowercase", description = "These commands are supported:")]
+#[command(rename_rule = "lowercase")]
 pub enum Command {
-    #[command(description = "get your number.")]
+    /// Get your number.
     Get,
-    #[command(description = "reset your number.")]
+    /// Reset your number.
     Reset,
 }
 

--- a/crates/teloxide/examples/dispatching_features.rs
+++ b/crates/teloxide/examples/dispatching_features.rs
@@ -95,21 +95,24 @@ struct ConfigParameters {
     maintainer_username: Option<String>,
 }
 
+/// Simple commands
 #[derive(BotCommands, Clone)]
-#[command(rename_rule = "lowercase", description = "Simple commands")]
+#[command(rename_rule = "lowercase")]
 enum SimpleCommand {
-    #[command(description = "shows this message.")]
+    /// Shows this message.
     Help,
-    #[command(description = "shows maintainer info.")]
+    /// Shows maintainer info.
     Maintainer,
-    #[command(description = "shows your ID.")]
+    /// Shows your ID.
     MyId,
 }
 
+/// Maintainer commands
 #[derive(BotCommands, Clone)]
-#[command(rename_rule = "lowercase", description = "Maintainer commands")]
+#[command(rename_rule = "lowercase")]
 enum MaintainerCommands {
-    #[command(parse_with = "split", description = "generate a number within range")]
+    /// Generate a number within range
+    #[command(parse_with = "split")]
     Rand { from: u64, to: u64 },
 }
 

--- a/crates/teloxide/examples/purchase.rs
+++ b/crates/teloxide/examples/purchase.rs
@@ -32,14 +32,15 @@ pub enum State {
     },
 }
 
+/// These commands are supported:
 #[derive(BotCommands, Clone)]
-#[command(rename_rule = "lowercase", description = "These commands are supported:")]
+#[command(rename_rule = "lowercase")]
 enum Command {
-    #[command(description = "display this text.")]
+    /// Display this text.
     Help,
-    #[command(description = "start the purchase procedure.")]
+    /// Start the purchase procedure.
     Start,
-    #[command(description = "cancel the purchase procedure.")]
+    /// Cancel the purchase procedure.
     Cancel,
 }
 

--- a/crates/teloxide/src/utils/command.rs
+++ b/crates/teloxide/src/utils/command.rs
@@ -169,8 +169,6 @@ pub use teloxide_macros::BotCommands;
 ///
 ///  3. `#[command(description = "description")]` and `/// description`
 /// Give your command a description. It will be shown in the help message.
-/// You can also write doc comment above the command, and it will be used as a
-/// description as well.
 ///
 ///  4. `#[command(parse_with = "parser")]`
 /// Parse arguments of one command with a given parser. `parser` must be a

--- a/crates/teloxide/src/utils/command.rs
+++ b/crates/teloxide/src/utils/command.rs
@@ -169,6 +169,8 @@ pub use teloxide_macros::BotCommands;
 ///
 ///  3. `#[command(description = "description")]` and `/// description`
 /// Give your command a description. It will be shown in the help message.
+/// You can also write doc comment above the command, and it will be used as a
+/// description as well.
 ///
 ///  4. `#[command(parse_with = "parser")]`
 /// Parse arguments of one command with a given parser. `parser` must be a

--- a/crates/teloxide/src/utils/command.rs
+++ b/crates/teloxide/src/utils/command.rs
@@ -90,7 +90,7 @@ pub use teloxide_macros::BotCommands;
 ///  2. `#[command(prefix = "prefix")]`
 /// Change a prefix for all commands (the default is `/`).
 ///
-///  3. `#[command(description = "description")]`
+///  3. `#[command(description = "description")]` and `/// description`
 /// Add a summary description of commands before all commands.
 ///
 ///  4. `#[command(parse_with = "parser")]`
@@ -167,7 +167,7 @@ pub use teloxide_macros::BotCommands;
 /// Rename one command to `name` (literal renaming; do not confuse with
 /// `rename_rule`).
 ///
-///  3. `#[command(description = "description")]`
+///  3. `#[command(description = "description")]` and `/// description`
 /// Give your command a description. It will be shown in the help message.
 ///
 ///  4. `#[command(parse_with = "parser")]`

--- a/crates/teloxide/tests/command.rs
+++ b/crates/teloxide/tests/command.rs
@@ -229,7 +229,6 @@ fn parse_named_fields() {
 #[test]
 #[cfg(feature = "macros")]
 fn descriptions_off() {
-    // FIXME: Remove `off` doc comment when `off` removed.
     #[derive(BotCommands, Debug, PartialEq)]
     #[command(rename_rule = "lowercase")]
     enum DefaultCommands {

--- a/crates/teloxide/tests/command.rs
+++ b/crates/teloxide/tests/command.rs
@@ -283,8 +283,8 @@ fn description_with_doc_attr_and_command() {
 
     assert_eq!(
         DefaultCommands::descriptions().to_string(),
-        "/start — Start command\nStart command\n/help — Help command\nwith new line\n/foo — Foo command\nwith \
-         new line\nFoo command\nwith new line"
+        "/start — Start command\nStart command\n/help — Help command\nwith new line\n/foo — Foo \
+         command\nwith new line\nFoo command\nwith new line"
     );
 }
 

--- a/crates/teloxide/tests/command.rs
+++ b/crates/teloxide/tests/command.rs
@@ -234,7 +234,7 @@ fn descriptions_off() {
     enum DefaultCommands {
         #[command(hide)]
         Start,
-        #[command(hide)]
+        #[command(description = "off")]
         Username,
         /// off
         Help,

--- a/crates/teloxide/tests/command.rs
+++ b/crates/teloxide/tests/command.rs
@@ -252,11 +252,15 @@ fn description_with_doc_attr() {
         Start,
         /// Help command\nwith new line
         Help,
+        /// Foo command
+        /// with new line
+        Foo,
     }
 
     assert_eq!(
         DefaultCommands::descriptions().to_string(),
-        "/start — Start command\n/help — Help command\nwith new line"
+        "/start — Start command\n/help — Help command\nwith new line\n/foo — Foo command\nwith \
+         new line"
     );
 }
 

--- a/crates/teloxide/tests/command.rs
+++ b/crates/teloxide/tests/command.rs
@@ -266,6 +266,30 @@ fn description_with_doc_attr() {
 
 #[test]
 #[cfg(feature = "macros")]
+fn description_with_doc_attr_and_command() {
+    #[derive(BotCommands, Debug, PartialEq)]
+    #[command(rename_rule = "lowercase")]
+    enum DefaultCommands {
+        /// Start command
+        #[command(description = "Start command")]
+        Start,
+        #[command(description = "Help command\nwith new line")]
+        Help,
+        /// Foo command
+        /// with new line
+        #[command(description = "Foo command\nwith new line")]
+        Foo,
+    }
+
+    assert_eq!(
+        DefaultCommands::descriptions().to_string(),
+        "/start — Start command\nStart command\n/help — Help command\nwith new line\n/foo — Foo command\nwith \
+         new line\nFoo command\nwith new line"
+    );
+}
+
+#[test]
+#[cfg(feature = "macros")]
 fn rename_rules() {
     #[derive(BotCommands, Debug, PartialEq)]
     enum DefaultCommands {

--- a/crates/teloxide/tests/command.rs
+++ b/crates/teloxide/tests/command.rs
@@ -244,6 +244,24 @@ fn descriptions_off() {
 
 #[test]
 #[cfg(feature = "macros")]
+fn description_with_doc_attr() {
+    #[derive(BotCommands, Debug, PartialEq)]
+    #[command(rename_rule = "lowercase")]
+    enum DefaultCommands {
+        /// Start command
+        Start,
+        /// Help command\nwith new line
+        Help,
+    }
+
+    assert_eq!(
+        DefaultCommands::descriptions().to_string(),
+        "/start — Start command\n/help — Help command\nwith new line"
+    );
+}
+
+#[test]
+#[cfg(feature = "macros")]
 fn rename_rules() {
     #[derive(BotCommands, Debug, PartialEq)]
     enum DefaultCommands {

--- a/crates/teloxide/tests/command.rs
+++ b/crates/teloxide/tests/command.rs
@@ -229,6 +229,7 @@ fn parse_named_fields() {
 #[test]
 #[cfg(feature = "macros")]
 fn descriptions_off() {
+    // FIXME: Remove `off` doc comment when `off` removed.
     #[derive(BotCommands, Debug, PartialEq)]
     #[command(rename_rule = "lowercase")]
     enum DefaultCommands {
@@ -236,10 +237,11 @@ fn descriptions_off() {
         Start,
         #[command(hide)]
         Username,
+        /// off
         Help,
     }
 
-    assert_eq!(DefaultCommands::descriptions().to_string(), "/help".to_owned());
+    assert_eq!(DefaultCommands::descriptions().to_string(), "/help — off".to_owned());
 }
 
 #[test]

--- a/crates/teloxide/tests/command.rs
+++ b/crates/teloxide/tests/command.rs
@@ -234,6 +234,7 @@ fn descriptions_off() {
     enum DefaultCommands {
         #[command(hide)]
         Start,
+        #[allow(deprecated)]
         #[command(description = "off")]
         Username,
         /// off

--- a/crates/teloxide/tests/command.rs
+++ b/crates/teloxide/tests/command.rs
@@ -250,7 +250,7 @@ fn description_with_doc_attr() {
     enum DefaultCommands {
         /// Start command
         Start,
-        /// Help command\nwith new line
+        /// Help command\nwithout replace the `\n`
         Help,
         /// Foo command
         /// with new line
@@ -259,8 +259,8 @@ fn description_with_doc_attr() {
 
     assert_eq!(
         DefaultCommands::descriptions().to_string(),
-        "/start — Start command\n/help — Help command\nwith new line\n/foo — Foo command\nwith \
-         new line"
+        "/start — Start command\n/help — Help command\\nwithout replace the `\\n`\n/foo — Foo \
+         command\nwith new line"
     );
 }
 

--- a/crates/teloxide/tests/command.rs
+++ b/crates/teloxide/tests/command.rs
@@ -228,13 +228,13 @@ fn parse_named_fields() {
 
 #[test]
 #[cfg(feature = "macros")]
+#[allow(deprecated)]
 fn descriptions_off() {
     #[derive(BotCommands, Debug, PartialEq)]
     #[command(rename_rule = "lowercase")]
     enum DefaultCommands {
         #[command(hide)]
         Start,
-        #[allow(deprecated)]
         #[command(description = "off")]
         Username,
         /// off


### PR DESCRIPTION
<!--
Before making this PR, please ensure the following:

- `CHANGELOG.md` is updated (if necessary).
- Documentation and tests are updated (if necessary).
-->
## Todos:
- [x] Tests
- [x] Update the `CHANGELOG.md`
- [x] Feature documentation

## Changes
Accept the doc comments as help message, and accept multiple doc comment and `#[command(description = "..")]`

## Ref
https://github.com/teloxide/teloxide/issues/635