### PR TITLE
Fix the type of `photo_size`,`photo_width` and `photo_height` in the `send_invoice` method

### DIFF
--- a/crates/teloxide-core/CHANGELOG.md
+++ b/crates/teloxide-core/CHANGELOG.md
@@ -28,8 +28,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Return types of `edit_message_live_location_inline`, `stop_message_live_location_inline`, and `set_game_score_inline`: `Message` => `True` ([#854][pr854])
 - Remove `latitude` and `longitude` parameters from `stop_message_live_location` and `stop_message_live_location_inline` ([#854][pr854])
+- Fix the type of `photo_size`,`photo_width` and `photo_height` in the `send_invoice` method ([#936][pr936])
 
 [pr854]: https://github.com/teloxide/teloxide/pull/854
+[pr936]: https://github.com/teloxide/teloxide/pull/936
 
 ### Changed
 

--- a/crates/teloxide-core/schema.ron
+++ b/crates/teloxide-core/schema.ron
@@ -3735,17 +3735,17 @@ Schema(
                 ),
                 Param(
                     name: "photo_size",
-                    ty: Option(String),
+                    ty: Option(u32),
                     descr: Doc(md: "Photo size in bytes")
                 ),
                 Param(
                     name: "photo_width",
-                    ty: Option(String),
+                    ty: Option(u32),
                     descr: Doc(md: "Photo width")
                 ),
                 Param(
                     name: "photo_height",
-                    ty: Option(String),
+                    ty: Option(u32),
                     descr: Doc(md: "Photo height")
                 ),
                 Param(

--- a/crates/teloxide-core/src/payloads/send_invoice.rs
+++ b/crates/teloxide-core/src/payloads/send_invoice.rs
@@ -45,11 +45,11 @@ impl_payload! {
             /// URL of the product photo for the invoice. Can be a photo of the goods or a marketing image for a service. People like it better when they see what they are paying for.
             pub photo_url: Url,
             /// Photo size in bytes
-            pub photo_size: String [into],
+            pub photo_size: u32,
             /// Photo width
-            pub photo_width: String [into],
+            pub photo_width: u32,
             /// Photo height
-            pub photo_height: String [into],
+            pub photo_height: u32,
             /// Pass _True_, if you require the user's full name to complete the order
             pub need_name: bool,
             /// Pass _True_, if you require the user's phone number to complete the order


### PR DESCRIPTION
This will fix https://github.com/teloxide/teloxide/issues/935

Change the `photo_size`,`photo_width` and `photo_height` types from `Option(String)` to `Option(u32)`

<!--
Before making this PR, please ensure the following:

- `CHANGELOG.md` is updated (if necessary).
- Documentation and tests are updated (if necessary).
-->
