### PR TITLE
Bump deps of webhook-axum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Sqlx version was bumped from `0.6` to `0.7.3`([PR 995](https://github.com/teloxide/teloxide/pull/995))
 - Feature `sqlite-storage` was renamed to `sqlite-storage-nativetls`([PR 995](https://github.com/teloxide/teloxide/pull/995))
 - MSRV (Minimal Supported Rust Version) was bumped from `1.68.0` to `1.70.0` ([PR 996][https://github.com/teloxide/teloxide/pull/996])
+- `axum` was bumped to `0.7`, along with related libraries used for webhooks ([PR 1093][https://github.com/teloxide/teloxide/pull/1093])
 
 ### Removed
 

--- a/crates/teloxide/Cargo.toml
+++ b/crates/teloxide/Cargo.toml
@@ -112,9 +112,9 @@ sqlx = { version = "0.7.3", optional = true, default-features = false, features 
 redis = { version = "0.24", features = ["tokio-comp"], optional = true }
 serde_cbor = { version = "0.11", optional = true }
 bincode = { version = "1.3", optional = true }
-axum = { version = "0.6.0", optional = true }
-tower = { version = "0.4.12", optional = true }
-tower-http = { version = "0.3.4", features = ["trace"], optional = true }
+axum = { version = "0.7.0", optional = true }
+tower = { version = "0.4.13", optional = true }
+tower-http = { version = "0.5.2", features = ["trace"], optional = true }
 rand = { version = "0.8.5", optional = true }
 
 # HACK: ahash 0.8.7 bumped MSRV to 1.72, to keep MVSR 1.68 we need to depend on an older version.

--- a/crates/teloxide/src/update_listeners/webhooks/axum.rs
+++ b/crates/teloxide/src/update_listeners/webhooks/axum.rs
@@ -47,13 +47,13 @@ where
     <R as Requester>::DeleteWebhook: Send,
 {
     let Options { address, .. } = options;
+    let tcp_listener = tokio::net::TcpListener::bind(address).await.unwrap();
 
     let (mut update_listener, stop_flag, app) = axum_to_router(bot, options).await?;
     let stop_token = update_listener.stop_token();
 
     tokio::spawn(async move {
-        axum::Server::bind(&address)
-            .serve(app.into_make_service())
+        axum::serve(tcp_listener, app)
             .with_graceful_shutdown(stop_flag)
             .await
             .map_err(|err| {
@@ -90,7 +90,7 @@ where
 /// [`delete_webhook`]: crate::payloads::DeleteWebhook
 /// [`stop`]: crate::stop::StopToken::stop
 /// [`options.address`]: Options::address
-/// [`with_graceful_shutdown`]: axum::Server::with_graceful_shutdown
+/// [`with_graceful_shutdown`]: axum::serve::Serve::with_graceful_shutdown
 ///
 /// ## Returns
 ///


### PR DESCRIPTION
Otherwise some changes in axum's Router interface prevent teloxide's webhook support from being used with up-to-date axum.

<!--
Before making this PR, please ensure the following:

- `CHANGELOG.md` is updated (if necessary).
- Documentation and tests are updated (if necessary).
-->
