### PR TITLE
Add tracing feature

### DIFF
--- a/crates/teloxide/Cargo.toml
+++ b/crates/teloxide/Cargo.toml
@@ -33,6 +33,8 @@ macros = ["teloxide-macros"]
 
 ctrlc_handler = ["tokio/signal"]
 
+tracing = ["dep:tracing"]
+
 native-tls = ["teloxide-core/native-tls"]
 rustls = ["teloxide-core/rustls"]
 auto-send = ["teloxide-core/auto_send"]
@@ -64,6 +66,7 @@ full = [
     "cache-me",
     "trace-adaptor",
     "erased",
+    "tracing",
 ]
 
 
@@ -107,6 +110,7 @@ tower = { version = "0.4.12", optional = true }
 tower-http = { version = "0.3.4", features = ["trace"], optional = true }
 rand = { version = "0.8.5", optional = true }
 
+tracing = { version = "0.1", optional = true }
 
 [dev-dependencies]
 rand = "0.8.3"

--- a/crates/teloxide/src/dispatching.rs
+++ b/crates/teloxide/src/dispatching.rs
@@ -246,3 +246,6 @@ pub use distribution::DefaultKey;
 pub use filter_ext::{MessageFilterExt, UpdateFilterExt};
 pub use handler_description::DpHandlerDescription;
 pub use handler_ext::{filter_command, HandlerExt};
+
+#[cfg(feature = "tracing")]
+pub use dispatcher::UpdateHandlerTracingExt;

--- a/crates/teloxide/src/dispatching/dispatcher.rs
+++ b/crates/teloxide/src/dispatching/dispatcher.rs
@@ -495,6 +495,32 @@ impl<R, Err, Key> Dispatcher<R, Err, Key> {
     }
 }
 
+/// Extension methods for adding `tracing` to [`UpdateHandler`].
+///
+/// This trait is only available if the `tracing` feature is enabled.
+#[cfg(feature = "tracing")]
+pub trait UpdateHandlerTracingExt<E> {
+    /// Returns an `UpdateHandler` with tracing enabled.
+    fn with_tracing(self, f: fn(Arc<Update>) -> tracing::Span) -> Self;
+}
+
+#[cfg(feature = "tracing")]
+impl<E: 'static> UpdateHandlerTracingExt<E> for UpdateHandler<E> {
+    fn with_tracing(self, f: fn(Arc<Update>) -> tracing::Span) -> Self {
+        use dptree::HandlerDescription;
+        use tracing::Instrument;
+
+        // This is a hacky replacement for `handler.description().clone()`.
+        // Ideally cloning `DpHandlerDescription` would be supported by `teloxide`.
+        let description = DpHandlerDescription::entry().merge_chain(self.description());
+
+        dptree::from_fn_with_description(description, move |deps: DependencyMap, cont| {
+            let update: Arc<Update> = deps.get();
+            self.clone().execute(deps, cont).instrument(f(update))
+        })
+    }
+}
+
 fn spawn_worker<Err>(
     deps: DependencyMap,
     handler: Arc<UpdateHandler<Err>>,


### PR DESCRIPTION
Creates a trait with a `with_tracing` method to instrument a handler with a custom `tracing::Span`