### PR TITLE
Update triagebot configuration

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1,6 +1,6 @@
 [assign]
 warn_non_default_branch = true
-# contributing_url = "https://rustc-dev-guide.rust-lang.org/contributing.html" # FIXME: configure
+contributing_url = "https://github.com/teloxide/teloxide/blob/master/CONTRIBUTING.md"
 
 [assign.adhoc_groups]
 # This is a special group that will be used if none of the `owners` entries matches.
@@ -56,5 +56,11 @@ allow-unauthenticated = [
 reviewed_label = "S-waiting-on-author"
 # These labels are removed when a review is submitted.
 review_labels = ["S-waiting-on-review"]
+
+[review-requested]
+# Those labels are removed when PR author requests a review from an assignee
+remove_labels = ["S-waiting-on-author"]
+# Those labels are added when PR author requests a review from an assignee
+add_labels = ["S-waiting-on-review"]
 
 [shortcut]


### PR DESCRIPTION
Update triagebot configuration

    - Add the `[review-requested]` table to add and remove status labels when requesting a review
    - Add `contributing_url` to `[assign]` table