### PR TITLE
Improve graceful shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `MessageToCopyNotFound` error to `teloxide::errors::ApiError` ([PR 917](https://github.com/teloxide/teloxide/pull/917)) 
 ### Fixed
 - Use `UserId` instead of `i64` for `user_id` in `html::user_mention` and `markdown::user_mention` ([PR 896](https://github.com/teloxide/teloxide/pull/896))
+- Greatly improved the speed of graceful shutdown (`^C`) ([PR 938](https://github.com/teloxide/teloxide/pull/938))
+
+### Removed
+
+- `UpdateListener::timeout_hint` and related APIs ([PR 938](https://github.com/teloxide/teloxide/pull/938))
 
 ## 0.12.2 - 2023-02-15
 

--- a/crates/teloxide/src/update_listeners.rs
+++ b/crates/teloxide/src/update_listeners.rs
@@ -32,8 +32,6 @@ pub mod webhooks;
 
 use futures::Stream;
 
-use std::time::Duration;
-
 use crate::{
     stop::StopToken,
     types::{AllowedUpdate, Update},
@@ -93,19 +91,6 @@ pub trait UpdateListener:
     /// crate::payloads::GetUpdates::allowed_updates
     fn hint_allowed_updates(&mut self, hint: &mut dyn Iterator<Item = AllowedUpdate>) {
         let _ = hint;
-    }
-
-    /// The timeout duration hint.
-    ///
-    /// This hints how often dispatcher should check for a shutdown. E.g., for
-    /// [`polling()`] this returns the [`timeout`].
-    ///
-    /// [`timeout`]: crate::payloads::GetUpdates::timeout
-    ///
-    /// If you are implementing this trait and not sure what to return from this
-    /// function, just leave it with the default implementation.
-    fn timeout_hint(&self) -> Option<Duration> {
-        None
     }
 }
 

--- a/crates/teloxide/src/update_listeners/polling.rs
+++ b/crates/teloxide/src/update_listeners/polling.rs
@@ -406,8 +406,10 @@ impl<B: Requester> Stream for PollingStream<'_, B> {
             .send();
         this.in_flight.set(Some(req));
 
-        // Recurse to poll `self.in_flight`
-        self.poll_next(cx)
+        // Immediately wake up to poll `self.in_flight`
+        // (without this this stream becomes a zombie)
+        cx.waker().wake_by_ref();
+        Poll::Pending
     }
 }
 

--- a/crates/teloxide/src/update_listeners/polling.rs
+++ b/crates/teloxide/src/update_listeners/polling.rs
@@ -301,10 +301,6 @@ impl<B: Requester + Send + 'static> UpdateListener for Polling<B> {
         // before
         self.allowed_updates = Some(hint.collect());
     }
-
-    fn timeout_hint(&self) -> Option<Duration> {
-        self.timeout
-    }
 }
 
 impl<'a, B: Requester + Send + 'a> AsUpdateStream<'a> for Polling<B> {


### PR DESCRIPTION
Turns out we were wasting a lot of time for no reason while doing graceful shutdown, this PR fixes it. This _almost_ fixes #711 — the shutdown is fast enough that it isn't really frustrating. Sometimes telegram still takes a bit of time to respond to the last `get_updates` request[^1], so I think we should still implement the "multiple ^C for forceful shutdown" (additionally it would help for cases when handlers are stuck).

Here is a comparison of new version (this PR/branch) and old one (current master)[^2][^3]:

https://github.com/teloxide/teloxide/assets/38225716/f2d56d01-ea2e-400b-abb2-78c4d6a59d94

[^1]: I think it happens when last `get_updates` call and the previous one happen with little delay between them
[^2]: Note that in second runs of both versions a wait for like 10s or so and the shutdown is much faster for those cases, that's the telegram quirk, I think
[^3]: I'm so dead by the fact that the new version is so much faster[^4], like... we could have had this all along 💀 we received so many complaints about the slow shutdown, and it turns out it was almost entirely our fault 💀
[^4]: the first run is 18s -> 3s (6x times faster), the second one is 10s (11s waiting) -> less than a second (8s waiting) (that's so much faster aaaaa)