### PR TITLE
Add `#[must_use]` to bot adaptors

### DIFF
--- a/crates/teloxide-core/src/requests/requester_ext.rs
+++ b/crates/teloxide-core/src/requests/requester_ext.rs
@@ -20,6 +20,7 @@ use crate::adaptors::throttle::{Limits, Throttle};
 pub trait RequesterExt: Requester {
     /// Add `get_me` caching ability, see [`CacheMe`] for more.
     #[cfg(feature = "cache_me")]
+    #[must_use]
     fn cache_me(self) -> CacheMe<Self>
     where
         Self: Sized,
@@ -29,6 +30,7 @@ pub trait RequesterExt: Requester {
 
     /// Send requests automatically, see [`AutoSend`] for more.
     #[cfg(feature = "auto_send")]
+    #[must_use]
     #[deprecated(
         since = "0.8.0",
         note = "`AutoSend` is no longer required to `.await` requests and is now noop"
@@ -43,6 +45,7 @@ pub trait RequesterExt: Requester {
 
     /// Erase requester type.
     #[cfg(feature = "erased")]
+    #[must_use]
     fn erase<'a>(self) -> ErasedRequester<'a, Self::Err>
     where
         Self: 'a,
@@ -53,6 +56,7 @@ pub trait RequesterExt: Requester {
 
     /// Trace requests, see [`Trace`] for more.
     #[cfg(feature = "trace_adaptor")]
+    #[must_use]
     fn trace(self, settings: Settings) -> Trace<Self>
     where
         Self: Sized,
@@ -64,6 +68,7 @@ pub trait RequesterExt: Requester {
     ///
     /// Note: this spawns the worker, just as [`Throttle::new_spawn`].
     #[cfg(feature = "throttle")]
+    #[must_use]
     fn throttle(self, limits: Limits) -> Throttle<Self>
     where
         Self: Sized + Clone + Send + Sync + 'static,
@@ -101,6 +106,7 @@ pub trait RequesterExt: Requester {
     /// crate::requests::Requester::edit_message_caption
     /// [`edit_message_caption_inline`]:
     /// crate::requests::Requester::edit_message_caption_inline
+    #[must_use]
     fn parse_mode(self, parse_mode: ParseMode) -> DefaultParseMode<Self>
     where
         Self: Sized,


### PR DESCRIPTION
Made `RequestExt` methods `#[must_use]`. Closes #898.