### PR TITLE
Fix typos in documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Use `UserId` instead of `i64` for `user_id` in `html::user_mention` and `markdown::user_mention` ([PR 896](https://github.com/teloxide/teloxide/pull/896))
 - Greatly improved the speed of graceful shutdown (`^C`) ([PR 938](https://github.com/teloxide/teloxide/pull/938))
+- Fix typos in docstrings ([PR 953](https://github.com/teloxide/teloxide/pull/953))
 
 ### Changed
 

--- a/crates/teloxide-core/src/types/input_file.rs
+++ b/crates/teloxide-core/src/types/input_file.rs
@@ -114,7 +114,7 @@ impl InputFile {
     }
 
     /// Shorthand for `Self { file_name: None, inner, id: default() }`
-    /// (private because `InnerFile` iы private implementation detail)
+    /// (private because `InnerFile` is private implementation detail)
     fn new(inner: InnerFile) -> Self {
         Self { file_name: None, inner, id: OnceCell::new() }
     }
@@ -258,7 +258,7 @@ impl Read {
             let res = ArcBox::<TakeCell<dyn AsyncRead + Send + Unpin>>::try_from(self.inner);
             match res {
                 // Fast/easy path: this is the only file copy, so we can just forward the underlying
-                // `dyn AsynсRead` via some adaptors to reqwest.
+                // `dyn AsyncRead` via some adaptors to reqwest.
                 Ok(arc_box) => {
                     let fr = FramedRead::new(ExclusiveArcAsyncRead(arc_box), BytesDecoder);
 
@@ -270,7 +270,7 @@ impl Read {
             }
         }
 
-        // Slow path: either wait until someone will read the whole `dyn AsynсRead` into
+        // Slow path: either wait until someone will read the whole `dyn AsyncRead` into
         // a buffer, or be the one who reads
         let body = self.into_shared_body().await;
 
@@ -321,7 +321,7 @@ impl Read {
                 let _ = self.notify.send(());
             }
 
-            // Wait until `dyn AsynсRead` is read into a buffer, if it hasn't been read yet
+            // Wait until `dyn AsyncRead` is read into a buffer, if it hasn't been read yet
             None if self.buf.get().is_none() => {
                 // Error indicates that the sender was dropped, by we hold `Arc<Sender>`, so
                 // this can't happen

--- a/crates/teloxide-core/src/types/input_media.rs
+++ b/crates/teloxide-core/src/types/input_media.rs
@@ -452,7 +452,7 @@ pub struct InputMediaDocument {
     /// using multipart/form-data.
     pub thumb: Option<InputFile>,
 
-    /// Caption of the document to be sent, 0-1024 charactersю
+    /// Caption of the document to be sent, 0-1024 characters.
     pub caption: Option<String>,
 
     /// Send [Markdown] or [HTML], if you want Telegram apps to show [bold,


### PR DESCRIPTION
Some docstrings contained cyrillic `с` and typos.