### PR TITLE
Don't auto-add `C-main` label to all PRs

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -20,13 +20,13 @@ new_pr = true
 #new_issue = true
 
 [autolabel."C-core"]
-trigger_files = ["crates/teloxide-core"]
+trigger_files = ["crates/teloxide-core/"]
 
 [autolabel."C-main"]
-trigger_files = ["crates/teloxide"]
+trigger_files = ["crates/teloxide/"]
 
 [autolabel."C-macros"]
-trigger_files = ["crates/teloxide-macros"]
+trigger_files = ["crates/teloxide-macros/"]
 
 
 [relabel]


### PR DESCRIPTION
it looks like triagebot uses `starts_with`, which makes `crate/teloxide` trigger on `crates/teloxide-core`, lmao.

<!--
Before making this PR, please ensure the following:

- `CHANGELOG.md` is updated (if necessary).
- Documentation and tests are updated (if necessary).
-->
