### PR TITLE
Sqlx version advance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - MSRV (Minimal Supported Rust Version) was bumped from `1.64.0` to `1.68.0` ([PR 950][https://github.com/teloxide/teloxide/pull/950])
+- Sqlx version was bumped from `0.6` to `0.7.3`([PR 995](https://github.com/teloxide/teloxide/pull/995))
+- Feature `sqlite-storage` was renamed to `sqlite-storage-nativetls`([PR 995](https://github.com/teloxide/teloxide/pull/995))
 
 ### Removed
 

--- a/crates/teloxide/Cargo.toml
+++ b/crates/teloxide/Cargo.toml
@@ -23,8 +23,7 @@ default = ["native-tls", "ctrlc_handler", "teloxide-core/default", "auto-send"]
 webhooks = ["rand"]
 webhooks-axum = ["webhooks", "axum", "tower", "tower-http"]
 
-# FIXME: rename `sqlite-storage` -> `sqlite-storage-nativetls`
-sqlite-storage = ["sqlx", "sqlx/runtime-tokio-native-tls", "native-tls"]
+sqlite-storage-nativetls = ["sqlx", "sqlx/runtime-tokio-native-tls", "native-tls"]
 sqlite-storage-rustls = ["sqlx", "sqlx/runtime-tokio-rustls", "rustls"]
 redis-storage = ["redis"]
 cbor-serializer = ["serde_cbor"]
@@ -51,9 +50,9 @@ nightly = ["teloxide-core/nightly"]
 full = [
     "webhooks",
     "webhooks-axum",
-    "sqlite-storage",
+    "sqlite-storage-nativetls",
     # "sqlite-storage-rustls" is explicitly ommited here,
-    # since it conflicts with "sqlite-storage"
+    # since it conflicts with "sqlite-storage-nativetls"
     "redis-storage",
     "cbor-serializer",
     "bincode-serializer",
@@ -124,7 +123,7 @@ tokio-stream = "0.1"
 
 
 [package.metadata.docs.rs]
-# NB: can't use `all-features = true`, because `sqlite-storage` conflicts with `sqlite-storage-rustls`
+# NB: can't use `all-features = true`, because `sqlite-storage-nativetls` conflicts with `sqlite-storage-rustls`
 features = ["full", "nightly"]
 # FIXME: Add back "-Znormalize-docs" when https://github.com/rust-lang/rust/issues/93703 is fixed
 rustdoc-args = ["--cfg", "docsrs"]
@@ -147,7 +146,7 @@ required-features = ["redis-storage", "cbor-serializer", "bincode-serializer"]
 [[test]]
 name = "sqlite"
 path = "tests/sqlite.rs"
-required-features = ["sqlite-storage", "cbor-serializer", "bincode-serializer"]
+required-features = ["sqlite-storage-nativetls", "cbor-serializer", "bincode-serializer"]
 
 
 [[example]]
@@ -170,7 +169,7 @@ required-features = ["macros", "ctrlc_handler"]
 [[example]]
 name = "db_remember"
 required-features = [
-    "sqlite-storage",
+    "sqlite-storage-nativetls",
     "redis-storage",
     "bincode-serializer",
     "macros",

--- a/crates/teloxide/Cargo.toml
+++ b/crates/teloxide/Cargo.toml
@@ -99,7 +99,7 @@ serde_with_macros = "1.4"
 aquamarine = "0.1.11"
 either = "1.9.0"
 
-sqlx = { version = "0.6", optional = true, default-features = false, features = [
+sqlx = { version = "0.7.3", optional = true, default-features = false, features = [
     "macros",
     "sqlite",
 ] }

--- a/crates/teloxide/src/dispatching/dialogue.rs
+++ b/crates/teloxide/src/dispatching/dialogue.rs
@@ -96,7 +96,7 @@
 #[cfg(feature = "redis-storage")]
 pub use self::{RedisStorage, RedisStorageError};
 
-#[cfg(feature = "sqlite-storage")]
+#[cfg(feature = "sqlite-storage-nativetls")]
 pub use self::{SqliteStorage, SqliteStorageError};
 
 pub use get_chat_id::GetChatId;

--- a/crates/teloxide/src/dispatching/dialogue/storage.rs
+++ b/crates/teloxide/src/dispatching/dialogue/storage.rs
@@ -6,7 +6,7 @@ mod trace_storage;
 #[cfg(feature = "redis-storage")]
 mod redis_storage;
 
-#[cfg(feature = "sqlite-storage")]
+#[cfg(feature = "sqlite-storage-nativetls")]
 mod sqlite_storage;
 
 use futures::future::BoxFuture;
@@ -22,7 +22,7 @@ pub use redis_storage::{RedisStorage, RedisStorageError};
 pub use serializer::Serializer;
 use std::sync::Arc;
 
-#[cfg(feature = "sqlite-storage")]
+#[cfg(feature = "sqlite-storage-nativetls")]
 pub use sqlite_storage::{SqliteStorage, SqliteStorageError};
 
 /// A storage with an erased error type.

--- a/crates/teloxide/src/dispatching/dialogue/storage/sqlite_storage.rs
+++ b/crates/teloxide/src/dispatching/dialogue/storage/sqlite_storage.rs
@@ -40,7 +40,6 @@ impl<S> SqliteStorage<S> {
         serializer: S,
     ) -> Result<Arc<Self>, SqliteStorageError<Infallible>> {
         let pool = SqlitePool::connect(format!("sqlite:{path}?mode=rwc").as_str()).await?;
-        let mut conn = pool.acquire().await?;
         sqlx::query(
             "
 CREATE TABLE IF NOT EXISTS teloxide_dialogues (
@@ -49,7 +48,7 @@ CREATE TABLE IF NOT EXISTS teloxide_dialogues (
 );
         ",
         )
-        .execute(&mut conn)
+        .execute(&pool)
         .await?;
 
         Ok(Arc::new(Self { pool, serializer }))

--- a/crates/teloxide/src/features.md
+++ b/crates/teloxide/src/features.md
@@ -16,8 +16,8 @@
 | `native-tls`         | Enables the [`native-tls`] TLS implementation (**enabled by default**). |
 | `rustls`             | Enables the [`rustls`] TLS implementation. |
 | `redis-storage`      | Enables the [Redis] storage support for dialogues. |
-| `sqlite-storage`     | Enables the [Sqlite] storage support for dialogues (depends on `native-tls`). |
-| `sqlite-storage-rustls`     | Enables the [Sqlite] storage support for dialogues (depends on `rustls`, conflicts with `sqlite-storage`). |
+| `sqlite-storage-nativetls`     | Enables the [Sqlite] storage support for dialogues (depends on `native-tls`). |
+| `sqlite-storage-rustls`     | Enables the [Sqlite] storage support for dialogues (depends on `rustls`, conflicts with `sqlite-storage-nativetls`). |
 | `cbor-serializer`    | Enables the [CBOR] serializer for dialogues. |
 | `bincode-serializer` | Enables the [Bincode] serializer for dialogues. |
 


### PR DESCRIPTION
Close #918 

I noticed in `crates/teloxide/Cargo.toml` that the feature `sqlite-storage` should be renamed to `sqlite-storage-nativetls`, so as far as `sqlx` is used only for the `Sqlite` database at the time of writing, I decided to change it too