### PR TITLE
Fix app build errors when using items gated behind sqlite-storage with rustls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix typos in documentation ([PR 953](https://github.com/teloxide/teloxide/pull/953))
 - Use `Seconds` instead of `String` in `InlineQueryResultAudio` for `audio_duration` ([PR 994](https://github.com/teloxide/teloxide/pull/994))
 - High CPU usage on network errors ([PR 1002](https://github.com/teloxide/teloxide/pull/1002), [Issue 780](https://github.com/teloxide/teloxide/issues/780))
+- Fix app build errors when using items gated behind sqlite-storage with the feature sqlite-storage-rustls ([PR 1018](https://github.com/teloxide/teloxide/pull/1018))
 
 ### Changed
 

--- a/crates/teloxide/src/dispatching/dialogue.rs
+++ b/crates/teloxide/src/dispatching/dialogue.rs
@@ -96,7 +96,7 @@
 #[cfg(feature = "redis-storage")]
 pub use self::{RedisStorage, RedisStorageError};
 
-#[cfg(feature = "sqlite-storage-nativetls")]
+#[cfg(any(feature = "sqlite-storage-nativetls", feature = "sqlite-storage-rustls"))]
 pub use self::{SqliteStorage, SqliteStorageError};
 
 pub use get_chat_id::GetChatId;

--- a/crates/teloxide/src/dispatching/dialogue/storage.rs
+++ b/crates/teloxide/src/dispatching/dialogue/storage.rs
@@ -6,7 +6,7 @@ mod trace_storage;
 #[cfg(feature = "redis-storage")]
 mod redis_storage;
 
-#[cfg(feature = "sqlite-storage-nativetls")]
+#[cfg(any(feature = "sqlite-storage-nativetls", feature = "sqlite-storage-rustls"))]
 mod sqlite_storage;
 
 use futures::future::BoxFuture;
@@ -22,7 +22,7 @@ pub use redis_storage::{RedisStorage, RedisStorageError};
 pub use serializer::Serializer;
 use std::sync::Arc;
 
-#[cfg(feature = "sqlite-storage-nativetls")]
+#[cfg(any(feature = "sqlite-storage-nativetls", feature = "sqlite-storage-rustls"))]
 pub use sqlite_storage::{SqliteStorage, SqliteStorageError};
 
 /// A storage with an erased error type.


### PR DESCRIPTION
When the feature `sqlite-storage-rustls` is enabled instead of the nativetls version, apps using this library won't compile, with the error `note: the item is gated behind the `sqlite-storage` feature`. This PR fixes that by modifying the conditional compilation to accept either feature.