### PR TITLE
Telegram struct serializing similar to original (skip empty/defaults)

### DIFF
--- a/crates/teloxide-core/src/types/bot_command.rs
+++ b/crates/teloxide-core/src/types/bot_command.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 /// This object represents a bot command.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#botcommand).
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct BotCommand {
     /// Text of the command, 1-32 characters.

--- a/crates/teloxide-core/src/types/callback_game.rs
+++ b/crates/teloxide-core/src/types/callback_game.rs
@@ -8,5 +8,6 @@ use serde::{Deserialize, Serialize};
 /// Use [@Botfather] to set up your game.
 ///
 /// [@Botfather]:  https://t.me/botfather
+#[serde_with_macros::skip_serializing_none]
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct CallbackGame;

--- a/crates/teloxide-core/src/types/chat_administrator_rights.rs
+++ b/crates/teloxide-core/src/types/chat_administrator_rights.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 /// Represents the rights of an administrator in a chat.
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct ChatAdministratorRights {
     /// `true`, if the user's presence in the chat is hidden

--- a/crates/teloxide-core/src/types/chat_invite_link.rs
+++ b/crates/teloxide-core/src/types/chat_invite_link.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::types::User;
 
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct ChatInviteLink {
     /// The invite link. If the link was created by another chat administrator,

--- a/crates/teloxide-core/src/types/chat_join_request.rs
+++ b/crates/teloxide-core/src/types/chat_join_request.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use crate::types::{Chat, ChatInviteLink, User};
 
 /// Represents a join request sent to a chat.
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ChatJoinRequest {
     /// Chat to which the request was sent

--- a/crates/teloxide-core/src/types/chat_location.rs
+++ b/crates/teloxide-core/src/types/chat_location.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 use crate::types::Location;
 
 /// Represents a location to which a chat is connected.
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ChatLocation {
     /// The location to which the supergroup is connected. Can't be a live

--- a/crates/teloxide-core/src/types/chat_member.rs
+++ b/crates/teloxide-core/src/types/chat_member.rs
@@ -7,6 +7,7 @@ use crate::types::{UntilDate, User};
 /// This object contains information about one member of the chat.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#chatmember).
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct ChatMember {
     /// Information about the user.
@@ -32,6 +33,7 @@ pub enum ChatMemberKind {
 }
 
 /// Owner of the group. This struct is part of the [`ChatMemberKind`] enum.
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct Owner {
     /// Custom title for this user.
@@ -43,6 +45,7 @@ pub struct Owner {
 
 /// Administrator of the group. This struct is part of the [`ChatMemberKind`]
 /// enum.
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct Administrator {
     /// Custom title for this user.
@@ -104,6 +107,7 @@ pub struct Administrator {
 
 /// User, restricted in the group. This struct is part of the [`ChatMemberKind`]
 /// enum.
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct Restricted {
     /// Date when restrictions will be lifted for this user.
@@ -148,6 +152,7 @@ pub struct Restricted {
 
 /// User that was banned in the chat and can't return to it or view chat
 /// messages. This struct is part of the [`ChatMemberKind`] enum.
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct Banned {
     /// Date when restrictions will be lifted for this user.

--- a/crates/teloxide-core/src/types/chat_member_updated.rs
+++ b/crates/teloxide-core/src/types/chat_member_updated.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::types::{Chat, ChatInviteLink, ChatMember, User};
 
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ChatMemberUpdated {
     /// Chat the user belongs to

--- a/crates/teloxide-core/src/types/chat_photo.rs
+++ b/crates/teloxide-core/src/types/chat_photo.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 /// This object represents a chat photo.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#chatphoto).
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct ChatPhoto {
     /// A file identifier of small (160x160) chat photo. This file_id can be

--- a/crates/teloxide-core/src/types/encrypted_passport_element.rs
+++ b/crates/teloxide-core/src/types/encrypted_passport_element.rs
@@ -6,6 +6,7 @@ use super::PassportFile;
 /// shared with the bot by the user.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#encryptedpassportelement).
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct EncryptedPassportElement {
     /// Base64-encoded element hash for using in

--- a/crates/teloxide-core/src/types/game_high_score.rs
+++ b/crates/teloxide-core/src/types/game_high_score.rs
@@ -5,6 +5,7 @@ use crate::types::user::User;
 /// This object represents one row of the high scores table for a game.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#gamehighscore).
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct GameHighScore {
     /// Position in high score table for the game.

--- a/crates/teloxide-core/src/types/inline_keyboard_button.rs
+++ b/crates/teloxide-core/src/types/inline_keyboard_button.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 /// This object represents one button of an inline keyboard.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#inlinekeyboardbutton).
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct InlineKeyboardButton {
     /// Label text on the button.

--- a/crates/teloxide-core/src/types/inline_keyboard_markup.rs
+++ b/crates/teloxide-core/src/types/inline_keyboard_markup.rs
@@ -11,6 +11,7 @@ use crate::types::InlineKeyboardButton;
 /// [The official docs](https://core.telegram.org/bots/api#inlinekeyboardmarkup).
 ///
 /// [inline keyboard]: https://core.telegram.org/bots#inline-keyboards-and-on-the-fly-updating
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, Default)]
 pub struct InlineKeyboardMarkup {
     /// Array of button rows, each represented by an array of

--- a/crates/teloxide-core/src/types/input_file.rs
+++ b/crates/teloxide-core/src/types/input_file.rs
@@ -31,7 +31,6 @@ use crate::types::InputSticker;
 /// This object represents the contents of a file to be uploaded.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#inputfile).
-#[serde_with_macros::skip_serializing_none]
 #[derive(Debug, Clone)]
 pub struct InputFile {
     id: OnceCell<Arc<str>>,

--- a/crates/teloxide-core/src/types/input_file.rs
+++ b/crates/teloxide-core/src/types/input_file.rs
@@ -31,6 +31,7 @@ use crate::types::InputSticker;
 /// This object represents the contents of a file to be uploaded.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#inputfile).
+#[serde_with_macros::skip_serializing_none]
 #[derive(Debug, Clone)]
 pub struct InputFile {
     id: OnceCell<Arc<str>>,

--- a/crates/teloxide-core/src/types/invoice.rs
+++ b/crates/teloxide-core/src/types/invoice.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 /// This object contains basic information about an invoice.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#invoice).
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct Invoice {
     /// Product name.

--- a/crates/teloxide-core/src/types/label_price.rs
+++ b/crates/teloxide-core/src/types/label_price.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 /// This object represents a portion of the price for goods or services.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#labeledprice).
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct LabeledPrice {
     /// Portion label.

--- a/crates/teloxide-core/src/types/location.rs
+++ b/crates/teloxide-core/src/types/location.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 /// This object represents a point on the map.
+#[serde_with_macros::skip_serializing_none]
 #[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Location {
     /// Longitude as defined by sender.

--- a/crates/teloxide-core/src/types/mask_position.rs
+++ b/crates/teloxide-core/src/types/mask_position.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 /// default.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#maskposition).
+#[serde_with_macros::skip_serializing_none]
 #[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MaskPosition {
     /// The part of the face relative to which the mask should be placed. One

--- a/crates/teloxide-core/src/types/me.rs
+++ b/crates/teloxide-core/src/types/me.rs
@@ -7,6 +7,7 @@ use crate::types::User;
 /// Returned only in [`GetMe`].
 ///
 /// [`GetMe`]: crate::payloads::GetMe
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct Me {
     #[serde(flatten)]

--- a/crates/teloxide-core/src/types/message.rs
+++ b/crates/teloxide-core/src/types/message.rs
@@ -365,7 +365,7 @@ pub struct MediaAnimation {
 
     /// For messages with a caption, special entities like usernames, URLs,
     /// bot commands, etc. that appear in the caption.
-    #[serde(default = "Vec::new", skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub caption_entities: Vec<MessageEntity>,
 
     /// `true`, if the message media is covered by a spoiler animation.
@@ -385,7 +385,7 @@ pub struct MediaAudio {
 
     /// For messages with a caption, special entities like usernames, URLs,
     /// bot commands, etc. that appear in the caption.
-    #[serde(default = "Vec::new", skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub caption_entities: Vec<MessageEntity>,
 
     /// The unique identifier of a media message group this message belongs
@@ -411,7 +411,7 @@ pub struct MediaDocument {
 
     /// For messages with a caption, special entities like usernames, URLs,
     /// bot commands, etc. that appear in the caption.
-    #[serde(default = "Vec::new", skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub caption_entities: Vec<MessageEntity>,
 
     /// The unique identifier of a media message group this message belongs
@@ -447,7 +447,7 @@ pub struct MediaPhoto {
 
     /// For messages with a caption, special entities like usernames, URLs,
     /// bot commands, etc. that appear in the caption.
-    #[serde(default = "Vec::new", skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub caption_entities: Vec<MessageEntity>,
 
     /// `true`, if the message media is covered by a spoiler animation.
@@ -482,7 +482,7 @@ pub struct MediaText {
 
     /// For text messages, special entities like usernames, URLs, bot
     /// commands, etc. that appear in the text.
-    #[serde(default = "Vec::new", skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub entities: Vec<MessageEntity>,
 }
 
@@ -497,7 +497,7 @@ pub struct MediaVideo {
 
     /// For messages with a caption, special entities like usernames, URLs,
     /// bot commands, etc. that appear in the caption.
-    #[serde(default = "Vec::new", skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub caption_entities: Vec<MessageEntity>,
 
     /// `true`, if the message media is covered by a spoiler animation.
@@ -529,7 +529,7 @@ pub struct MediaVoice {
 
     /// For messages with a caption, special entities like usernames, URLs,
     /// bot commands, etc. that appear in the caption.
-    #[serde(default = "Vec::new", skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub caption_entities: Vec<MessageEntity>,
 }
 

--- a/crates/teloxide-core/src/types/message.rs
+++ b/crates/teloxide-core/src/types/message.rs
@@ -120,16 +120,16 @@ pub struct MessageCommon {
     /// `true`, if the message is sent to a forum topic.
     // FIXME: `is_topic_message` is included even in service messages, like ForumTopicCreated.
     //        more this to `Message`
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub is_topic_message: bool,
 
     /// `true`, if the message is a channel post that was automatically
     /// forwarded to the connected discussion group.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub is_automatic_forward: bool,
 
     /// `true`, if the message can't be forwarded.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub has_protected_content: bool,
 }
 

--- a/crates/teloxide-core/src/types/message.rs
+++ b/crates/teloxide-core/src/types/message.rs
@@ -365,7 +365,7 @@ pub struct MediaAnimation {
 
     /// For messages with a caption, special entities like usernames, URLs,
     /// bot commands, etc. that appear in the caption.
-    #[serde(default = "Vec::new")]
+    #[serde(skip_serializing_if = "Vec::is_empty", default = "Vec::new")]
     pub caption_entities: Vec<MessageEntity>,
 
     /// `true`, if the message media is covered by a spoiler animation.
@@ -385,7 +385,7 @@ pub struct MediaAudio {
 
     /// For messages with a caption, special entities like usernames, URLs,
     /// bot commands, etc. that appear in the caption.
-    #[serde(default = "Vec::new")]
+    #[serde(skip_serializing_if = "Vec::is_empty", default = "Vec::new")]
     pub caption_entities: Vec<MessageEntity>,
 
     /// The unique identifier of a media message group this message belongs
@@ -411,7 +411,7 @@ pub struct MediaDocument {
 
     /// For messages with a caption, special entities like usernames, URLs,
     /// bot commands, etc. that appear in the caption.
-    #[serde(default)]
+    #[serde(skip_serializing_if = "Vec::is_empty", default = "Vec::new")]
     pub caption_entities: Vec<MessageEntity>,
 
     /// The unique identifier of a media message group this message belongs
@@ -447,7 +447,7 @@ pub struct MediaPhoto {
 
     /// For messages with a caption, special entities like usernames, URLs,
     /// bot commands, etc. that appear in the caption.
-    #[serde(default = "Vec::new")]
+    #[serde(skip_serializing_if = "Vec::is_empty", default = "Vec::new")]
     pub caption_entities: Vec<MessageEntity>,
 
     /// `true`, if the message media is covered by a spoiler animation.
@@ -482,7 +482,7 @@ pub struct MediaText {
 
     /// For text messages, special entities like usernames, URLs, bot
     /// commands, etc. that appear in the text.
-    #[serde(default = "Vec::new")]
+    #[serde(skip_serializing_if = "Vec::is_empty", default = "Vec::new")]
     pub entities: Vec<MessageEntity>,
 }
 
@@ -497,7 +497,7 @@ pub struct MediaVideo {
 
     /// For messages with a caption, special entities like usernames, URLs,
     /// bot commands, etc. that appear in the caption.
-    #[serde(default = "Vec::new")]
+    #[serde(skip_serializing_if = "Vec::is_empty", default = "Vec::new")]
     pub caption_entities: Vec<MessageEntity>,
 
     /// `true`, if the message media is covered by a spoiler animation.
@@ -529,7 +529,7 @@ pub struct MediaVoice {
 
     /// For messages with a caption, special entities like usernames, URLs,
     /// bot commands, etc. that appear in the caption.
-    #[serde(default = "Vec::new")]
+    #[serde(skip_serializing_if = "Vec::is_empty", default = "Vec::new")]
     pub caption_entities: Vec<MessageEntity>,
 }
 

--- a/crates/teloxide-core/src/types/message.rs
+++ b/crates/teloxide-core/src/types/message.rs
@@ -17,6 +17,7 @@ use crate::types::{
 /// This object represents a message.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#message).
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Message {
     /// Unique message identifier inside this chat.
@@ -132,6 +133,7 @@ pub struct MessageCommon {
     pub has_protected_content: bool,
 }
 
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MessageNewChatMembers {
     /// New members that were added to the group or supergroup and
@@ -140,6 +142,7 @@ pub struct MessageNewChatMembers {
     pub new_chat_members: Vec<User>,
 }
 
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MessageLeftChatMember {
     /// A member was removed from the group, information about them (this
@@ -147,30 +150,35 @@ pub struct MessageLeftChatMember {
     pub left_chat_member: User,
 }
 
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MessageNewChatTitle {
     /// A chat title was changed to this value.
     pub new_chat_title: String,
 }
 
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MessageNewChatPhoto {
     /// A chat photo was change to this value.
     pub new_chat_photo: Vec<PhotoSize>,
 }
 
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct MessageDeleteChatPhoto {
     /// Service message: the chat photo was deleted.
     pub delete_chat_photo: True,
 }
 
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct MessageGroupChatCreated {
     /// Service message: the group has been created.
     pub group_chat_created: True,
 }
 
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct MessageSupergroupChatCreated {
     /// Service message: the supergroup has been created. This field can‘t
@@ -181,6 +189,7 @@ pub struct MessageSupergroupChatCreated {
     pub supergroup_chat_created: True,
 }
 
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct MessageChannelChatCreated {
     /// Service message: the channel has been created. This field can‘t be
@@ -191,6 +200,7 @@ pub struct MessageChannelChatCreated {
     pub channel_chat_created: True,
 }
 
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MessageMessageAutoDeleteTimerChanged {
     /// Service message: auto-delete timer settings changed in the chat.
@@ -225,6 +235,7 @@ pub enum ChatMigration {
     },
 }
 
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MessagePinned {
     /// Specified message was pinned. Note that the Message object in this
@@ -234,6 +245,7 @@ pub struct MessagePinned {
     pub pinned: Box<Message>,
 }
 
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MessageInvoice {
     /// Message is an invoice for a [payment], information about the
@@ -244,6 +256,7 @@ pub struct MessageInvoice {
     pub invoice: Invoice,
 }
 
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MessageSuccessfulPayment {
     /// Message is a service message about a successful payment,
@@ -253,6 +266,7 @@ pub struct MessageSuccessfulPayment {
     pub successful_payment: SuccessfulPayment,
 }
 
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MessageConnectedWebsite {
     /// The domain name of the website on which the user has logged in.
@@ -262,6 +276,7 @@ pub struct MessageConnectedWebsite {
     pub connected_website: String,
 }
 
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MessagePassportData {
     /// Telegram Passport data.
@@ -269,6 +284,7 @@ pub struct MessagePassportData {
 }
 
 /// Information about forwarded message.
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Forward {
     /// Date the original message was sent in Unix time.
@@ -336,6 +352,7 @@ pub enum MediaKind {
     Migration(ChatMigration),
 }
 
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MediaAnimation {
     /// Message is an animation, information about the animation. For
@@ -376,6 +393,7 @@ pub struct MediaAudio {
     pub media_group_id: Option<String>,
 }
 
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MediaContact {
     /// Message is a shared contact, information about the contact.
@@ -401,6 +419,7 @@ pub struct MediaDocument {
     pub media_group_id: Option<String>,
 }
 
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MediaGame {
     /// Message is a game, information about the game. [More
@@ -410,6 +429,7 @@ pub struct MediaGame {
     pub game: Game,
 }
 
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MediaLocation {
     /// Message is a shared location, information about the location.
@@ -439,18 +459,21 @@ pub struct MediaPhoto {
     pub media_group_id: Option<String>,
 }
 
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MediaPoll {
     /// Message is a native poll, information about the poll.
     pub poll: Poll,
 }
 
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MediaSticker {
     /// Message is a sticker, information about the sticker.
     pub sticker: Sticker,
 }
 
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MediaText {
     /// For text messages, the actual UTF-8 text of the message, 0-4096
@@ -486,6 +509,7 @@ pub struct MediaVideo {
     pub media_group_id: Option<String>,
 }
 
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MediaVideoNote {
     /// Message is a [video note], information about the video message.
@@ -516,12 +540,14 @@ pub struct MediaVenue {
     // Note: for backward compatibility telegram also sends `location` field, but we ignore it
 }
 
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MessageDice {
     /// Message is a dice with random value from 1 to 6.
     pub dice: Dice,
 }
 
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MessageProximityAlertTriggered {
     /// Service message. A user in the chat triggered another user's proximity
@@ -529,6 +555,7 @@ pub struct MessageProximityAlertTriggered {
     pub proximity_alert_triggered: ProximityAlertTriggered,
 }
 
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MessageWriteAccessAllowed {
     /// Service message: the user allowed the bot added to the attachment menu
@@ -536,66 +563,77 @@ pub struct MessageWriteAccessAllowed {
     pub write_access_allowed: WriteAccessAllowed,
 }
 
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MessageForumTopicCreated {
     /// Service message: forum topic created.
     pub forum_topic_created: ForumTopicCreated,
 }
 
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MessageForumTopicEdited {
     /// Service message: forum topic edited.
     pub forum_topic_edited: ForumTopicEdited,
 }
 
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MessageForumTopicClosed {
     /// Service message: forum topic closed.
     pub forum_topic_closed: ForumTopicClosed,
 }
 
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MessageForumTopicReopened {
     /// Service message: forum topic reopened.
     pub forum_topic_reopened: ForumTopicReopened,
 }
 
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MessageGeneralForumTopicHidden {
     /// Service message: the 'General' forum topic hidden.
     pub general_forum_topic_hidden: GeneralForumTopicHidden,
 }
 
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MessageGeneralForumTopicUnhidden {
     /// Service message: the 'General' forum topic unhidden.
     pub general_forum_topic_unhidden: GeneralForumTopicUnhidden,
 }
 
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MessageVideoChatScheduled {
     /// Service message: video chat scheduled
     pub video_chat_scheduled: VideoChatScheduled,
 }
 
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MessageVideoChatStarted {
     /// Service message: video chat started.
     pub video_chat_started: VideoChatStarted,
 }
 
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MessageVideoChatEnded {
     /// Service message: video chat ended.
     pub video_chat_ended: VideoChatEnded,
 }
 
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MessageVideoChatParticipantsInvited {
     /// Service message: new participants invited to a video chat.
     pub video_chat_participants_invited: VideoChatParticipantsInvited,
 }
 
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MessageWebAppData {
     /// Service message: data sent by a Web App.

--- a/crates/teloxide-core/src/types/message.rs
+++ b/crates/teloxide-core/src/types/message.rs
@@ -365,7 +365,7 @@ pub struct MediaAnimation {
 
     /// For messages with a caption, special entities like usernames, URLs,
     /// bot commands, etc. that appear in the caption.
-    #[serde(skip_serializing_if = "Vec::is_empty", default = "Vec::new")]
+    #[serde(default = "Vec::new", skip_serializing_if = "Vec::is_empty")]
     pub caption_entities: Vec<MessageEntity>,
 
     /// `true`, if the message media is covered by a spoiler animation.
@@ -385,7 +385,7 @@ pub struct MediaAudio {
 
     /// For messages with a caption, special entities like usernames, URLs,
     /// bot commands, etc. that appear in the caption.
-    #[serde(skip_serializing_if = "Vec::is_empty", default = "Vec::new")]
+    #[serde(default = "Vec::new", skip_serializing_if = "Vec::is_empty")]
     pub caption_entities: Vec<MessageEntity>,
 
     /// The unique identifier of a media message group this message belongs
@@ -411,7 +411,7 @@ pub struct MediaDocument {
 
     /// For messages with a caption, special entities like usernames, URLs,
     /// bot commands, etc. that appear in the caption.
-    #[serde(skip_serializing_if = "Vec::is_empty", default = "Vec::new")]
+    #[serde(default = "Vec::new", skip_serializing_if = "Vec::is_empty")]
     pub caption_entities: Vec<MessageEntity>,
 
     /// The unique identifier of a media message group this message belongs
@@ -447,7 +447,7 @@ pub struct MediaPhoto {
 
     /// For messages with a caption, special entities like usernames, URLs,
     /// bot commands, etc. that appear in the caption.
-    #[serde(skip_serializing_if = "Vec::is_empty", default = "Vec::new")]
+    #[serde(default = "Vec::new", skip_serializing_if = "Vec::is_empty")]
     pub caption_entities: Vec<MessageEntity>,
 
     /// `true`, if the message media is covered by a spoiler animation.
@@ -482,7 +482,7 @@ pub struct MediaText {
 
     /// For text messages, special entities like usernames, URLs, bot
     /// commands, etc. that appear in the text.
-    #[serde(skip_serializing_if = "Vec::is_empty", default = "Vec::new")]
+    #[serde(default = "Vec::new", skip_serializing_if = "Vec::is_empty")]
     pub entities: Vec<MessageEntity>,
 }
 
@@ -497,7 +497,7 @@ pub struct MediaVideo {
 
     /// For messages with a caption, special entities like usernames, URLs,
     /// bot commands, etc. that appear in the caption.
-    #[serde(skip_serializing_if = "Vec::is_empty", default = "Vec::new")]
+    #[serde(default = "Vec::new", skip_serializing_if = "Vec::is_empty")]
     pub caption_entities: Vec<MessageEntity>,
 
     /// `true`, if the message media is covered by a spoiler animation.
@@ -529,7 +529,7 @@ pub struct MediaVoice {
 
     /// For messages with a caption, special entities like usernames, URLs,
     /// bot commands, etc. that appear in the caption.
-    #[serde(skip_serializing_if = "Vec::is_empty", default = "Vec::new")]
+    #[serde(default = "Vec::new", skip_serializing_if = "Vec::is_empty")]
     pub caption_entities: Vec<MessageEntity>,
 }
 

--- a/crates/teloxide-core/src/types/message_auto_delete_timer_changed.rs
+++ b/crates/teloxide-core/src/types/message_auto_delete_timer_changed.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 
 /// This object represents a service message about a change in auto-delete timer
 /// settings.
+#[serde_with_macros::skip_serializing_none]
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct MessageAutoDeleteTimerChanged {
     /// New auto-delete time for messages in the chat

--- a/crates/teloxide-core/src/types/message_entity.rs
+++ b/crates/teloxide-core/src/types/message_entity.rs
@@ -9,6 +9,7 @@ use crate::types::{User, UserId};
 /// For example, hashtags, usernames, URLs, etc.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#messageentity).
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct MessageEntity {
     #[serde(flatten)]

--- a/crates/teloxide-core/src/types/order_info.rs
+++ b/crates/teloxide-core/src/types/order_info.rs
@@ -5,6 +5,7 @@ use crate::types::ShippingAddress;
 /// This object represents information about an order.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#orderinfo).
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, Default)]
 pub struct OrderInfo {
     /// User's name.

--- a/crates/teloxide-core/src/types/passport_data.rs
+++ b/crates/teloxide-core/src/types/passport_data.rs
@@ -6,6 +6,7 @@ use super::{EncryptedCredentials, EncryptedPassportElement};
 /// user.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#passportdata).
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct PassportData {
     /// Array with information about documents and other Telegram Passport

--- a/crates/teloxide-core/src/types/passport_element_error.rs
+++ b/crates/teloxide-core/src/types/passport_element_error.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 /// submitted that should be resolved by the user.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#passportelementerror).
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize)]
 pub struct PassportElementError {
     /// Error message.
@@ -73,6 +74,7 @@ pub enum PassportElementErrorKind {
 /// The error is considered resolved when the field's value changes.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#passportelementerrordatafield).
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize)]
 pub struct PassportElementErrorDataField {
     /// The section of the user's Telegram Passport which has the error.
@@ -127,6 +129,7 @@ impl PassportElementErrorDataField {
 /// document changes.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#passportelementerrorfrontside).
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize)]
 pub struct PassportElementErrorFrontSide {
     /// The section of the user's Telegram Passport which has the issue.
@@ -166,6 +169,7 @@ impl PassportElementErrorFrontSide {
 /// document changes.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#passportelementerrorreverseside).
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize)]
 pub struct PassportElementErrorReverseSide {
     /// The section of the user's Telegram Passport which has the issue.
@@ -204,6 +208,7 @@ impl PassportElementErrorReverseSide {
 /// The error is considered resolved when the file with the selfie changes.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#passportelementerrorselfie).
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize)]
 pub struct PassportElementErrorSelfie {
     /// The section of the user's Telegram Passport which has the issue.
@@ -242,6 +247,7 @@ impl PassportElementErrorSelfie {
 /// changes.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#passportelementerrorfile).
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize)]
 pub struct PassportElementErrorFile {
     /// The section of the user's Telegram Passport which has the issue.
@@ -280,6 +286,7 @@ impl PassportElementErrorFile {
 /// changes.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#passportelementerrorfiles).
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize)]
 pub struct PassportElementErrorFiles {
     /// The section of the user's Telegram Passport which has the issue.
@@ -318,6 +325,7 @@ impl PassportElementErrorFiles {
 /// The error is considered resolved when the file changes.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#passportelementerrortranslationfile).
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize)]
 pub struct PassportElementErrorTranslationFile {
     /// Type of element of the user's Telegram Passport which has the
@@ -357,6 +365,7 @@ impl PassportElementErrorTranslationFile {
 /// change.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#passportelementerrortranslationfiles).
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize)]
 pub struct PassportElementErrorTranslationFiles {
     /// Type of element of the user's Telegram Passport which has the issue
@@ -394,6 +403,7 @@ impl PassportElementErrorTranslationFiles {
 /// The error is considered resolved when new data is added.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#passportelementerrorunspecified).
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize)]
 pub struct PassportElementErrorUnspecified {
     /// Type of element of the user's Telegram Passport which has the

--- a/crates/teloxide-core/src/types/passport_file.rs
+++ b/crates/teloxide-core/src/types/passport_file.rs
@@ -10,6 +10,7 @@ use crate::types::FileMeta;
 /// don't exceed 10MB.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#passportfile).
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, Deref)]
 pub struct PassportFile {
     /// Metadata of the passport file.

--- a/crates/teloxide-core/src/types/poll_answer.rs
+++ b/crates/teloxide-core/src/types/poll_answer.rs
@@ -1,6 +1,7 @@
 use crate::types::User;
 use serde::{Deserialize, Serialize};
 
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct PollAnswer {
     /// Unique poll identifier.

--- a/crates/teloxide-core/src/types/proximity_alert_triggered.rs
+++ b/crates/teloxide-core/src/types/proximity_alert_triggered.rs
@@ -4,6 +4,7 @@ use crate::types::User;
 
 /// This object represents the content of a service message, sent whenever a
 /// user in the chat triggers a proximity alert set by another user.
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct ProximityAlertTriggered {
     /// User that triggered the alert.

--- a/crates/teloxide-core/src/types/shipping_address.rs
+++ b/crates/teloxide-core/src/types/shipping_address.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 /// This object represents a shipping address.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#shippingaddress).
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct ShippingAddress {
     /// ISO 3166-1 alpha-2 country code.

--- a/crates/teloxide-core/src/types/shipping_option.rs
+++ b/crates/teloxide-core/src/types/shipping_option.rs
@@ -5,6 +5,7 @@ use crate::types::LabeledPrice;
 /// This object represents one shipping option.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#shippingoption).
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct ShippingOption {
     /// Shipping option identifier.

--- a/crates/teloxide-core/src/types/shipping_query.rs
+++ b/crates/teloxide-core/src/types/shipping_query.rs
@@ -5,6 +5,7 @@ use crate::types::{ShippingAddress, User};
 /// This object contains information about an incoming shipping query.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#shippingquery).
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct ShippingQuery {
     /// Unique query identifier.

--- a/crates/teloxide-core/src/types/sticker_set.rs
+++ b/crates/teloxide-core/src/types/sticker_set.rs
@@ -7,6 +7,7 @@ use crate::types::{PhotoSize, Sticker, StickerFormat, StickerType};
 /// This object represents a sticker set.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#stickerset).
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct StickerSet {
     /// Sticker set name.

--- a/crates/teloxide-core/src/types/update.rs
+++ b/crates/teloxide-core/src/types/update.rs
@@ -12,6 +12,7 @@ use crate::types::{
 /// [The official docs](https://core.telegram.org/bots/api#update).
 ///
 /// [object]: https://core.telegram.org/bots/api#available-types
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Update {
     /// The update‘s unique identifier. Update identifiers start from a certain

--- a/crates/teloxide-core/src/types/user_profile_photos.rs
+++ b/crates/teloxide-core/src/types/user_profile_photos.rs
@@ -5,6 +5,7 @@ use crate::types::PhotoSize;
 /// This object represent a user's profile pictures.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#userprofilephotos).
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct UserProfilePhotos {
     /// Total number of profile pictures the target user has.


### PR DESCRIPTION
Close #863

## Solution

- [ ] add `serde_with_macros::skip_serializing_none` to every Telegram struct by default to exclude empty fields
- [ ] add `skip_serializing_if = "std::ops::Not::not"` to exclude `False` to "True or absent" fields
- [ ] add `skip_serializing_if = "Vec::is_empty"` to exclude empty `[ ]`