### PR TITLE
Solve CI warnings replacing outdated actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,6 @@ jobs:
 
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@master
-        id: toolchain
         with:
           toolchain: stable
 
@@ -141,12 +140,12 @@ jobs:
 
       - name: Check examples
         run: |
-          cargo +${{ steps.toolchain.outputs.name }} check --examples --features full
+          cargo +stable check --examples --features full
 
       # TODO: prolly move it to a separate step?
       - name: Check with no default features
         run: |
-          cargo +${{ steps.toolchain.outputs.name }} check --no-default-features
+          cargo +stable check --no-default-features
 
   clippy:
     name: Run linter

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,33 +53,29 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Rust ${{ env.rust_nightly }}
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: ${{ env.rust_nightly }}
-          override: true
           components: rustfmt
 
       - name: Cache Dependencies
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
 
       - name: Check formatting
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        run: |
+          cargo fmt --all -- --check
 
   test:
     name: Test
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: 
+        rust:
           - stable
           - beta
           - nightly
           - msrv
-    
+
         include:
           - rust: stable
             toolchain: stable
@@ -94,26 +90,22 @@ jobs:
             toolchain: 1.64.0
             features: "--features full"
 
-    steps:      
+    steps:
       - name: Checkout
         uses: actions/checkout@v3
 
       - name: Install Rust ${{ matrix.toolchain }}
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: ${{ matrix.toolchain }}
-          override: true
 
       - name: Cache Dependencies
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
 
       # NB. Don't test (build) examples so we can use non-msrv features in them (--tests/--doc)
-      - name: Compile 
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --tests --no-run --verbose ${{ matrix.features }}
+      - name: Compile
+        run: |
+          cargo +${{ matrix.toolchain }} test --tests --no-run --verbose ${{ matrix.features }}
 
       - name: Setup redis
         run: |
@@ -121,19 +113,15 @@ jobs:
           redis-server --port 7777 > /dev/null &
           redis-server --port 7778 > /dev/null &
           redis-server --port 7779 > /dev/null &
-      
-      - name: Test unit & integration tests 
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --tests --verbose ${{ matrix.features }}
-          
+
+      - name: Test unit & integration tests
+        run: |
+          cargo +${{ matrix.toolchain }} test --tests --verbose ${{ matrix.features }}
+
       - name: Test documentation tests
         if: ${{ matrix.rust != 'msrv' }}
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --doc --verbose ${{ matrix.features }}
+        run: |
+          cargo +${{ matrix.toolchain }} test --doc --verbose ${{ matrix.features }}
 
   check-examples:
     runs-on: ubuntu-latest
@@ -143,27 +131,22 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Rust stable
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
+        id: toolchain
         with:
-          profile: minimal
           toolchain: stable
-          override: true
 
       - name: Cache Dependencies
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
 
       - name: Check examples
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --examples --features full
+        run: |
+          cargo +${{ steps.toolchain.outputs.name }} check --examples --features full
 
       # TODO: prolly move it to a separate step?
       - name: Check with no default features
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --no-default-features
+        run: |
+          cargo +${{ steps.toolchain.outputs.name }} check --no-default-features
 
   clippy:
     name: Run linter
@@ -174,21 +157,17 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Rust ${{ env.rust_nightly }}
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: ${{ env.rust_nightly }}
-          override: true
           components: clippy
 
       - name: Cache Dependencies
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
 
       - name: clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all-targets --features "full nightly"
+        run: |
+          cargo clippy --all-targets --features "full nightly"
 
   doc:
     name: check docs
@@ -199,16 +178,13 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Rust ${{ env.rust_nightly }}
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: ${{ env.rust_nightly }}
-          override: true
 
       - name: Cache Dependencies
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
 
       - name: rustdoc
-        uses: actions-rs/cargo@v1
-        with:
-          command: docs # from .cargo/config.toml
+        run: |
+          cargo docs # from .cargo/config.toml


### PR DESCRIPTION
<!--
Before making this PR, please ensure the following:

- `CHANGELOG.md` is updated (if necessary).
- Documentation and tests are updated (if necessary).
-->

Hi, I don't know if you are interested to solve CI warnings ... I describe what I did

Warnings principally arise from 2 unmantained actions
`actions-rs/toolchain`  `actions-rs/cargo`, although widely used,
and from an outdated `Swatinem/rust-cache@v1` version

For `Swatinem/rust-cache`, `set-output` and `save-state` warnings were
fixed in the [release v2.0.1](https://github.com/Swatinem/rust-cache/releases/tag/v2.0.1). Instead the best replacement for `actions-rs/toolchain`
seems to be `dtolnay/rust-toolchain` (see https://github.com/actions-rs/toolchain/issues/216),
`cargo` command can be executed simply inside a run task

Two side-effects of these changes that I have experienced testing CI are:
1. **Problem:** cargo command in run task reads `rust-toolchain.toml`
and selects always the nightly pinned version, instead in the previous
behavior, If I didn't miss something, the installed toolchain is used by cargo
  **Solution:** when toolchain != nightly --> `cargo +${{ toolchain_installed }} ...`

2. **Problem:** `dtolnay/rust-toolchain` [conditionally](https://github.com/dtolnay/rust-toolchain/blob/b44cb146d03e8d870c57ab64b80f04586349ca5d/action.yml#L100-L111) enable sparse-registry
mode to speed-up crates.io sync. But for some reason with the pinned
nightly version it doesn't work unless adding the flag `-Z sparse-registry`
to cargo command, maybe an unhandled exception
  **Solution:** when toolchain == nightly --> `CARGO_REGISTRIES_CRATES_IO_PROTOCOL: git`
