### PR TITLE
Use `UserId` instead of `i64` for `user_id` in `user_mention`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## unreleased
 
+### Fixed
+- Use `u64` instead of `i64` for `user_id` in `html::user_mention` and `markdown::user_mention` ([PR 896](https://github.com/teloxide/teloxide/pull/896))
+
 ## 0.12.2 - 2023-02-15
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## unreleased
 
 ### Fixed
-- Use `u64` instead of `i64` for `user_id` in `html::user_mention` and `markdown::user_mention` ([PR 896](https://github.com/teloxide/teloxide/pull/896))
+- Use `UserId` instead of `i64` for `user_id` in `html::user_mention` and `markdown::user_mention` ([PR 896](https://github.com/teloxide/teloxide/pull/896))
 
 ## 0.12.2 - 2023-02-15
 

--- a/crates/teloxide/src/utils/html.rs
+++ b/crates/teloxide/src/utils/html.rs
@@ -2,7 +2,7 @@
 //!
 //! [spec]: https://core.telegram.org/bots/api#html-style
 
-use teloxide_core::types::User;
+use teloxide_core::types::{User, UserId};
 
 /// Applies the bold font style to the string.
 ///
@@ -56,7 +56,7 @@ pub fn link(url: &str, text: &str) -> String {
 /// Builds an inline user mention link with an anchor.
 #[must_use = "This function returns a new string, rather than mutating the argument, so calling it \
               without using its output does nothing useful"]
-pub fn user_mention(user_id: u64, text: &str) -> String {
+pub fn user_mention(user_id: UserId, text: &str) -> String {
     link(format!("tg://user?id={user_id}").as_str(), text)
 }
 
@@ -158,7 +158,7 @@ mod tests {
     #[test]
     fn test_user_mention() {
         assert_eq!(
-            user_mention(123_456_789, "<pwner666>"),
+            user_mention(UserId(123_456_789), "<pwner666>"),
             "<a href=\"tg://user?id=123456789\">&lt;pwner666&gt;</a>",
         );
     }

--- a/crates/teloxide/src/utils/html.rs
+++ b/crates/teloxide/src/utils/html.rs
@@ -56,7 +56,7 @@ pub fn link(url: &str, text: &str) -> String {
 /// Builds an inline user mention link with an anchor.
 #[must_use = "This function returns a new string, rather than mutating the argument, so calling it \
               without using its output does nothing useful"]
-pub fn user_mention(user_id: i64, text: &str) -> String {
+pub fn user_mention(user_id: u64, text: &str) -> String {
     link(format!("tg://user?id={user_id}").as_str(), text)
 }
 

--- a/crates/teloxide/src/utils/markdown.rs
+++ b/crates/teloxide/src/utils/markdown.rs
@@ -2,7 +2,7 @@
 //!
 //! [spec]: https://core.telegram.org/bots/api#markdownv2-style
 
-use teloxide_core::types::User;
+use teloxide_core::types::{User, UserId};
 
 /// Applies the bold font style to the string.
 ///
@@ -71,7 +71,7 @@ pub fn link(url: &str, text: &str) -> String {
 /// Builds an inline user mention link with an anchor.
 #[must_use = "This function returns a new string, rather than mutating the argument, so calling it \
               without using its output does nothing useful"]
-pub fn user_mention(user_id: u64, text: &str) -> String {
+pub fn user_mention(user_id: UserId, text: &str) -> String {
     link(format!("tg://user?id={user_id}").as_str(), text)
 }
 
@@ -203,7 +203,10 @@ mod tests {
 
     #[test]
     fn test_user_mention() {
-        assert_eq!(user_mention(123_456_789, "pwner666"), "[pwner666](tg://user?id=123456789)");
+        assert_eq!(
+            user_mention(UserId(123_456_789), "pwner666"),
+            "[pwner666](tg://user?id=123456789)"
+        );
     }
 
     #[test]

--- a/crates/teloxide/src/utils/markdown.rs
+++ b/crates/teloxide/src/utils/markdown.rs
@@ -71,7 +71,7 @@ pub fn link(url: &str, text: &str) -> String {
 /// Builds an inline user mention link with an anchor.
 #[must_use = "This function returns a new string, rather than mutating the argument, so calling it \
               without using its output does nothing useful"]
-pub fn user_mention(user_id: i64, text: &str) -> String {
+pub fn user_mention(user_id: u64, text: &str) -> String {
     link(format!("tg://user?id={user_id}").as_str(), text)
 }
 


### PR DESCRIPTION
Fixed:
- `i64` to `u64` in `html::user_mention` and `markdown::user_mention`

Because `types::UserId` is `u64`, not `i64`.