### PR TITLE
Add `MessageToCopyNotFound` to `teloxide::errors::ApiError`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## unreleased
 
+### Added
+- Add `MessageToCopyNotFound` error to `teloxide::errors::ApiError` ([PR 917](https://github.com/teloxide/teloxide/pull/917)) 
 ### Fixed
 - Use `UserId` instead of `i64` for `user_id` in `html::user_mention` and `markdown::user_mention` ([PR 896](https://github.com/teloxide/teloxide/pull/896))
 

--- a/crates/teloxide-core/src/errors.rs
+++ b/crates/teloxide-core/src/errors.rs
@@ -213,6 +213,13 @@ impl_api_error! {
         /// [`DeleteMessage`]: crate::payloads::DeleteMessage
         MessageToDeleteNotFound = "Bad Request: message to delete not found",
 
+        /// Occurs when bot tries to copy a message which does not exists.
+        /// May happen in methods:
+        /// 1. [`CopyMessage`]
+        ///
+        /// [`CopyMessage`]: crate::payloads::CopyMessage
+        MessageToCopyNotFound = "Bad Request: message to copy not found",
+
         /// Occurs when bot tries to send a text message without text.
         ///
         /// May happen in methods:
@@ -821,6 +828,10 @@ mod tests {
             (
                 "{\"data\": \"Bad Request: message to delete not found\"}",
                 ApiError::MessageToDeleteNotFound,
+            ),
+            (
+                "{\"data\": \"Bad Request: message to copy not found\"}",
+                ApiError::MessageToCopyNotFound,
             ),
             ("{\"data\": \"Bad Request: message text is empty\"}", ApiError::MessageTextIsEmpty),
             ("{\"data\": \"Bad Request: message can't be edited\"}", ApiError::MessageCantBeEdited),


### PR DESCRIPTION
Fix https://github.com/teloxide/teloxide/issues/916