### PR TITLE
Configure triagebot

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1,0 +1,59 @@
+[assign]
+warn_non_default_branch = true
+# contributing_url = "https://rustc-dev-guide.rust-lang.org/contributing.html" # FIXME: configure
+
+[assign.adhoc_groups]
+# This is a special group that will be used if none of the `owners` entries matches.
+fallback = ["@WaffleLapkin", "@Hirrolot"]
+
+[assign.owners]
+"crates/teloxide-core" = ["@WaffleLapkin"]
+"crates/teloxide-macros" = ["@WaffleLapkin"]
+".github" = ["@WaffleLapkin"]
+
+
+[autolabel."S-waiting-on-review"]
+new_pr = true
+
+#[autolabel."new-issue"]
+#new_issue = true
+
+[autolabel."C-core"]
+trigger_files = ["crates/teloxide-core"]
+
+[autolabel."C-main"]
+trigger_files = ["crates/teloxide"]
+
+[autolabel."C-macros"]
+trigger_files = ["crates/teloxide-macros"]
+
+
+[relabel]
+allow-unauthenticated = [
+    "S-*", # Status
+    "C-*", # Crate
+    "breaking change",
+    "bug",
+    "documentation",
+    "duplicate",
+    "feature-request",
+    "FIXME",
+    "frozen",
+    "proposal",
+    "question",
+    "tba-update",
+    "Unknown API error",
+    "WIP",
+]
+
+
+# https://forge.rust-lang.org/triagebot/github-releases.html?
+
+
+[review-submitted]
+# This label is added when a review is submitted.
+reviewed_label = "S-waiting-on-author"
+# These labels are removed when a review is submitted.
+review_labels = ["S-waiting-on-review"]
+
+[shortcut]

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -9,6 +9,7 @@ fallback = ["@WaffleLapkin", "@Hirrolot"]
 [assign.owners]
 "crates/teloxide-core" = ["@WaffleLapkin"]
 "crates/teloxide-macros" = ["@WaffleLapkin"]
+"crates/teloxide" = ["@Hirrolot"]
 ".github" = ["@WaffleLapkin"]
 
 


### PR DESCRIPTION
I've started my own instance of the [rust-lang/triagebot](https://github.com/rust-lang/triagebot) as @teloxidebot. This bot allows doing quite a few cool thing, for example:
- Managing labels (even if you are not a member) with `@teloxidebot label +somelabel` (for non-members tags are white-listed)
- Claiming issues (assigning yourself) with `@rustbot claim`
- Setting status labels with `@teloxide ready`/`@teloxide author`/`@teloxide blocked`
- Automatically applying labels based on edited files
- Automatically assigning PRs to codeowners
- And more, see docs: https://forge.rust-lang.org/triagebot/index.html

While triagebot is a bit of an overkill for us, probably, its label managing abilities are very useful, so I thought I'd add it.

Also triagebot is a bit `rust-lang/` hard-coded (for example it tries to fetch https://team-api.infra.rust-lang.org/v1/teams.json). I don't think it's a blocked (the bot mostly works), but I should fork the bot and remove/disable parts that we don't need 😅 

Also in the future we should
- Add instructions for using the bot to contributing.md or something
- And add an url to it in the config
- Update bot's avatar/bio
- Document how to setup the bot for a new repository