### PR TITLE
`#[command(hide)]` to hide a command from the help message

### DIFF
--- a/crates/teloxide-macros/CHANGELOG.md
+++ b/crates/teloxide-macros/CHANGELOG.md
@@ -10,6 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix `split` parser for tuple variants with len < 2 ([issue #834](https://github.com/teloxide/teloxide/issues/834))
 
+### Added
+
+- Now you can use `#[command(hide)]` to hide a command from the help message ([PR #862](https://github.com/teloxide/teloxide/pull/862))
+
+### Deprecated
+
+- `off` in `#[command(description = "off")]` is deprecated in favour of `#[command(hide)]`
+
 ## 0.7.1 - 2023-01-17
 
 ### Fixed

--- a/crates/teloxide-macros/src/command.rs
+++ b/crates/teloxide-macros/src/command.rs
@@ -49,7 +49,6 @@ impl Command {
         let prefix = prefix.map(|(p, _)| p).unwrap_or_else(|| global_options.prefix.clone());
         let description = description.map(|(d, _)| d);
         let parser = parser.map(|(p, _)| p).unwrap_or_else(|| global_options.parser_type.clone());
-
         Ok(Self { prefix, description, parser, name, hidden: hide.is_some() })
     }
 

--- a/crates/teloxide-macros/src/command.rs
+++ b/crates/teloxide-macros/src/command.rs
@@ -59,6 +59,7 @@ impl Command {
     }
 
     pub(crate) fn description_is_enabled(&self) -> bool {
+        // FIXME: remove the first, `== "off"`, check eventually
         self.description != Some("off".to_owned()) && !self.hidden
     }
 }

--- a/crates/teloxide-macros/src/command.rs
+++ b/crates/teloxide-macros/src/command.rs
@@ -12,6 +12,8 @@ pub(crate) struct Command {
     pub name: String,
     /// Parser for arguments of this command.
     pub parser: ParserType,
+    /// Whether the command is hidden from the help message.
+    pub hidden: bool,
 }
 
 impl Command {
@@ -29,6 +31,7 @@ impl Command {
             parser,
             // FIXME: error on/do not ignore separator
             separator: _,
+            hide,
         } = attrs;
 
         let name = match (rename, rename_rule) {
@@ -47,7 +50,7 @@ impl Command {
         let description = description.map(|(d, _)| d);
         let parser = parser.map(|(p, _)| p).unwrap_or_else(|| global_options.parser_type.clone());
 
-        Ok(Self { prefix, description, parser, name })
+        Ok(Self { prefix, description, parser, name, hidden: hide.is_some() })
     }
 
     pub fn get_prefixed_command(&self) -> String {
@@ -56,6 +59,6 @@ impl Command {
     }
 
     pub(crate) fn description_is_enabled(&self) -> bool {
-        self.description != Some("off".to_owned())
+        self.description != Some("off".to_owned()) && !self.hidden
     }
 }

--- a/crates/teloxide-macros/src/command.rs
+++ b/crates/teloxide-macros/src/command.rs
@@ -49,7 +49,9 @@ impl Command {
         let prefix = prefix.map(|(p, _)| p).unwrap_or_else(|| global_options.prefix.clone());
         let description = description.map(|(d, _)| d);
         let parser = parser.map(|(p, _)| p).unwrap_or_else(|| global_options.parser_type.clone());
-        Ok(Self { prefix, description, parser, name, hidden: hide.is_some() })
+        let hidden = hide.is_some();
+
+        Ok(Self { prefix, description, parser, name, hidden })
     }
 
     pub fn get_prefixed_command(&self) -> String {

--- a/crates/teloxide-macros/src/command_attr.rs
+++ b/crates/teloxide-macros/src/command_attr.rs
@@ -17,6 +17,7 @@ pub(crate) struct CommandAttrs {
     pub rename: Option<(String, Span)>,
     pub parser: Option<(ParserType, Span)>,
     pub separator: Option<(String, Span)>,
+    pub hide: Option<((), Span)>,
 }
 
 /// A single k/v attribute for `BotCommands` derive macro.
@@ -41,6 +42,7 @@ enum CommandAttrKind {
     Rename(String),
     ParseWith(ParserType),
     Separator(String),
+    Hide,
 }
 
 impl CommandAttrs {
@@ -58,6 +60,7 @@ impl CommandAttrs {
                 rename: None,
                 parser: None,
                 separator: None,
+                hide: None,
             },
             |mut this, attr| {
                 fn insert<T>(opt: &mut Option<(T, Span)>, x: T, sp: Span) -> Result<()> {
@@ -77,6 +80,7 @@ impl CommandAttrs {
                     Rename(r) => insert(&mut this.rename, r, attr.sp),
                     ParseWith(p) => insert(&mut this.parser, p, attr.sp),
                     Separator(s) => insert(&mut this.separator, s, attr.sp),
+                    Hide => insert(&mut this.hide, (), attr.sp),
                 }?;
 
                 Ok(this)
@@ -100,10 +104,11 @@ impl CommandAttr {
             "rename" => Rename(value.expect_string()?),
             "parse_with" => ParseWith(ParserType::parse(value)?),
             "separator" => Separator(value.expect_string()?),
+            "hide" => Hide,
             _ => {
                 return Err(compile_error_at(
                     "unexpected attribute name (expected one of `prefix`, `description`, \
-                     `rename`, `parse_with` and `separator`",
+                     `rename`, `parse_with`, `separator` and `hide`",
                     key.span(),
                 ))
             }

--- a/crates/teloxide-macros/src/command_enum.rs
+++ b/crates/teloxide-macros/src/command_enum.rs
@@ -13,11 +13,17 @@ pub(crate) struct CommandEnum {
 impl CommandEnum {
     pub fn from_attributes(attributes: &[syn::Attribute]) -> Result<Self> {
         let attrs = CommandAttrs::from_attributes(attributes)?;
-        let CommandAttrs { prefix, description, rename_rule, rename, parser, separator } = attrs;
+        let CommandAttrs { prefix, description, rename_rule, rename, parser, separator, hide } =
+            attrs;
 
         if let Some((_rename, sp)) = rename {
             return Err(compile_error_at(
                 "`rename` attribute can only be applied to enums *variants*",
+                sp,
+            ));
+        } else if let Some((_hide, sp)) = hide {
+            return Err(compile_error_at(
+                "`hide` attribute can only be applied to enums *variants*",
                 sp,
             ));
         }

--- a/crates/teloxide/src/utils/command.rs
+++ b/crates/teloxide/src/utils/command.rs
@@ -177,7 +177,7 @@ pub use teloxide_macros::BotCommands;
 ///
 ///  5. `#[command(hide)]`
 /// Hide a command from the help message. It will still be parsed.
-/// 
+///
 /// ## Example
 /// ```
 /// # #[cfg(feature = "macros")] {

--- a/crates/teloxide/src/utils/command.rs
+++ b/crates/teloxide/src/utils/command.rs
@@ -168,14 +168,16 @@ pub use teloxide_macros::BotCommands;
 /// `rename_rule`).
 ///
 ///  3. `#[command(description = "description")]`
-/// Give your command a description. Write `"off"` for `"description"` to hide a
-/// command.
+/// Give your command a description. It will be shown in the help message.
 ///
 ///  4. `#[command(parse_with = "parser")]`
 /// Parse arguments of one command with a given parser. `parser` must be a
 /// function of the signature `fn(String) -> Result<Tuple, ParseError>`, where
 /// `Tuple` corresponds to the variant's arguments.
 ///
+///  5. `#[command(hide)]`
+/// Hide a command from the help message. It will still be parsed.
+/// 
 /// ## Example
 /// ```
 /// # #[cfg(feature = "macros")] {

--- a/crates/teloxide/tests/command.rs
+++ b/crates/teloxide/tests/command.rs
@@ -232,8 +232,10 @@ fn descriptions_off() {
     #[derive(BotCommands, Debug, PartialEq)]
     #[command(rename_rule = "lowercase")]
     enum DefaultCommands {
-        #[command(description = "off")]
+        #[command(hide)]
         Start,
+        #[command(hide)]
+        Username,
         Help,
     }
 


### PR DESCRIPTION
<!--
Before making this PR, please ensure the following:

- `CHANGELOG.md` is updated (if necessary).
- Documentation and tests are updated (if necessary).
-->
## Todos:
- [x] Update the `CHANGELOG.md`
- [x] Tests
- [x] Feature documentation
- [x] Deprecate `#[command(description = "off")]`

## Ref
https://github.com/teloxide/teloxide/issues/635