### PR TITLE
Fixed `ChatPermissions` bug and improved trace `Settings`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - High CPU usage on network errors ([PR 1002](https://github.com/teloxide/teloxide/pull/1002), [Issue 780](https://github.com/teloxide/teloxide/issues/780))
 - Fix app build errors when using items gated behind sqlite-storage with the feature sqlite-storage-rustls ([PR 1018](https://github.com/teloxide/teloxide/pull/1018))
 - Fix typo in `ApiError::ToMuchMessages` variant (rename it to `TooMuchMessages`) ([PR 1046](https://github.com/teloxide/teloxide/pull/1046))
+- Fix `ChatPermission` behavior to accurately reflect Telegram's functionality ([PR 1068](https://github.com/teloxide/teloxide/pull/1068))
 
 ### Changed
 

--- a/crates/teloxide-core/src/adaptors/trace.rs
+++ b/crates/teloxide-core/src/adaptors/trace.rs
@@ -66,20 +66,20 @@ bitflags::bitflags! {
     /// ```
     pub struct Settings: u8 {
         /// Trace requests (only request kind, e.g. `send_message`)
-        const TRACE_REQUESTS = 0b00000001;
+        const TRACE_REQUESTS = 1;
 
         /// Trace requests verbosely (with all parameters).
         ///
         /// Implies [`TRACE_REQUESTS`]
-        const TRACE_REQUESTS_VERBOSE = 0b00000011;
+        const TRACE_REQUESTS_VERBOSE = (1 << 1) | Self::TRACE_REQUESTS.bits;
 
         /// Trace responses (only request kind, e.g. `send_message`)
-        const TRACE_RESPONSES = 0b00000100;
+        const TRACE_RESPONSES = 1 << 2;
 
         /// Trace responses verbosely (with full response).
         ///
         /// Implies [`TRACE_RESPONSES`]
-        const TRACE_RESPONSES_VERBOSE = 0b00001100;
+        const TRACE_RESPONSES_VERBOSE = (1 << 3) | Self::TRACE_RESPONSES.bits;
 
         /// Trace everything.
         ///

--- a/crates/teloxide-core/src/types/chat_permissions.rs
+++ b/crates/teloxide-core/src/types/chat_permissions.rs
@@ -30,84 +30,67 @@ bitflags::bitflags! {
     /// assert!(permissions_v1.contains(ChatPermissions::INVITE_USERS));
     /// assert!(permissions_v1.contains(ChatPermissions::SEND_VIDEOS));
     ///
-    /// // Implied by `SEND_VIDEOS`
-    /// assert!(permissions_v1.contains(ChatPermissions::SEND_MESSAGES));
-    ///
     /// // Difference, remove permissions
     /// let permissions_v2 = permissions_v1 - ChatPermissions::SEND_VIDEOS;
     /// assert!(!permissions_v2.contains(ChatPermissions::SEND_VIDEOS));
-    ///
-    /// // Removing `SEND_VIDEOS` also removes `SEND_MESSAGES` and vice versa
-    /// // because `SEND_MESSAGES` is implied by `SEND_VIDEOS`
-    /// assert!(!permissions_v2.contains(ChatPermissions::SEND_MESSAGES));
-    ///
-    /// let permissions_v3 = permissions_v1 - ChatPermissions::SEND_MESSAGES;
-    /// assert!(!permissions_v3.contains(ChatPermissions::SEND_VIDEOS));
     /// ```
     #[derive(Serialize, Deserialize)]
     #[serde(from = "ChatPermissionsRaw", into = "ChatPermissionsRaw")]
     pub struct ChatPermissions: u16 {
         /// Set if the user is allowed to send text messages, contacts,
-        /// locations and venues.
+        /// giveaways, giveaway winners, invoices, locations and venues
         const SEND_MESSAGES = 1;
 
-        /// Set if the user is allowed to send polls, implies
-        /// `SEND_MESSAGES`.
-        const SEND_POLLS = (1 << 2) | Self::SEND_MESSAGES.bits;
+        /// Set if the user is allowed to send polls
+        const SEND_POLLS = 1 << 1;
 
         /// Set if the user is allowed to send animations, games, stickers and
-        /// use inline bots, implies `SEND_MEDIA_MESSAGES`.
-        const SEND_OTHER_MESSAGES = (1 << 3);
+        /// use inline bots.
+        const SEND_OTHER_MESSAGES = 1 << 2;
 
         /// Set if the user is allowed to add web page previews to
-        /// their messages, implies `SEND_MEDIA_MESSAGES`.
-        const ADD_WEB_PAGE_PREVIEWS = (1 << 4);
+        /// their messages.
+        const ADD_WEB_PAGE_PREVIEWS = 1 << 3;
 
         /// Set if the user is allowed to change the chat title, photo and
         /// other settings. Ignored in public supergroups.
-        const CHANGE_INFO = (1 << 5);
+        const CHANGE_INFO = 1 << 4;
 
         /// Set if the user is allowed to invite new users to the chat.
-        const INVITE_USERS = (1 << 6);
+        const INVITE_USERS = 1 << 5;
 
         /// Set if the user is allowed to pin messages. Ignored in public
         /// supergroups.
-        const PIN_MESSAGES = (1 << 7);
+        const PIN_MESSAGES = 1 << 6;
 
         /// Set if the user is allowed to create, rename, close, and reopen forum topics.
-        const MANAGE_TOPICS = (1 << 8);
+        const MANAGE_TOPICS = 1 << 7;
 
-        /// Set if the user is allowed to send audios. implies
-        /// `SEND_MESSAGES`.
-        const SEND_AUDIOS = (1 << 9) | Self::SEND_MESSAGES.bits;
+        /// Set if the user is allowed to send audios.
+        const SEND_AUDIOS = 1 << 8;
 
-        /// Set if the user is allowed to send documents. implies
-        /// `SEND_MESSAGES`.
-        const SEND_DOCUMENTS = (1 << 10) | Self::SEND_MESSAGES.bits;
+        /// Set if the user is allowed to send documents.
+        const SEND_DOCUMENTS = 1 << 9;
 
-        /// Set if the user is allowed to send photos. implies
-        /// `SEND_MESSAGES`.
-        const SEND_PHOTOS = (1 << 11) | Self::SEND_MESSAGES.bits;
+        /// Set if the user is allowed to send photos.
+        const SEND_PHOTOS = 1 << 10;
 
-        /// Set if the user is allowed to send videos. implies
-        /// `SEND_MESSAGES`.
-        const SEND_VIDEOS = (1 << 12) | Self::SEND_MESSAGES.bits;
+        /// Set if the user is allowed to send videos.
+        const SEND_VIDEOS = 1 << 11;
 
-        /// Set if the user is allowed to send video notes. implies
-        /// `SEND_MESSAGES`.
-        const SEND_VIDEO_NOTES = (1 << 13) | Self::SEND_MESSAGES.bits;
+        /// Set if the user is allowed to send video notes.
+        const SEND_VIDEO_NOTES = 1 << 12;
 
         /// Set if the user is allowed to send voice notes. implies
         /// `SEND_MESSAGES`.
-        const SEND_VOICE_NOTES = (1 << 14) | Self::SEND_MESSAGES.bits;
+        const SEND_VOICE_NOTES = 1 << 13;
 
         /// Set if the user is allowed to send audios, documents,
         /// photos, videos, video notes and voice notes, implies
-        /// `SEND_MESSAGES`, `SEND_AUDIOS`, `SEND_DOCUMENTS`,
-        /// `SEND_PHOTOS`, `SEND_VIDEOS`, `SEND_VIDEO_NOTES` and `SEND_VOICE_NOTES`.
+        /// `SEND_AUDIOS`, `SEND_DOCUMENTS`, `SEND_PHOTOS`,
+        /// `SEND_VIDEOS`, `SEND_VIDEO_NOTES` and `SEND_VOICE_NOTES`.
         /// Note: this is not a separate permission on it's own, this is just a alias for all the permissions mentioned.
-        const SEND_MEDIA_MESSAGES = Self::SEND_MESSAGES.bits
-                                            | Self::SEND_AUDIOS.bits
+        const SEND_MEDIA_MESSAGES = Self::SEND_AUDIOS.bits
                                             | Self::SEND_DOCUMENTS.bits
                                             | Self::SEND_PHOTOS.bits
                                             | Self::SEND_VIDEOS.bits
@@ -278,12 +261,12 @@ impl From<ChatPermissions> for ChatPermissionsRaw {
     fn from(this: ChatPermissions) -> Self {
         Self {
             can_send_messages: this.can_send_messages(),
-            can_send_audios: this.contains(ChatPermissions::SEND_AUDIOS),
-            can_send_documents: this.contains(ChatPermissions::SEND_DOCUMENTS),
-            can_send_photos: this.contains(ChatPermissions::SEND_PHOTOS),
-            can_send_videos: this.contains(ChatPermissions::SEND_VIDEOS),
-            can_send_video_notes: this.contains(ChatPermissions::SEND_VIDEO_NOTES),
-            can_send_voice_notes: this.contains(ChatPermissions::SEND_VOICE_NOTES),
+            can_send_audios: this.can_send_audios(),
+            can_send_documents: this.can_send_documents(),
+            can_send_photos: this.can_send_photos(),
+            can_send_videos: this.can_send_videos(),
+            can_send_video_notes: this.can_send_video_notes(),
+            can_send_voice_notes: this.can_send_voice_notes(),
             can_send_polls: this.can_send_polls(),
             can_send_other_messages: this.can_send_other_messages(),
             can_add_web_page_previews: this.can_add_web_page_previews(),
@@ -370,7 +353,9 @@ mod tests {
 
     #[test]
     fn serialization() {
-        let permissions = ChatPermissions::SEND_AUDIOS | ChatPermissions::PIN_MESSAGES;
+        let permissions = ChatPermissions::SEND_MESSAGES
+            | ChatPermissions::SEND_AUDIOS
+            | ChatPermissions::PIN_MESSAGES;
         let expected = r#"{"can_send_messages":true,"can_send_audios":true,"can_pin_messages":true,"can_manage_topics":false}"#;
         let actual = serde_json::to_string(&permissions).unwrap();
         assert_eq!(expected, actual);
@@ -379,8 +364,20 @@ mod tests {
     #[test]
     fn deserialization() {
         let json = r#"{"can_send_messages":true,"can_send_photos":true,"can_pin_messages":true}"#;
-        let expected = ChatPermissions::SEND_PHOTOS | ChatPermissions::PIN_MESSAGES;
+        let expected = ChatPermissions::SEND_MESSAGES
+            | ChatPermissions::SEND_PHOTOS
+            | ChatPermissions::PIN_MESSAGES;
         let actual = serde_json::from_str(json).unwrap();
         assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn modfiy_permission() {
+        let before = ChatPermissions::SEND_MESSAGES
+            | ChatPermissions::SEND_PHOTOS
+            | ChatPermissions::SEND_AUDIOS;
+        let after = before - ChatPermissions::SEND_MESSAGES;
+        let expected = ChatPermissions::SEND_PHOTOS | ChatPermissions::SEND_AUDIOS;
+        assert_eq!(after, expected);
     }
 }


### PR DESCRIPTION
This PR addresses a bug in `ChatPermissions` that caused incorrect behavior with media variants. Previously, all media variants implied that `SEND_MESSAGES` also needed to be enabled for them to function. This led to issues:

- **Inaccurate Representation**: Telegram allows disabling `SEND_MESSAGES` while keeping media permissions active. This means users can send media, interact with inline bots and... even without text messaging abilities.
- **Bitflag Invalidation**: Assuming `SEND_MESSAGES` on every variant caused problems with bitflags. Removing one permission from a combination like `ChatPermissions::SEND_AUDIOS | ChatPermissions::SEND_VIDEOS` would invalidate the entire bitflag because both expected `SEND_MESSAGES` to be present. Removing one would also remove `SEND_MESSAGES`, making the remaining permission invalid.

## Improvements:

- Fixe the `ChatPermissions` behavior to accurately reflect Telegram's functionality.
- Enhanced the clarity of `trace::Settings` for better understanding.
- A new test has been added to `ChatPermissions` to ensure it functions as intended.
