### PR TITLE
adding enum variant to handle unknown 400

### DIFF
--- a/crates/teloxide-core/src/errors.rs
+++ b/crates/teloxide-core/src/errors.rs
@@ -238,7 +238,7 @@ impl_api_error! {
         /// [`DeleteMessage`]: crate::payloads::DeleteMessage
         MessageCantBeDeleted = "Bad Request: message can't be deleted",
 
-        /// Occurs when a bot tries to delete a message created by the bot 
+        /// Occurs when a bot tries to delete a message created by the bot
         /// in a group they belong to but have no rights to delete the message
         /// for all in the group.
         ///
@@ -882,7 +882,6 @@ mod tests {
                 ApiError::PollQuestionMustBeNonEmpty,
             ),
             (
-
                 "{\"data\": \"Bad Request: poll options length must not exceed 100\"}",
                 ApiError::PollOptionsLengthTooLong,
             ),

--- a/crates/teloxide-core/src/errors.rs
+++ b/crates/teloxide-core/src/errors.rs
@@ -238,6 +238,16 @@ impl_api_error! {
         /// [`DeleteMessage`]: crate::payloads::DeleteMessage
         MessageCantBeDeleted = "Bad Request: message can't be deleted",
 
+        /// Occurs when a bot tries to delete a message created by the bot 
+        /// in a group they belong to but have no rights to delete the message
+        /// for all in the group.
+        ///
+        /// May happen in methods:
+        /// 1. [`DeleteMessage`]
+        ///
+        /// [`DeleteMessage`]: crate::payloads::DeleteMessage
+        MessageCantBeDeletedForEveryone = "Bad Request: message can't be deleted for everyone",
+
         /// Occurs when bot tries to edit a message which does not exists.
         ///
         /// May happen in methods:
@@ -829,6 +839,10 @@ mod tests {
                 ApiError::MessageCantBeDeleted,
             ),
             (
+                "{\"data\": \"Bad Request: message can't be deleted for everyone\"}",
+                ApiError::MessageCantBeDeletedForEveryone,
+            ),
+            (
                 "{\"data\": \"Bad Request: message to edit not found\"}",
                 ApiError::MessageToEditNotFound,
             ),
@@ -868,6 +882,7 @@ mod tests {
                 ApiError::PollQuestionMustBeNonEmpty,
             ),
             (
+
                 "{\"data\": \"Bad Request: poll options length must not exceed 100\"}",
                 ApiError::PollOptionsLengthTooLong,
             ),


### PR DESCRIPTION
### Change Description
Created new ApiError enum variant to handle previously unhanded 400 error from Telegram. This was highlighted in issue #901. A new test case was added so the variant would be included in the "custom_result" test for the ApiError enum. 

### Doc Notes
The Doc Comment that was added to the variant tries to sum up the use case the error might occur however there is no official guidance on why this would occur so please change/add if we think of a better example of why this error might occur.

Tests ran and passed after change but please let me know if there are any other considerations :+1: 