### PR TITLE
Use GATs in `Download`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ env:
   # - **/README.md
   # - **/src/lib.rs
   # - down below in a matrix
-  rust_msrv: 1.64.0
+  rust_msrv: 1.65.0
 
   CI: 1
 
@@ -91,7 +91,7 @@ jobs:
             toolchain: nightly-2023-05-28
             features: "--features full nightly"
           - rust: msrv
-            toolchain: 1.64.0
+            toolchain: 1.65.0
             features: "--features full"
 
     steps:      

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["crates/*"]
 # The settings below will be applied to all crates in the workspace
 [workspace.package]
 # MSRV (minimal supported Rust version).
-rust-version = "1.64"
+rust-version = "1.65"
 edition = "2021"
 
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ $ set TELOXIDE_TOKEN=<Your token here>
 $ $env:TELOXIDE_TOKEN=<Your token here>
 ```
 
- 4. Make sure that your Rust compiler is up to date (`teloxide` currently requires rustc at least version 1.64):
+ 4. Make sure that your Rust compiler is up to date (`teloxide` currently requires rustc at least version 1.65):
 ```bash
 # If you're using stable
 $ rustup update stable

--- a/crates/teloxide-core/CHANGELOG.md
+++ b/crates/teloxide-core/CHANGELOG.md
@@ -45,10 +45,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `RequestError::RetryAfter` single fields type to `Seconds` ([#859][pr859])
 - `CallbackGame`, `ForumTopicClosed`, `ForumTopicReopened`, `GeneralForumTopicHidden`, `GeneralForumTopicUnhidden` and `WriteAccessAllowed` structures
   are now defined as named (`struct S {}`) instead of unit (`struct S;`) in order to fix their deserialization ([#876][pr876])
+- `Download` now uses GAT feature on the `Fut` and `Err` associated types, instead of a lifetime on the whole trait ([#885][pr885])
+- MSRV (Minimal Supported Rust Version) was bumped from `1.64.0` to `1.65.0`
 
 [pr852]: https://github.com/teloxide/teloxide/pull/853
 [pr859]: https://github.com/teloxide/teloxide/pull/859
 [pr876]: https://github.com/teloxide/teloxide/pull/876
+[pr885]: https://github.com/teloxide/teloxide/pull/885
 
 ### Deprecated
 

--- a/crates/teloxide-core/README.md
+++ b/crates/teloxide-core/README.md
@@ -27,7 +27,7 @@
 ```toml
 teloxide-core = "0.9"
 ```
-_Compiler support: requires rustc 1.64+_.
+_Compiler support: requires rustc 1.65+_.
 
 [`teloxide`]: https://docs.rs/teloxide
 [Telegram Bot API]: https://core.telegram.org/bots/api

--- a/crates/teloxide-core/src/adaptors/auto_send.rs
+++ b/crates/teloxide-core/src/adaptors/auto_send.rs
@@ -177,7 +177,6 @@ where
 }
 
 download_forward! {
-    'w
     B
     AutoSend<B>
     { this => this.inner() }

--- a/crates/teloxide-core/src/adaptors/cache_me.rs
+++ b/crates/teloxide-core/src/adaptors/cache_me.rs
@@ -201,7 +201,6 @@ where
 }
 
 download_forward! {
-    'w
     B
     CacheMe<B>
     { this => this.inner() }

--- a/crates/teloxide-core/src/adaptors/parse_mode.rs
+++ b/crates/teloxide-core/src/adaptors/parse_mode.rs
@@ -196,7 +196,6 @@ impl<B: Requester> Requester for DefaultParseMode<B> {
 }
 
 download_forward! {
-    'w
     B
     DefaultParseMode<B>
     { this => this.inner() }

--- a/crates/teloxide-core/src/adaptors/throttle/requester_impl.rs
+++ b/crates/teloxide-core/src/adaptors/throttle/requester_impl.rs
@@ -182,7 +182,6 @@ where
 }
 
 download_forward! {
-    'w
     B
     Throttle<B>
     { this => this.inner() }

--- a/crates/teloxide-core/src/bot/download.rs
+++ b/crates/teloxide-core/src/bot/download.rs
@@ -8,18 +8,18 @@ use crate::{
     DownloadError,
 };
 
-impl<'w> Download<'w> for Bot {
-    type Err = DownloadError;
+impl Download for Bot {
+    type Err<'dst> = DownloadError;
 
     // I would like to unbox this, but my coworkers will kill me if they'll see yet
     // another hand written `Future`. (waffle)
-    type Fut = BoxFuture<'w, Result<(), Self::Err>>;
+    type Fut<'dst> = BoxFuture<'dst, Result<(), Self::Err<'dst>>>;
 
-    fn download_file(
+    fn download_file<'dst>(
         &self,
         path: &str,
-        destination: &'w mut (dyn AsyncWrite + Unpin + Send),
-    ) -> Self::Fut {
+        destination: &'dst mut (dyn AsyncWrite + Unpin + Send),
+    ) -> Self::Fut<'dst> {
         net::download_file(
             &self.client,
             reqwest::Url::clone(&*self.api_url),

--- a/crates/teloxide-core/src/lib.rs
+++ b/crates/teloxide-core/src/lib.rs
@@ -7,7 +7,7 @@
 //!```toml
 //! teloxide_core = "0.9"
 //! ```
-//! _Compiler support: requires rustc 1.64+_.
+//! _Compiler support: requires rustc 1.65+_.
 //!
 //! ```
 //! # async {

--- a/crates/teloxide-core/src/local_macros.rs
+++ b/crates/teloxide-core/src/local_macros.rs
@@ -372,26 +372,26 @@ macro_rules! impl_payload {
 }
 
 macro_rules! download_forward {
-    ($l:lifetime $T:ident $S:ty {$this:ident => $inner:expr}) => {
-        impl<$l, $T: $crate::net::Download<$l>> $crate::net::Download<$l> for $S {
-            type Err = <$T as $crate::net::Download<$l>>::Err;
+    ($T:ident $S:ty {$this:ident => $inner:expr}) => {
+        impl<$T: $crate::net::Download> $crate::net::Download for $S {
+            type Err<'dst> = <$T as $crate::net::Download>::Err<'dst>;
 
-            type Fut = <$T as $crate::net::Download<$l>>::Fut;
+            type Fut<'dst> = <$T as $crate::net::Download>::Fut<'dst>;
 
-            fn download_file(
+            fn download_file<'dst>(
                 &self,
                 path: &str,
-                destination: &'w mut (dyn tokio::io::AsyncWrite
-                             + core::marker::Unpin
-                             + core::marker::Send),
-            ) -> Self::Fut {
+                destination: &'dst mut (dyn tokio::io::AsyncWrite
+                               + core::marker::Unpin
+                               + core::marker::Send),
+            ) -> Self::Fut<'dst> {
                 let $this = self;
                 ($inner).download_file(path, destination)
             }
 
-            type StreamErr = <$T as $crate::net::Download<$l>>::StreamErr;
+            type StreamErr = <$T as $crate::net::Download>::StreamErr;
 
-            type Stream = <$T as $crate::net::Download<$l>>::Stream;
+            type Stream = <$T as $crate::net::Download>::Stream;
 
             fn download_file_stream(&self, path: &str) -> Self::Stream {
                 let $this = self;


### PR DESCRIPTION
This was a long-standing `FIXME`, GATs were stable for a few versions now, so a small MSRV bump seems fine.

I also plan to use GATs to replace `AsUpdateStream` but this turned out to be a bit more involved, so I'll leave it as a follow-up.