### PR TITLE
Bump chrono and fix deprecation error

### DIFF
--- a/crates/teloxide-core/Cargo.toml
+++ b/crates/teloxide-core/Cargo.toml
@@ -72,7 +72,7 @@ takecell = "0.1"
 take_mut = "0.2"
 rc-box = "1.1.1"
 never = "0.1.0"
-chrono = { version = "0.4.19", default-features = false }
+chrono = { version = "0.4.30", default-features = false }
 either = "1.6.1"
 bitflags = { version = "1.2" }
 

--- a/crates/teloxide-core/src/types.rs
+++ b/crates/teloxide-core/src/types.rs
@@ -269,7 +269,7 @@ pub(crate) fn serde_timestamp<E: serde::de::Error>(
 
     NaiveDateTime::from_timestamp_opt(timestamp, 0)
         .ok_or_else(|| E::custom("invalid timestump"))
-        .map(|naive| DateTime::from_utc(naive, Utc))
+        .map(|naive| DateTime::from_naive_utc_and_offset(naive, Utc))
 }
 
 pub(crate) mod serde_opt_date_from_unix_timestamp {
@@ -305,8 +305,10 @@ pub(crate) mod serde_opt_date_from_unix_timestamp {
 
         {
             let json = r#"{"date":1}"#;
-            let expected =
-                DateTime::from_utc(chrono::NaiveDateTime::from_timestamp_opt(1, 0).unwrap(), Utc);
+            let expected = DateTime::from_naive_utc_and_offset(
+                chrono::NaiveDateTime::from_timestamp_opt(1, 0).unwrap(),
+                Utc,
+            );
 
             let Struct { date } = serde_json::from_str(json).unwrap();
             assert_eq!(date, Some(expected));

--- a/crates/teloxide-core/src/types/update.rs
+++ b/crates/teloxide-core/src/types/update.rs
@@ -395,8 +395,10 @@ mod test {
     #[test]
     fn message() {
         let timestamp = 1_569_518_342;
-        let date =
-            DateTime::from_utc(NaiveDateTime::from_timestamp_opt(timestamp, 0).unwrap(), Utc);
+        let date = DateTime::from_naive_utc_and_offset(
+            NaiveDateTime::from_timestamp_opt(timestamp, 0).unwrap(),
+            Utc,
+        );
 
         let json = r#"{
             "update_id":892252934,


### PR DESCRIPTION
Use `DateTime::from_naive_utc_and_offset` instead of `DateTime::from_utc`

ref: https://github.com/chronotope/chrono/commit/87bb2c8aeb58d0fe9fdda9aca1c7454182922755