### PR TITLE
Require chrono >= 0.4.32

### DIFF
--- a/crates/teloxide-core/Cargo.toml
+++ b/crates/teloxide-core/Cargo.toml
@@ -72,7 +72,7 @@ once_cell = "1.5.0"
 takecell = "0.1"
 take_mut = "0.2"
 rc-box = "1.1.1"
-chrono = { version = "0.4.30", default-features = false }
+chrono = { version = "0.4.32", default-features = false }
 either = "1.6.1"
 bitflags = { version = "1.2" }
 


### PR DESCRIPTION
It's required for teloxide's usages of `chrono::Duration::try_seconds`: https://github.com/chronotope/chrono/commit/a2820c4
