### PR TITLE
crates: remove unused dependencies

### DIFF
--- a/crates/teloxide-core/Cargo.toml
+++ b/crates/teloxide-core/Cargo.toml
@@ -72,7 +72,6 @@ once_cell = "1.5.0"
 takecell = "0.1"
 take_mut = "0.2"
 rc-box = "1.1.1"
-never = "0.1.0"
 chrono = { version = "0.4.30", default-features = false }
 either = "1.6.1"
 bitflags = { version = "1.2" }

--- a/crates/teloxide/Cargo.toml
+++ b/crates/teloxide/Cargo.toml
@@ -96,7 +96,6 @@ derive_more = "0.99"
 thiserror = "1.0"
 futures = "0.3.15"
 pin-project = "1.0"
-serde_with_macros = "3.4"
 aquamarine = "0.5.0"
 either = "1.9.0"
 


### PR DESCRIPTION
Drops unused `serde_with_macros` from `teloxide` and `never` from `teloxide-core`

Fixes #1015
