### PR TITLE
Add a feature for rustls + native certs

### DIFF
--- a/crates/teloxide-core/Cargo.toml
+++ b/crates/teloxide-core/Cargo.toml
@@ -22,6 +22,7 @@ categories = ["api-bindings", "asynchronous"]
 default = ["native-tls"]
 
 rustls = ["reqwest/rustls-tls"]
+rustls-native-roots = ["reqwest/rustls-tls-native-roots"]
 native-tls = ["reqwest/native-tls"]
 
 # Features which require nightly compiler.

--- a/crates/teloxide/Cargo.toml
+++ b/crates/teloxide/Cargo.toml
@@ -42,6 +42,7 @@ ctrlc_handler = ["tokio/signal"]
 
 native-tls = ["teloxide-core/native-tls"]
 rustls = ["teloxide-core/rustls"]
+rustls-native-roots = ["teloxide-core/rustls-native-roots"]
 throttle = ["teloxide-core/throttle"]
 cache-me = [
     "teloxide-core/cache_me",


### PR DESCRIPTION
This just propagates `reqwest/rustls-tls-native-roots`, which is a compromise approach of using `rustls` but with native (not bundled) certificates.
