### PR TITLE
Update outdated documentation

### DIFF
--- a/crates/teloxide-core/src/types/callback_query.rs
+++ b/crates/teloxide-core/src/types/callback_query.rs
@@ -40,8 +40,7 @@ pub struct CallbackQuery {
     /// [games]: https://core.telegram.org/bots/api#games
     pub chat_instance: String,
 
-    /// A data associated with the callback button. Be aware that the message
-    /// originated the query can contain no callback buttons with this data.
+    /// A data associated with the callback button.
     pub data: Option<String>,
 
     /// A short name of a Game to be returned, serves as the unique identifier

--- a/crates/teloxide-core/src/types/callback_query.rs
+++ b/crates/teloxide-core/src/types/callback_query.rs
@@ -40,8 +40,8 @@ pub struct CallbackQuery {
     /// [games]: https://core.telegram.org/bots/api#games
     pub chat_instance: String,
 
-    /// A data associated with the callback button. Be aware that a bad client
-    /// can send arbitrary data in this field.
+    /// A data associated with the callback button. Be aware that the message
+    /// originated the query can contain no callback buttons with this data.
     pub data: Option<String>,
 
     /// A short name of a Game to be returned, serves as the unique identifier


### PR DESCRIPTION
Updated documentation of `CallbackQuery` to align with current [official API version](https://core.telegram.org/bots/api#callbackquery). 