### PR TITLE
Support more methods in `DefaultParseMode`

### DIFF
--- a/crates/teloxide-core/CHANGELOG.md
+++ b/crates/teloxide-core/CHANGELOG.md
@@ -67,6 +67,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `SendGame::reply_to_message_id`, `SendSticker::reply_to_message_id` and `SendInvoice::reply_to_message_id` now use `MessageId` instead of `i32` ([#887][pr887])
 - Use `UpdateId` for `Update::id` ([#892][pr892])
 - MSRV (Minimal Supported Rust Version) was bumped from `1.64.0` to `1.68.0` ([#950][pr950])
+- Add proper support for `edit_message_caption_inline`, `copy_message`, `answer_inline_query`, `answer_web_app_query`, `send_media_group`, `edit_message_media`, and `edit_message_media_inline` to `DefaultParseMode` adaptor ([#961][pr961])
+  - Note that now `DefaultParseMode` sets the default on `send`, instead of request creation
+  - `DefaultParseMode` now also requires that the supported requests implement `Clone` (as a user you should not notice anything changing)
 
 [pr852]: https://github.com/teloxide/teloxide/pull/853
 [pr859]: https://github.com/teloxide/teloxide/pull/859
@@ -74,6 +77,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [pr885]: https://github.com/teloxide/teloxide/pull/885
 [pr892]: https://github.com/teloxide/teloxide/pull/892
 [pr950]: https://github.com/teloxide/teloxide/pull/950
+[pr961]: https://github.com/teloxide/teloxide/pull/961
 
 ### Deprecated
 

--- a/crates/teloxide-core/src/adaptors/parse_mode.rs
+++ b/crates/teloxide-core/src/adaptors/parse_mode.rs
@@ -4,9 +4,9 @@ use url::Url;
 
 use crate::{
     payloads::{
-        EditMessageCaption, EditMessageCaptionInline, EditMessageText, EditMessageTextInline,
-        SendAnimation, SendAudio, SendDocument, SendMessage, SendPhoto, SendPoll, SendVideo,
-        SendVoice,
+        CopyMessage, EditMessageCaption, EditMessageCaptionInline, EditMessageText,
+        EditMessageTextInline, SendAnimation, SendAudio, SendDocument, SendMessage, SendPhoto,
+        SendPoll, SendVideo, SendVoice,
     },
     prelude::Requester,
     requests::{HasPayload, Output, Request},
@@ -144,6 +144,7 @@ where
     B::EditMessageCaption: Clone,
     B::EditMessageCaptionInline: Clone,
     B::SendPoll: Clone,
+    B::CopyMessage: Clone,
 {
     type Err = B::Err;
 
@@ -159,7 +160,8 @@ where
         edit_message_text,
         edit_message_text_inline,
         edit_message_caption,
-        edit_message_caption_inline => f, fty
+        edit_message_caption_inline,
+        copy_message => f, fty
     }
 
     requester_forward! {
@@ -171,7 +173,6 @@ where
         delete_webhook,
         get_webhook_info,
         forward_message,
-        copy_message,
         send_video_note,
         send_media_group,
         send_location,
@@ -310,5 +311,8 @@ impl_visit_parse_modes! {
     EditMessageTextInline => [parse_mode],
     EditMessageCaption => [parse_mode],
     EditMessageCaptionInline => [parse_mode],
+    // FIXME: check if `parse_mode` changes anything if `.caption` is not set
+    //        (and if it does, maybe not call visitor if `self.caption.is_none()`)
+    CopyMessage => [parse_mode],
     SendPoll => [explanation_parse_mode],
 }

--- a/crates/teloxide-core/src/adaptors/parse_mode.rs
+++ b/crates/teloxide-core/src/adaptors/parse_mode.rs
@@ -326,9 +326,9 @@ impl_visit_parse_modes! {
 
 impl VisitParseModes for AnswerInlineQuery {
     fn visit_parse_modes(&mut self, mut visitor: impl FnMut(&mut Option<ParseMode>)) {
-        for result in &mut self.results {
-            visit_parse_modes_in_inline_query_result(result, &mut visitor);
-        }
+        self.results
+            .iter_mut()
+            .for_each(|result| visit_parse_modes_in_inline_query_result(result, &mut visitor))
     }
 }
 
@@ -340,9 +340,9 @@ impl VisitParseModes for AnswerWebAppQuery {
 
 impl VisitParseModes for SendMediaGroup {
     fn visit_parse_modes(&mut self, mut visitor: impl FnMut(&mut Option<ParseMode>)) {
-        for media in &mut self.media {
-            visit_parse_modes_in_input_media(media, &mut visitor);
-        }
+        self.media
+            .iter_mut()
+            .for_each(|media| visit_parse_modes_in_input_media(media, &mut visitor))
     }
 }
 


### PR DESCRIPTION
This PR makes `DefaultParseMode` 10 times as annoying to implement and 20 times as useful.

Adds support for `edit_message_caption_inline`, `copy_message`, `answer_inline_query`, `answer_web_app_query`, `send_media_group`, `edit_message_media`, and `edit_message_media_inline`.

Resolves #919.
cc @fr0staman (could you check if I forgot something?)