### PR TITLE
Implement `GetChatId` for `teloxide-core::types::*`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `filter_video_chat_ended`
   - `filter_video_chat_participants_invited`
   - `filter_web_app_data` 
+- Implement `GetChatId` for `teloxide_core::types::{BotCommandScope, Chat, ChatJoinRequest, ChatMemberUpdated, MessageCommon, Recipient, ResponseParameters, TargetMessage, UpdateKind}`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `filter_video_chat_ended`
   - `filter_video_chat_participants_invited`
   - `filter_web_app_data` 
-- Implement `GetChatId` for `teloxide_core::types::{BotCommandScope, Chat, ChatJoinRequest, ChatMemberUpdated, MessageCommon, Recipient, ResponseParameters, TargetMessage}`.
+- Implement `GetChatId` for `teloxide_core::types::{Chat, ChatJoinRequest, ChatMemberUpdated, Recipient, TargetMessage}`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `filter_video_chat_ended`
   - `filter_video_chat_participants_invited`
   - `filter_web_app_data` 
-- Implement `GetChatId` for `teloxide_core::types::{Chat, ChatJoinRequest, ChatMemberUpdated, Recipient, TargetMessage}`.
+- Implement `GetChatId` for `teloxide_core::types::{Chat, ChatJoinRequest, ChatMemberUpdated}`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `filter_video_chat_ended`
   - `filter_video_chat_participants_invited`
   - `filter_web_app_data` 
-- Implement `GetChatId` for `teloxide_core::types::{BotCommandScope, Chat, ChatJoinRequest, ChatMemberUpdated, MessageCommon, Recipient, ResponseParameters, TargetMessage, UpdateKind}`.
+- Implement `GetChatId` for `teloxide_core::types::{BotCommandScope, Chat, ChatJoinRequest, ChatMemberUpdated, MessageCommon, Recipient, ResponseParameters, TargetMessage}`.
 
 ### Fixed
 

--- a/crates/teloxide/src/dispatching/dialogue/get_chat_id.rs
+++ b/crates/teloxide/src/dispatching/dialogue/get_chat_id.rs
@@ -1,15 +1,12 @@
-use crate::types::{CallbackQuery, ChatId, Message, Update};
+use crate::types::{
+    BotCommandScope, CallbackQuery, Chat, ChatId, ChatJoinRequest, ChatMemberUpdated, Message,
+    MessageCommon, Recipient, ResponseParameters, TargetMessage, Update, UpdateKind,
+};
 
-/// Something that may has a chat ID.
+/// Something that may have a chat ID.
 pub trait GetChatId {
     #[must_use]
     fn chat_id(&self) -> Option<ChatId>;
-}
-
-impl GetChatId for Message {
-    fn chat_id(&self) -> Option<ChatId> {
-        Some(self.chat.id)
-    }
 }
 
 impl GetChatId for CallbackQuery {
@@ -18,8 +15,100 @@ impl GetChatId for CallbackQuery {
     }
 }
 
+impl GetChatId for MessageCommon {
+    fn chat_id(&self) -> Option<ChatId> {
+        self.sender_chat.as_ref().map(|chat| chat.id)
+    }
+}
+
 impl GetChatId for Update {
     fn chat_id(&self) -> Option<ChatId> {
         self.chat().map(|chat| chat.id)
     }
 }
+
+impl GetChatId for Recipient {
+    fn chat_id(&self) -> Option<ChatId> {
+        match self {
+            Recipient::Id(chat_id) => Some(*chat_id),
+            Recipient::ChannelUsername(_) => None,
+        }
+    }
+}
+
+impl GetChatId for BotCommandScope {
+    fn chat_id(&self) -> Option<ChatId> {
+        match self {
+            BotCommandScope::Default
+            | BotCommandScope::AllPrivateChats
+            | BotCommandScope::AllGroupChats
+            | BotCommandScope::AllChatAdministrators => None,
+            BotCommandScope::Chat { chat_id: recipient }
+            | BotCommandScope::ChatAdministrators { chat_id: recipient }
+            | BotCommandScope::ChatMember { chat_id: recipient, .. } => recipient.chat_id(),
+        }
+    }
+}
+
+impl GetChatId for Chat {
+    fn chat_id(&self) -> Option<ChatId> {
+        Some(self.id)
+    }
+}
+
+impl GetChatId for UpdateKind {
+    fn chat_id(&self) -> Option<ChatId> {
+        match self {
+            UpdateKind::Message(message)
+            | UpdateKind::EditedMessage(message)
+            | UpdateKind::ChannelPost(message)
+            | UpdateKind::EditedChannelPost(message) => GetChatId::chat_id(message),
+            UpdateKind::CallbackQuery(callback_query) => callback_query.chat_id(),
+            UpdateKind::MyChatMember(chat_member_updated) => chat_member_updated.chat_id(),
+            UpdateKind::ChatMember(chat_member_updated) => chat_member_updated.chat_id(),
+            UpdateKind::ChatJoinRequest(chat_join_request) => chat_join_request.chat_id(),
+            UpdateKind::InlineQuery(_)
+            | UpdateKind::ChosenInlineResult(_)
+            | UpdateKind::ShippingQuery(_)
+            | UpdateKind::PreCheckoutQuery(_)
+            | UpdateKind::Poll(_)
+            | UpdateKind::PollAnswer(_)
+            | UpdateKind::Error(_) => None,
+        }
+    }
+}
+
+impl GetChatId for ResponseParameters {
+    fn chat_id(&self) -> Option<ChatId> {
+        match self {
+            ResponseParameters::MigrateToChatId(chat_id) => Some(*chat_id),
+            ResponseParameters::RetryAfter(_) => None,
+        }
+    }
+}
+
+impl GetChatId for TargetMessage {
+    fn chat_id(&self) -> Option<ChatId> {
+        match self {
+            TargetMessage::Common { chat_id: recipient, .. } => recipient.chat_id(),
+            TargetMessage::Inline { .. } => None,
+        }
+    }
+}
+
+/// Implements [`GetChatId`] for all types passed in, as long as they have a
+/// `chat` field with a `Chat` type
+macro_rules! impl_GetChatId_for_chat_field {
+    // Comma-separated list of types bound to `t`
+    ($($t:ty),* $(,)?) => {
+        $(
+            impl GetChatId for $t {
+                fn chat_id(&self) -> Option<ChatId> {
+                    Some(self.chat.id)
+                }
+            }
+        )*
+    };
+}
+
+impl_GetChatId_for_chat_field!(Message, ChatMemberUpdated, ChatJoinRequest);

--- a/crates/teloxide/src/dispatching/dialogue/get_chat_id.rs
+++ b/crates/teloxide/src/dispatching/dialogue/get_chat_id.rs
@@ -1,6 +1,6 @@
 use crate::types::{
     BotCommandScope, CallbackQuery, Chat, ChatId, ChatJoinRequest, ChatMemberUpdated, Message,
-    MessageCommon, Recipient, ResponseParameters, TargetMessage, Update, UpdateKind,
+    MessageCommon, Recipient, ResponseParameters, TargetMessage, Update,
 };
 
 /// Something that may have a chat ID.
@@ -56,28 +56,6 @@ impl GetChatId for Chat {
     }
 }
 
-impl GetChatId for UpdateKind {
-    fn chat_id(&self) -> Option<ChatId> {
-        match self {
-            UpdateKind::Message(message)
-            | UpdateKind::EditedMessage(message)
-            | UpdateKind::ChannelPost(message)
-            | UpdateKind::EditedChannelPost(message) => GetChatId::chat_id(message),
-            UpdateKind::CallbackQuery(callback_query) => callback_query.chat_id(),
-            UpdateKind::MyChatMember(chat_member_updated) => chat_member_updated.chat_id(),
-            UpdateKind::ChatMember(chat_member_updated) => chat_member_updated.chat_id(),
-            UpdateKind::ChatJoinRequest(chat_join_request) => chat_join_request.chat_id(),
-            UpdateKind::InlineQuery(_)
-            | UpdateKind::ChosenInlineResult(_)
-            | UpdateKind::ShippingQuery(_)
-            | UpdateKind::PreCheckoutQuery(_)
-            | UpdateKind::Poll(_)
-            | UpdateKind::PollAnswer(_)
-            | UpdateKind::Error(_) => None,
-        }
-    }
-}
-
 impl GetChatId for ResponseParameters {
     fn chat_id(&self) -> Option<ChatId> {
         match self {
@@ -96,19 +74,20 @@ impl GetChatId for TargetMessage {
     }
 }
 
-/// Implements [`GetChatId`] for all types passed in, as long as they have a
-/// `chat` field with a `Chat` type
-macro_rules! impl_GetChatId_for_chat_field {
-    // Comma-separated list of types bound to `t`
-    ($($t:ty),* $(,)?) => {
-        $(
-            impl GetChatId for $t {
-                fn chat_id(&self) -> Option<ChatId> {
-                    Some(self.chat.id)
-                }
-            }
-        )*
-    };
+impl GetChatId for Message {
+    fn chat_id(&self) -> Option<ChatId> {
+        Some(self.chat.id)
+    }
 }
 
-impl_GetChatId_for_chat_field!(Message, ChatMemberUpdated, ChatJoinRequest);
+impl GetChatId for ChatMemberUpdated {
+    fn chat_id(&self) -> Option<ChatId> {
+        Some(self.chat.id)
+    }
+}
+
+impl GetChatId for ChatJoinRequest {
+    fn chat_id(&self) -> Option<ChatId> {
+        Some(self.chat.id)
+    }
+}

--- a/crates/teloxide/src/dispatching/dialogue/get_chat_id.rs
+++ b/crates/teloxide/src/dispatching/dialogue/get_chat_id.rs
@@ -1,6 +1,6 @@
 use crate::types::{
-    BotCommandScope, CallbackQuery, Chat, ChatId, ChatJoinRequest, ChatMemberUpdated, Message,
-    MessageCommon, Recipient, ResponseParameters, TargetMessage, Update,
+    CallbackQuery, Chat, ChatId, ChatJoinRequest, ChatMemberUpdated, Message,
+    Recipient, TargetMessage, Update,
 };
 
 /// Something that may have a chat ID.
@@ -9,15 +9,15 @@ pub trait GetChatId {
     fn chat_id(&self) -> Option<ChatId>;
 }
 
-impl GetChatId for CallbackQuery {
+impl GetChatId for Message {
     fn chat_id(&self) -> Option<ChatId> {
-        self.message.as_ref().map(|mes| mes.chat.id)
+        Some(self.chat.id)
     }
 }
 
-impl GetChatId for MessageCommon {
+impl GetChatId for CallbackQuery {
     fn chat_id(&self) -> Option<ChatId> {
-        self.sender_chat.as_ref().map(|chat| chat.id)
+        self.message.as_ref().map(|mes| mes.chat.id)
     }
 }
 
@@ -36,32 +36,9 @@ impl GetChatId for Recipient {
     }
 }
 
-impl GetChatId for BotCommandScope {
-    fn chat_id(&self) -> Option<ChatId> {
-        match self {
-            BotCommandScope::Default
-            | BotCommandScope::AllPrivateChats
-            | BotCommandScope::AllGroupChats
-            | BotCommandScope::AllChatAdministrators => None,
-            BotCommandScope::Chat { chat_id: recipient }
-            | BotCommandScope::ChatAdministrators { chat_id: recipient }
-            | BotCommandScope::ChatMember { chat_id: recipient, .. } => recipient.chat_id(),
-        }
-    }
-}
-
 impl GetChatId for Chat {
     fn chat_id(&self) -> Option<ChatId> {
         Some(self.id)
-    }
-}
-
-impl GetChatId for ResponseParameters {
-    fn chat_id(&self) -> Option<ChatId> {
-        match self {
-            ResponseParameters::MigrateToChatId(chat_id) => Some(*chat_id),
-            ResponseParameters::RetryAfter(_) => None,
-        }
     }
 }
 
@@ -71,12 +48,6 @@ impl GetChatId for TargetMessage {
             TargetMessage::Common { chat_id: recipient, .. } => recipient.chat_id(),
             TargetMessage::Inline { .. } => None,
         }
-    }
-}
-
-impl GetChatId for Message {
-    fn chat_id(&self) -> Option<ChatId> {
-        Some(self.chat.id)
     }
 }
 

--- a/crates/teloxide/src/dispatching/dialogue/get_chat_id.rs
+++ b/crates/teloxide/src/dispatching/dialogue/get_chat_id.rs
@@ -1,6 +1,5 @@
 use crate::types::{
-    CallbackQuery, Chat, ChatId, ChatJoinRequest, ChatMemberUpdated, Message,
-    Recipient, TargetMessage, Update,
+    CallbackQuery, Chat, ChatId, ChatJoinRequest, ChatMemberUpdated, Message, Update,
 };
 
 /// Something that may have a chat ID.
@@ -27,27 +26,9 @@ impl GetChatId for Update {
     }
 }
 
-impl GetChatId for Recipient {
-    fn chat_id(&self) -> Option<ChatId> {
-        match self {
-            Recipient::Id(chat_id) => Some(*chat_id),
-            Recipient::ChannelUsername(_) => None,
-        }
-    }
-}
-
 impl GetChatId for Chat {
     fn chat_id(&self) -> Option<ChatId> {
         Some(self.id)
-    }
-}
-
-impl GetChatId for TargetMessage {
-    fn chat_id(&self) -> Option<ChatId> {
-        match self {
-            TargetMessage::Common { chat_id: recipient, .. } => recipient.chat_id(),
-            TargetMessage::Inline { .. } => None,
-        }
     }
 }
 


### PR DESCRIPTION
<!--
Before making this PR, please ensure the following:

- `CHANGELOG.md` is updated (if necessary).
- Documentation and tests are updated (if necessary).
-->
First contribution.

Implements `GetChatId` for remaining `teloxide-core::types::*` which can hold a `ChatId`.

No tests were implemented, since this is just a really basic  “getter trait”. I was in doubt of using the hygienic macro, in favor of just repeating the implementation body, ended up using the simple macro with clear documentation to make the code more concise.

Closes #983, since it implements for all updates, too.