### PR TITLE
Changed `escape` functions in both html and markdown utils to do less allocations and also be slightly faster

### DIFF
--- a/crates/teloxide/src/utils/html.rs
+++ b/crates/teloxide/src/utils/html.rs
@@ -101,7 +101,15 @@ pub fn code_inline(s: &str) -> String {
 #[must_use = "This function returns a new string, rather than mutating the argument, so calling it \
               without using its output does nothing useful"]
 pub fn escape(s: &str) -> String {
-    s.replace('&', "&amp;").replace('<', "&lt;").replace('>', "&gt;")
+    s.chars().fold(String::with_capacity(s.len()), |mut s, c| {
+        match c {
+            '&' => s.push_str("&amp;"),
+            '<' => s.push_str("&lt;"),
+            '>' => s.push_str("&gt;"),
+            c => s.push(c),
+        }
+        s
+    })
 }
 
 #[must_use = "This function returns a new string, rather than mutating the argument, so calling it \

--- a/crates/teloxide/src/utils/markdown.rs
+++ b/crates/teloxide/src/utils/markdown.rs
@@ -109,24 +109,17 @@ pub fn code_inline(s: &str) -> String {
 #[must_use = "This function returns a new string, rather than mutating the argument, so calling it \
               without using its output does nothing useful"]
 pub fn escape(s: &str) -> String {
-    s.replace('_', r"\_")
-        .replace('*', r"\*")
-        .replace('[', r"\[")
-        .replace(']', r"\]")
-        .replace('(', r"\(")
-        .replace(')', r"\)")
-        .replace('~', r"\~")
-        .replace('`', r"\`")
-        .replace('>', r"\>")
-        .replace('#', r"\#")
-        .replace('+', r"\+")
-        .replace('-', r"\-")
-        .replace('=', r"\=")
-        .replace('|', r"\|")
-        .replace('{', r"\{")
-        .replace('}', r"\}")
-        .replace('.', r"\.")
-        .replace('!', r"\!")
+    const CHARS: [char; 18] = [
+        '_', '*', '[', ']', '(', ')', '~', '`', '>', '#', '+', '-', '=', '|', '{', '}', '.', '!',
+    ];
+
+    s.chars().fold(String::with_capacity(s.len()), |mut s, c| {
+        if CHARS.contains(&c) {
+            s.push('\\');
+        }
+        s.push(c);
+        s
+    })
 }
 
 /// Escapes all markdown special characters specific for the inline link URL
@@ -134,7 +127,13 @@ pub fn escape(s: &str) -> String {
 #[must_use = "This function returns a new string, rather than mutating the argument, so calling it \
               without using its output does nothing useful"]
 pub fn escape_link_url(s: &str) -> String {
-    s.replace('`', r"\`").replace(')', r"\)")
+    s.chars().fold(String::with_capacity(s.len()), |mut s, c| {
+        if ['`', ')'].contains(&c) {
+            s.push('\\');
+        }
+        s.push(c);
+        s
+    })
 }
 
 /// Escapes all markdown special characters specific for the code block (``` and
@@ -142,7 +141,13 @@ pub fn escape_link_url(s: &str) -> String {
 #[must_use = "This function returns a new string, rather than mutating the argument, so calling it \
               without using its output does nothing useful"]
 pub fn escape_code(s: &str) -> String {
-    s.replace('\\', r"\\").replace('`', r"\`")
+    s.chars().fold(String::with_capacity(s.len()), |mut s, c| {
+        if ['`', '\\'].contains(&c) {
+            s.push('\\');
+        }
+        s.push(c);
+        s
+    })
 }
 
 #[must_use = "This function returns a new string, rather than mutating the argument, so calling it \

--- a/crates/teloxide/src/utils/markdown.rs
+++ b/crates/teloxide/src/utils/markdown.rs
@@ -109,9 +109,8 @@ pub fn code_inline(s: &str) -> String {
 #[must_use = "This function returns a new string, rather than mutating the argument, so calling it \
               without using its output does nothing useful"]
 pub fn escape(s: &str) -> String {
-    const CHARS: [char; 18] = [
-        '_', '*', '[', ']', '(', ')', '~', '`', '>', '#', '+', '-', '=', '|', '{', '}', '.', '!',
-    ];
+    const CHARS: [char; 18] =
+        ['_', '*', '[', ']', '(', ')', '~', '`', '>', '#', '+', '-', '=', '|', '{', '}', '.', '!'];
 
     s.chars().fold(String::with_capacity(s.len()), |mut s, c| {
         if CHARS.contains(&c) {


### PR DESCRIPTION
We are currently chaining `replace` function back to back for escaping `html` and `markdown` characters, this can cause some slowdown and extra allocations because `replace` function will allocate a new string on each call.
I updated the `escape` functions to don't use `replace` anymore, result is no more useless allocations/deallocations and also being slightly faster.
I used `stats_alloc` crate to monitor the allocations, bellow I'll share the test code and the results.
```rs
use stats_alloc::{StatsAlloc, Region, INSTRUMENTED_SYSTEM};
use std::alloc::System;

#[global_allocator]
static GLOBAL: &StatsAlloc<System> = &INSTRUMENTED_SYSTEM;

// Just a long string to test the escape functions
const TEXT: &str = "<<<<<<<<>>>>>&&&&&&&&&&&**********************************************{{{{{{{{{{{{{{{{{}}}}}}}}}}}}}}}{{}{}{}{}{{{}}{}P}}{{}{}'_', '*', '[', ']', '(', ')', '~', '`', '>', '#', '+', '-', '=', '|', '{', '}', '.', '!''_', '*', '[', ']', '(', ')', '~', '`', '>', '#', '+', '-', '=', '|', '{', '}', '.', '!'";


fn main() {
    let reg = Region::new(GLOBAL);
    let val_old = escape_markdown_old(TEXT);
    println!("Stats at markdown old function: {:#?}", reg.change());

    let reg = Region::new(GLOBAL);
    let val = escape_markdown(TEXT);
    println!("Stats at markdown new function: {:#?}", reg.change());

    assert_eq!(val, val_old);

    let reg = Region::new(GLOBAL);
    let val_old = escape_html_old(TEXT);
    println!("Stats at html old function: {:#?}", reg.change());

    let reg = Region::new(GLOBAL);
    let val = escape_html(TEXT);
    println!("Stats at html new function: {:#?}", reg.change());

    assert_eq!(val, val_old);
}

fn escape_markdown(s: &str) -> String {
    const CHARS: [char; 18] = [
        '_', '*', '[', ']', '(', ')', '~', '`', '>', '#', '+', '-', '=', '|', '{', '}', '.', '!',
    ];

    s.chars().fold(String::with_capacity(s.len()), |mut s, c| {
        if CHARS.contains(&c) {
            s.push('\\');
        }
        s.push(c);
        s
    })
}

fn escape_markdown_old(s: &str) -> String {
    s.replace('_', r"\_")
        .replace('*', r"\*")
        .replace('[', r"\[")
        .replace(']', r"\]")
        .replace('(', r"\(")
        .replace(')', r"\)")
        .replace('~', r"\~")
        .replace('`', r"\`")
        .replace('>', r"\>")
        .replace('#', r"\#")
        .replace('+', r"\+")
        .replace('-', r"\-")
        .replace('=', r"\=")
        .replace('|', r"\|")
        .replace('{', r"\{")
        .replace('}', r"\}")
        .replace('.', r"\.")
        .replace('!', r"\!")
}

fn escape_html(s: &str) ->String {
    s.chars().fold(String::with_capacity(s.len()), |mut s, c| {
        match c {
            '&' => s.push_str("&amp;"),
            '<' => s.push_str("&lt;"),
            '>' => s.push_str("&gt;"),
            c => s.push(c),
        }
        s
    })
}

fn escape_html_old(s: &str) ->String {
    s.replace('&', "&amp;").replace('<', "&lt;").replace('>', "&gt;")
}
```
result:
```
Stats at markdown old function: Stats {
    allocations: 18,
    deallocations: 17,
    reallocations: 28,
    bytes_allocated: 8354,
    bytes_deallocated: 7742,
    bytes_reallocated: 5091,
}
Stats at markdown new function: Stats {
    allocations: 1,
    deallocations: 0,
    reallocations: 1,
    bytes_allocated: 556,
    bytes_deallocated: 0,
    bytes_reallocated: 278,
}
Stats at html old function: Stats {
    allocations: 3,
    deallocations: 2,
    reallocations: 1,
    bytes_allocated: 842,
    bytes_deallocated: 556,
    bytes_reallocated: 143,
}
Stats at html new function: Stats {
    allocations: 1,
    deallocations: 0,
    reallocations: 1,
    bytes_allocated: 556,
    bytes_deallocated: 0,
    bytes_reallocated: 278,
}
```
as you can see results talk for themselves so I won't go to more details.