### PR TITLE
feature: Support for Business Messages (receiving and sending)

### DIFF
--- a/crates/teloxide-core/schema.ron
+++ b/crates/teloxide-core/schema.ron
@@ -292,6 +292,11 @@ Schema(
                         }
                     ),
                 ),
+                Param(
+                    name: "business_connection_id",
+                    ty: Option(String),
+                    descr: Doc(md: "Business connection identifier"),
+                ),
             ],
         ),
         Method(

--- a/crates/teloxide-core/src/payloads/send_message.rs
+++ b/crates/teloxide-core/src/payloads/send_message.rs
@@ -45,6 +45,8 @@ impl_payload! {
             /// [inline keyboard]: https://core.telegram.org/bots#inline-keyboards-and-on-the-fly-updating
             /// [custom reply keyboard]: https://core.telegram.org/bots#keyboards
             pub reply_markup: ReplyMarkup [into],
+            /// Business connection identifier
+            pub business_connection_id: String [into],
         }
     }
 }

--- a/crates/teloxide-core/src/types/allowed_update.rs
+++ b/crates/teloxide-core/src/types/allowed_update.rs
@@ -17,4 +17,6 @@ pub enum AllowedUpdate {
     MyChatMember,
     ChatMember,
     ChatJoinRequest,
+    BusinessMessage,
+    EditedBusinessMessage,
 }

--- a/crates/teloxide-core/src/types/message.rs
+++ b/crates/teloxide-core/src/types/message.rs
@@ -41,6 +41,8 @@ pub struct Message {
 
     #[serde(flatten)]
     pub kind: MessageKind,
+
+    pub business_connection_id: Option<String>,
 }
 
 // FIXME: this could be a use-case for serde mixed-tags, some variants need to
@@ -1769,7 +1771,8 @@ mod tests {
                 kind: MessageKind::ChatShared(MessageChatShared {
                     chat_shared: ChatShared { request_id: 348349, chat_id: ChatId(384939) }
                 }),
-                via_bot: None
+                via_bot: None,
+                business_connection_id: None,
             }
         );
     }

--- a/crates/teloxide-core/src/types/update.rs
+++ b/crates/teloxide-core/src/types/update.rs
@@ -227,7 +227,7 @@ impl Update {
         use UpdateKind::*;
 
         let chat = match &self.kind {
-            Message(m) | EditedMessage(m) | ChannelPost(m) | EditedChannelPost(m)  => &m.chat,
+            Message(m) | EditedMessage(m) | ChannelPost(m) | EditedChannelPost(m) => &m.chat,
             BusinessMessage(m) | EditedBusinessMessage(m) => &m.chat,
             CallbackQuery(q) => &q.message.as_ref()?.chat,
             ChatMember(m) => &m.chat,

--- a/crates/teloxide/src/dispatching/filter_ext.rs
+++ b/crates/teloxide/src/dispatching/filter_ext.rs
@@ -155,4 +155,6 @@ define_update_ext! {
     (filter_my_chat_member, UpdateKind::MyChatMember, MyChatMember),
     (filter_chat_member, UpdateKind::ChatMember, ChatMember),
     (filter_chat_join_request, UpdateKind::ChatJoinRequest, ChatJoinRequest),
+    (filter_business_message, UpdateKind::BusinessMessage, BusinessMessage),
+    (filter_edited_business_message, UpdateKind::EditedBusinessMessage, EditedBusinessMessage),
 }

--- a/crates/teloxide/src/dispatching/handler_description.rs
+++ b/crates/teloxide/src/dispatching/handler_description.rs
@@ -75,6 +75,8 @@ impl EventKind for Kind {
             MyChatMember,
             ChatMember,
             ChatJoinRequest,
+            BusinessMessage,
+            EditedBusinessMessage,
         ]
         .into_iter()
         .map(Kind)


### PR DESCRIPTION
Part of Bot Api 7.2:  https://core.telegram.org/bots/api#march-31-2024

> * Added updates about new messages in a business account connected to the bot, represented by the field business_message in the class [Update](https://core.telegram.org/bots/api#update).
> * Added the parameter business_connection_id to the methods [sendMessage](https://core.telegram.org/bots/api#sendmessage)


# Example

```rust
    let bot = Bot::from_env();

    let handler = Update::filter_business_message().endpoint(
        |bot: Bot, msg: Message| async move {
            let mut request = bot
                .send_message(msg.chat.id, format!("Hello, how can I help you?"))
                .with_payload_mut(|payload| {
                    payload.business_connection_id = msg.business_connection_id.clone();
                    payload.reply_to_message_id = Some(msg.id);
                });

            request.await?;
            respond(())
        },
    );

    Dispatcher::builder(bot, handler)
        .build()
        .dispatch()
        .await;
```