### PR TITLE
Add exponential backoff strategy to the polling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Greatly improved the speed of graceful shutdown (`^C`) ([PR 938](https://github.com/teloxide/teloxide/pull/938))
 - Fix typos in docstrings ([PR 953](https://github.com/teloxide/teloxide/pull/953))
 - Use `Seconds` instead of `String` in `InlineQueryResultAudio` for `audio_duration` ([PR 994](https://github.com/teloxide/teloxide/pull/994))
+- Issue [#780](https://github.com/teloxide/teloxide/issues/780) ([PR 1002](https://github.com/teloxide/teloxide/pull/1002))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Greatly improved the speed of graceful shutdown (`^C`) ([PR 938](https://github.com/teloxide/teloxide/pull/938))
 - Fix typos in docstrings ([PR 953](https://github.com/teloxide/teloxide/pull/953))
 - Use `Seconds` instead of `String` in `InlineQueryResultAudio` for `audio_duration` ([PR 994](https://github.com/teloxide/teloxide/pull/994))
-- Issue [#780](https://github.com/teloxide/teloxide/issues/780) ([PR 1002](https://github.com/teloxide/teloxide/pull/1002))
+- High CPU usage on network errors ([PR 1002](https://github.com/teloxide/teloxide/pull/1002), [Issue 780](https://github.com/teloxide/teloxide/issues/780))
 
 ### Changed
 

--- a/crates/teloxide/src/backoff.rs
+++ b/crates/teloxide/src/backoff.rs
@@ -4,7 +4,12 @@ pub type BackoffStrategy = Box<dyn Send + Fn(u32) -> Duration>;
 
 /// Calculates the backoff time in seconds for exponential strategy with base 2
 ///
+/// The maximum duration is limited to a little less than half an hour (1024
+/// secs), so the successive timings are(in secs): 1, 2, 4, .., 1024, 1024, ..
+///
 /// More at: <https://en.wikipedia.org/wiki/Exponential_backoff#Exponential_backoff_algorithm>
 pub fn exponential_backoff_strategy(error_count: u32) -> Duration {
-    Duration::from_secs((1_u64 << error_count).min(30 * 60))
+    // The error_count has to be limited so as not to cause overflow: 2^10 = 1024 ~
+    // a little less than half an hour
+    Duration::from_secs(1_u64 << error_count.min(10))
 }

--- a/crates/teloxide/src/backoff_strategy.rs
+++ b/crates/teloxide/src/backoff_strategy.rs
@@ -1,10 +1,10 @@
 use std::time::Duration;
 
-pub type BackoffStrategy = Box<dyn Fn(u32) -> Duration + Send>;
+pub type BackoffStrategy = Box<dyn Send + Fn(u32) -> Duration>;
 
 /// Calculates the backoff time in seconds for exponential strategy with base 2
 ///
 /// More at: <https://en.wikipedia.org/wiki/Exponential_backoff#Exponential_backoff_algorithm>
 pub fn exponential_backoff_strategy(error_count: u32) -> Duration {
-    Duration::from_secs(2_u64.pow(error_count))
+    Duration::from_secs((1_u64 << error_count).min(30 * 60))
 }

--- a/crates/teloxide/src/backoff_strategy.rs
+++ b/crates/teloxide/src/backoff_strategy.rs
@@ -1,0 +1,10 @@
+use std::time::Duration;
+
+pub type BackoffStrategy = Box<dyn Fn(u32) -> Duration + Send>;
+
+/// Calculates the backoff time in seconds for exponential strategy with base 2
+///
+/// More at: <https://en.wikipedia.org/wiki/Exponential_backoff#Exponential_backoff_algorithm>
+pub fn exponential_backoff_strategy(error_count: u32) -> Duration {
+    Duration::from_secs(2_u64.pow(error_count))
+}

--- a/crates/teloxide/src/lib.rs
+++ b/crates/teloxide/src/lib.rs
@@ -135,7 +135,7 @@ pub use repls::{repl, repl_with_listener};
 #[allow(deprecated)]
 pub use repls::{commands_repl, commands_repl_with_listener};
 
-pub mod backoff_strategy;
+pub mod backoff;
 pub mod dispatching;
 pub mod error_handlers;
 pub mod prelude;

--- a/crates/teloxide/src/lib.rs
+++ b/crates/teloxide/src/lib.rs
@@ -135,6 +135,7 @@ pub use repls::{repl, repl_with_listener};
 #[allow(deprecated)]
 pub use repls::{commands_repl, commands_repl_with_listener};
 
+pub mod backoff_strategy;
 pub mod dispatching;
 pub mod error_handlers;
 pub mod prelude;

--- a/crates/teloxide/src/update_listeners/polling.rs
+++ b/crates/teloxide/src/update_listeners/polling.rs
@@ -88,9 +88,9 @@ where
     }
 
     /// The backoff strategy that will be used for delay calculation between
-    /// reconnections
+    /// reconnections caused by network errors.
     ///
-    /// By default, the [`exponential_backoff_strategy`] is used
+    /// By default, the [`exponential_backoff_strategy`] is used.
     pub fn backoff_strategy(self, backoff_strategy: BackoffStrategy) -> Self {
         Self { backoff_strategy, ..self }
     }
@@ -462,7 +462,7 @@ impl<B: Requester> Stream for PollingStream<'_, B> {
             }
         }
         // Poll eepy future until completion, needed for backoff strategy
-        if let Some(eepy) = this.eepy.as_mut().as_pin_mut() {
+        else if let Some(eepy) = this.eepy.as_mut().as_pin_mut() {
             match eepy.poll(cx) {
                 Poll::Ready(_) => {
                     // As soon as delay is waited we increment the counter

--- a/crates/teloxide/src/update_listeners/polling.rs
+++ b/crates/teloxide/src/update_listeners/polling.rs
@@ -12,8 +12,10 @@ use std::{
 };
 
 use futures::{ready, stream::Stream};
+use tokio::time::{sleep, Sleep};
 
 use crate::{
+    backoff_strategy::{exponential_backoff_strategy, BackoffStrategy},
     requests::{HasPayload, Request, Requester},
     stop::{mk_stop_token, StopFlag, StopToken},
     types::{AllowedUpdate, Update},
@@ -31,6 +33,7 @@ pub struct PollingBuilder<R> {
     pub limit: Option<u8>,
     pub allowed_updates: Option<Vec<AllowedUpdate>>,
     pub drop_pending_updates: bool,
+    pub backoff_strategy: BackoffStrategy,
 }
 
 impl<R> PollingBuilder<R>
@@ -84,6 +87,14 @@ where
         Self { drop_pending_updates: true, ..self }
     }
 
+    /// The backoff strategy that will be used for delay calculation between
+    /// reconnections
+    ///
+    /// By default, the [`exponential_backoff_strategy`] is used
+    pub fn backoff_strategy(self, backoff_strategy: BackoffStrategy) -> Self {
+        Self { backoff_strategy, ..self }
+    }
+
     /// Deletes webhook if it was set up.
     pub async fn delete_webhook(self) -> Self {
         delete_webhook_if_setup(&self.bot).await;
@@ -96,7 +107,8 @@ where
     ///
     /// See also: [`polling_default`], [`Polling`].
     pub fn build(self) -> Polling<R> {
-        let Self { bot, timeout, limit, allowed_updates, drop_pending_updates } = self;
+        let Self { bot, timeout, limit, allowed_updates, drop_pending_updates, backoff_strategy } =
+            self;
         let (token, flag) = mk_stop_token();
         let polling = Polling {
             bot,
@@ -107,6 +119,7 @@ where
             flag: Some(flag),
             token,
             stop_token_cloned: false,
+            backoff_strategy,
         };
 
         assert_update_listener(polling)
@@ -252,6 +265,7 @@ pub struct Polling<B: Requester> {
     flag: Option<StopFlag>,
     token: StopToken,
     stop_token_cloned: bool,
+    backoff_strategy: BackoffStrategy,
 }
 
 impl<R> Polling<R>
@@ -270,6 +284,7 @@ where
             limit: None,
             allowed_updates: None,
             drop_pending_updates: false,
+            backoff_strategy: Box::new(exponential_backoff_strategy),
         }
     }
 
@@ -317,6 +332,14 @@ pub struct PollingStream<'a, B: Requester> {
     /// The flag that notifies polling to stop polling.
     #[pin]
     flag: StopFlag,
+
+    /// How long it takes to make next reconnection attempt
+    #[pin]
+    eepy: Option<Sleep>,
+
+    /// Counter for network errors occured during the current series of
+    /// reconnections
+    error_count: u32,
 }
 
 impl<B: Requester + Send + 'static> UpdateListener for Polling<B> {
@@ -369,6 +392,8 @@ impl<'a, B: Requester + Send + 'a> AsUpdateStream<'a> for Polling<B> {
             buffer: Vec::new().into_iter(),
             in_flight: None,
             flag,
+            eepy: None,
+            error_count: 0,
         }
     }
 }
@@ -415,6 +440,9 @@ impl<B: Requester> Stream for PollingStream<'_, B> {
                     return Ready(Some(Err(err)));
                 }
                 Ok(updates) => {
+                    // Once we got the update hense the backoff reconnection strategy worked
+                    *this.error_count = 0;
+
                     if let Some(upd) = updates.last() {
                         *this.offset = upd.id.as_offset();
                     }
@@ -424,7 +452,26 @@ impl<B: Requester> Stream for PollingStream<'_, B> {
                         true => *this.drop_pending_updates = false,
                     }
                 }
-                Err(err) => return Ready(Some(Err(err))),
+                Err(err) => {
+                    // Prevents the CPU spike occuring at network connection lose: <https://github.com/teloxide/teloxide/issues/780>
+                    let backoff_strategy = &this.polling.backoff_strategy;
+                    this.eepy.set(Some(sleep(backoff_strategy(*this.error_count))));
+                    log::trace!("set {:?} reconnection delay", backoff_strategy(*this.error_count));
+                    return Ready(Some(Err(err)));
+                }
+            }
+        }
+        // Poll eepy future until completion, needed for backoff strategy
+        if let Some(eepy) = this.eepy.as_mut().as_pin_mut() {
+            match eepy.poll(cx) {
+                Poll::Ready(_) => {
+                    // As soon as delay is waited we increment the counter
+                    *this.error_count = this.error_count.saturating_add(1);
+                    log::trace!("current error count: {}", *this.error_count);
+                    log::trace!("backoff delay completed");
+                    this.eepy.set(None);
+                }
+                Poll::Pending => return Poll::Pending,
             }
         }
 


### PR DESCRIPTION
Close #780

Add the exponential backoff strategy to the polling mechanism (+ ability to change it with custom one). 

Checked on Ubuntu 23.10. Here's my system monitor after network disconnected:
![image](https://github.com/teloxide/teloxide/assets/74814717/b55804f8-e79f-49dc-84a5-6ae7b6a2b273)

Log with `RUST_LOG=trace`:
```bash
 INFO  teloxide_test > Starting throw dice bot...
 DEBUG reqwest::connect > starting new connection: https://api.telegram.org/
 DEBUG teloxide::dispatching::dispatcher > hinting allowed updates: [Message]
 TRACE teloxide::update_listeners::polling > polling polling stream
 TRACE teloxide::update_listeners::polling > polling polling stream
 TRACE teloxide::update_listeners::polling > polling polling stream
 TRACE teloxide::update_listeners::polling > in-flight request completed
 TRACE teloxide::update_listeners::polling > Set 1s reconnection delay
 ERROR teloxide::error_handlers            > An error from the update listener: Network(reqwest::Error { kind: Request, url: Url { scheme: "https", cannot_be_a_base: false, username: "", password: None, host: Some(Domain("api.telegram.org")), port: None, path: "/token:redacted/GetUpdates", query: None, fragment: None }, source: TimedOut })
 TRACE teloxide::update_listeners::polling > polling polling stream
 TRACE teloxide::update_listeners::polling > polling polling stream
 TRACE teloxide::update_listeners::polling > current error count: 1
 TRACE teloxide::update_listeners::polling > backoff delay completed
 TRACE teloxide::update_listeners::polling > polling polling stream
 DEBUG reqwest::connect                    > starting new connection: https://api.telegram.org/
 TRACE teloxide::update_listeners::polling > polling polling stream
 TRACE teloxide::update_listeners::polling > in-flight request completed
 TRACE teloxide::update_listeners::polling > Set 2s reconnection delay
 ERROR teloxide::error_handlers            > An error from the update listener: Network(reqwest::Error { kind: Request, url: Url { scheme: "https", cannot_be_a_base: false, username: "", password: None, host: Some(Domain("api.telegram.org")), port: None, path: "/token:redacted/GetUpdates", query: None, fragment: None }, source: hyper::Error(Connect, ConnectError("dns error", Custom { kind: Uncategorized, error: "failed to lookup address information: Temporary failure in name resolution" })) })
 TRACE teloxide::update_listeners::polling > polling polling stream
 TRACE teloxide::update_listeners::polling > polling polling stream
 TRACE teloxide::update_listeners::polling > current error count: 2
 TRACE teloxide::update_listeners::polling > backoff delay completed
 TRACE teloxide::update_listeners::polling > polling polling stream
 DEBUG reqwest::connect                    > starting new connection: https://api.telegram.org/
 TRACE teloxide::update_listeners::polling > polling polling stream
 TRACE teloxide::update_listeners::polling > in-flight request completed
 TRACE teloxide::update_listeners::polling > Set 4s reconnection delay
 ERROR teloxide::error_handlers            > An error from the update listener: Network(reqwest::Error { kind: Request, url: Url { scheme: "https", cannot_be_a_base: false, username: "", password: None, host: Some(Domain("api.telegram.org")), port: None, path: "/token:redacted/GetUpdates", query: None, fragment: None }, source: hyper::Error(Connect, ConnectError("dns error", Custom { kind: Uncategorized, error: "failed to lookup address information: Temporary failure in name resolution" })) })
 TRACE teloxide::update_listeners::polling > polling polling stream
 TRACE teloxide::update_listeners::polling > polling polling stream
 TRACE teloxide::update_listeners::polling > current error count: 3
 TRACE teloxide::update_listeners::polling > backoff delay completed
 TRACE teloxide::update_listeners::polling > polling polling stream
 DEBUG reqwest::connect                    > starting new connection: https://api.telegram.org/
 TRACE teloxide::update_listeners::polling > polling polling stream
 TRACE teloxide::update_listeners::polling > in-flight request completed
 TRACE teloxide::update_listeners::polling > Set 8s reconnection delay
```

When I turn my internet connection on, bot starts working normally