### PR TITLE
Replace `serde_with_macros` with `serde_with`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -912,7 +912,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.6",
  "tokio",
  "tower-service",
  "tracing",
@@ -1843,6 +1843,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678b5a069e50bf00ecd22d0cd8ddf7c236f68581b03db652061ed5eb13a312ff"
+dependencies = [
+ "serde",
+ "serde_with_macros",
+]
+
+[[package]]
 name = "serde_with_macros"
 version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2238,7 +2248,7 @@ dependencies = [
  "ron",
  "serde",
  "serde_json",
- "serde_with_macros",
+ "serde_with",
  "take_mut",
  "takecell",
  "thiserror",

--- a/crates/teloxide-core/Cargo.toml
+++ b/crates/teloxide-core/Cargo.toml
@@ -63,7 +63,7 @@ log = "0.4"
 
 serde = { version = "1.0.114", features = ["derive"] }
 serde_json = "1.0.55"
-serde_with_macros = "1.5.2"
+serde_with = "1.5.2"
 uuid = { version = "1.1.0", features = ["v4"] }        # for attaching input files
 
 derive_more = "0.99.9"

--- a/crates/teloxide-core/src/local_macros.rs
+++ b/crates/teloxide-core/src/local_macros.rs
@@ -124,7 +124,7 @@ macro_rules! impl_payload {
             )?
         }
     ) => {
-        #[serde_with_macros::skip_serializing_none]
+        #[serde_with::skip_serializing_none]
         #[must_use = "Requests do nothing unless sent"]
         $(
             #[ $($method_meta)* ]

--- a/crates/teloxide-core/src/serde_multipart/serializers.rs
+++ b/crates/teloxide-core/src/serde_multipart/serializers.rs
@@ -378,7 +378,7 @@ impl Serializer for PartSerializer {
 
     fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
         unimplemented!(
-            "We use `#[serde_with_macros::skip_serializing_none]` everywhere so `None`s are not \
+            "We use `#[serde_with::skip_serializing_none]` everywhere so `None`s are not \
              serialized"
         )
     }

--- a/crates/teloxide-core/src/types/animation.rs
+++ b/crates/teloxide-core/src/types/animation.rs
@@ -7,7 +7,7 @@ use crate::types::{FileMeta, PhotoSize, Seconds};
 /// without sound).
 ///
 /// [The official docs](https://core.telegram.org/bots/api#animation).
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct Animation {
     /// Metadata of the animation file.

--- a/crates/teloxide-core/src/types/audio.rs
+++ b/crates/teloxide-core/src/types/audio.rs
@@ -7,7 +7,7 @@ use crate::types::{FileMeta, PhotoSize, Seconds};
 /// clients.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#audio).
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct Audio {
     /// Metadata of the audio file.

--- a/crates/teloxide-core/src/types/bot_command.rs
+++ b/crates/teloxide-core/src/types/bot_command.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 /// This object represents a bot command.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#botcommand).
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct BotCommand {
     /// Text of the command, 1-32 characters.

--- a/crates/teloxide-core/src/types/callback_game.rs
+++ b/crates/teloxide-core/src/types/callback_game.rs
@@ -8,6 +8,6 @@ use serde::{Deserialize, Serialize};
 /// Use [@Botfather] to set up your game.
 ///
 /// [@Botfather]:  https://t.me/botfather
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct CallbackGame {}

--- a/crates/teloxide-core/src/types/callback_query.rs
+++ b/crates/teloxide-core/src/types/callback_query.rs
@@ -15,7 +15,7 @@ use crate::types::{Message, User};
 ///
 /// [inline keyboard]: https://core.telegram.org/bots#inline-keyboards-and-on-the-fly-updating
 /// [inline mode]: https://core.telegram.org/bots/api#inline-mode
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct CallbackQuery {
     /// An unique identifier for this query.

--- a/crates/teloxide-core/src/types/chat.rs
+++ b/crates/teloxide-core/src/types/chat.rs
@@ -7,7 +7,7 @@ use crate::types::{
 /// This object represents a chat.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#chat).
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Chat {
     /// A unique identifier for this chat.
@@ -52,7 +52,7 @@ pub struct Chat {
     pub chat_full_info: ChatFullInfo,
 }
 
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum ChatKind {
@@ -60,7 +60,7 @@ pub enum ChatKind {
     Private(ChatPrivate),
 }
 
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ChatPublic {
     /// A title, for supergroups, channels and group chats.
@@ -94,7 +94,7 @@ pub struct ChatPublic {
     pub has_protected_content: Option<True>,
 }
 
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(from = "serde_helper::ChatPrivate", into = "serde_helper::ChatPrivate")]
 pub struct ChatPrivate {
@@ -135,7 +135,7 @@ pub struct ChatPrivate {
     pub has_restricted_voice_and_video_messages: Option<True>,
 }
 
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 #[serde(tag = "type")]
@@ -145,7 +145,7 @@ pub enum PublicChatKind {
     Supergroup(PublicChatSupergroup),
 }
 
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct PublicChatChannel {
     /// A username, for private chats, supergroups and channels if available.
@@ -158,7 +158,7 @@ pub struct PublicChatChannel {
     pub linked_chat_id: Option<i64>,
 }
 
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct PublicChatGroup {
     /// A default chat member permissions, for groups and supergroups. Returned
@@ -168,7 +168,7 @@ pub struct PublicChatGroup {
     pub permissions: Option<ChatPermissions>,
 }
 
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct PublicChatSupergroup {
     /// A username, for private chats, supergroups and channels if

--- a/crates/teloxide-core/src/types/chat_administrator_rights.rs
+++ b/crates/teloxide-core/src/types/chat_administrator_rights.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 /// Represents the rights of an administrator in a chat.
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct ChatAdministratorRights {
     /// `true`, if the user's presence in the chat is hidden

--- a/crates/teloxide-core/src/types/chat_full_info.rs
+++ b/crates/teloxide-core/src/types/chat_full_info.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 // TODO: in the TBA7.3 the Chat will be splitted into Chat and ChatInfo
 // Currently it's just a container for the some fields of the Chat struct
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ChatFullInfo {
     /// Expiration date of the emoji status of the chat or the other party in a

--- a/crates/teloxide-core/src/types/chat_invite_link.rs
+++ b/crates/teloxide-core/src/types/chat_invite_link.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::types::User;
 
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct ChatInviteLink {
     /// The invite link. If the link was created by another chat administrator,

--- a/crates/teloxide-core/src/types/chat_join_request.rs
+++ b/crates/teloxide-core/src/types/chat_join_request.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use crate::types::{Chat, ChatId, ChatInviteLink, User};
 
 /// Represents a join request sent to a chat.
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ChatJoinRequest {
     /// Chat to which the request was sent

--- a/crates/teloxide-core/src/types/chat_location.rs
+++ b/crates/teloxide-core/src/types/chat_location.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use crate::types::Location;
 
 /// Represents a location to which a chat is connected.
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ChatLocation {
     /// The location to which the supergroup is connected. Can't be a live

--- a/crates/teloxide-core/src/types/chat_member.rs
+++ b/crates/teloxide-core/src/types/chat_member.rs
@@ -7,7 +7,7 @@ use crate::types::{UntilDate, User};
 /// This object contains information about one member of the chat.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#chatmember).
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct ChatMember {
     /// Information about the user.
@@ -33,7 +33,7 @@ pub enum ChatMemberKind {
 }
 
 /// Owner of the group. This struct is part of the [`ChatMemberKind`] enum.
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct Owner {
     /// Custom title for this user.
@@ -45,7 +45,7 @@ pub struct Owner {
 
 /// Administrator of the group. This struct is part of the [`ChatMemberKind`]
 /// enum.
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct Administrator {
     /// Custom title for this user.
@@ -107,7 +107,7 @@ pub struct Administrator {
 
 /// User, restricted in the group. This struct is part of the [`ChatMemberKind`]
 /// enum.
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct Restricted {
     /// Date when restrictions will be lifted for this user.
@@ -166,7 +166,7 @@ pub struct Restricted {
 
 /// User that was banned in the chat and can't return to it or view chat
 /// messages. This struct is part of the [`ChatMemberKind`] enum.
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct Banned {
     /// Date when restrictions will be lifted for this user.

--- a/crates/teloxide-core/src/types/chat_member_updated.rs
+++ b/crates/teloxide-core/src/types/chat_member_updated.rs
@@ -6,7 +6,7 @@ use crate::types::{Chat, ChatInviteLink, ChatMember, User};
 /// This object represents changes in the status of a chat member.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#chatmemberupdated).
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ChatMemberUpdated {
     /// Chat the user belongs to

--- a/crates/teloxide-core/src/types/chat_photo.rs
+++ b/crates/teloxide-core/src/types/chat_photo.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 /// This object represents a chat photo.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#chatphoto).
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct ChatPhoto {
     /// A file identifier of small (160x160) chat photo. This file_id can be

--- a/crates/teloxide-core/src/types/chosen_inline_result.rs
+++ b/crates/teloxide-core/src/types/chosen_inline_result.rs
@@ -8,7 +8,7 @@ use crate::types::{Location, User};
 /// [The official docs](https://core.telegram.org/bots/api#choseninlineresult).
 ///
 /// [result]: https://core.telegram.org/bots/api#inlinequeryresult
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ChosenInlineResult {
     /// The unique identifier for the result that was chosen.

--- a/crates/teloxide-core/src/types/contact.rs
+++ b/crates/teloxide-core/src/types/contact.rs
@@ -5,7 +5,7 @@ use crate::types::UserId;
 /// This object represents a phone contact.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#contact).
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct Contact {
     /// A contact's phone number.

--- a/crates/teloxide-core/src/types/dice.rs
+++ b/crates/teloxide-core/src/types/dice.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use crate::types::DiceEmoji;
 
 /// This object represents an animated emoji that displays a random value.
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Dice {
     /// Emoji on which the dice throw animation is based.

--- a/crates/teloxide-core/src/types/document.rs
+++ b/crates/teloxide-core/src/types/document.rs
@@ -11,7 +11,7 @@ use crate::types::{FileMeta, PhotoSize};
 /// [photos]: https://core.telegram.org/bots/api#photosize
 /// [voice messages]: https://core.telegram.org/bots/api#voice
 /// [audio files]: https://core.telegram.org/bots/api#audio
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct Document {
     /// Metadata of the document file.

--- a/crates/teloxide-core/src/types/encrypted_credentials.rs
+++ b/crates/teloxide-core/src/types/encrypted_credentials.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 /// [`EncryptedPassportElement`]:
 /// crate::types::EncryptedPassportElement
 /// [Telegram Passport Documentation]: https://core.telegram.org/passport#receiving-information
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct EncryptedCredentials {
     /// Base64-encoded encrypted JSON-serialized data with unique user's

--- a/crates/teloxide-core/src/types/encrypted_passport_element.rs
+++ b/crates/teloxide-core/src/types/encrypted_passport_element.rs
@@ -6,7 +6,7 @@ use super::PassportFile;
 /// shared with the bot by the user.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#encryptedpassportelement).
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct EncryptedPassportElement {
     /// Base64-encoded element hash for using in
@@ -39,7 +39,7 @@ pub enum EncryptedPassportElementKind {
     Email(EncryptedPassportElementEmail),
 }
 
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct EncryptedPassportElementPersonalDetails {
     ///  Base64-encoded encrypted Telegram Passport element data provided
@@ -53,7 +53,7 @@ pub struct EncryptedPassportElementPersonalDetails {
     pub data: String,
 }
 
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct EncryptedPassportElementPassport {
     ///  Base64-encoded encrypted Telegram Passport element data provided
@@ -97,7 +97,7 @@ pub struct EncryptedPassportElementPassport {
     pub translation: Option<Vec<PassportFile>>,
 }
 
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct EncryptedPassportElementDriverLicense {
     ///  Base64-encoded encrypted Telegram Passport element data provided
@@ -150,7 +150,7 @@ pub struct EncryptedPassportElementDriverLicense {
     pub translation: Option<Vec<PassportFile>>,
 }
 
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct EncryptedPassportElementIdentityCard {
     ///  Base64-encoded encrypted Telegram Passport element data provided
@@ -203,7 +203,7 @@ pub struct EncryptedPassportElementIdentityCard {
     pub translation: Option<Vec<PassportFile>>,
 }
 
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct EncryptedPassportElementInternalPassport {
     ///  Base64-encoded encrypted Telegram Passport element data provided
@@ -247,7 +247,7 @@ pub struct EncryptedPassportElementInternalPassport {
     pub translation: Option<Vec<PassportFile>>,
 }
 
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct EncryptedPassportElementAddress {
     ///  Base64-encoded encrypted Telegram Passport element data provided
@@ -261,7 +261,7 @@ pub struct EncryptedPassportElementAddress {
     pub data: String,
 }
 
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct EncryptedPassportElementUtilityBill {
     /// Array of encrypted files with documents provided by the user,
@@ -287,7 +287,7 @@ pub struct EncryptedPassportElementUtilityBill {
     pub translation: Option<Vec<PassportFile>>,
 }
 
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct EncryptedPassportElementBankStatement {
     /// Array of encrypted files with documents provided by the user,
@@ -313,7 +313,7 @@ pub struct EncryptedPassportElementBankStatement {
     pub translation: Option<Vec<PassportFile>>,
 }
 
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct EncryptedPassportElementRentalAgreement {
     /// Array of encrypted files with documents provided by the user,
@@ -339,7 +339,7 @@ pub struct EncryptedPassportElementRentalAgreement {
     pub translation: Option<Vec<PassportFile>>,
 }
 
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct EncryptedPassportElementPassportRegistration {
     /// Array of encrypted files with documents provided by the user,
@@ -365,7 +365,7 @@ pub struct EncryptedPassportElementPassportRegistration {
     pub translation: Option<Vec<PassportFile>>,
 }
 
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct EncryptedPassportElementTemporaryRegistration {
     /// Array of encrypted files with documents provided by the user,
@@ -391,7 +391,7 @@ pub struct EncryptedPassportElementTemporaryRegistration {
     pub translation: Option<Vec<PassportFile>>,
 }
 
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct EncryptedPassportElementPhoneNumber {
     /// User's verified phone number, available only for `phone_number`
@@ -399,7 +399,7 @@ pub struct EncryptedPassportElementPhoneNumber {
     pub phone_number: String,
 }
 
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct EncryptedPassportElementEmail {
     /// User's verified email address, available only for `email` type.

--- a/crates/teloxide-core/src/types/force_reply.rs
+++ b/crates/teloxide-core/src/types/force_reply.rs
@@ -12,7 +12,7 @@ use crate::types::True;
 /// [The official docs](https://core.telegram.org/bots/api#forcereply).
 ///
 /// [privacy mode]: https://core.telegram.org/bots#privacy-mode
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Default, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct ForceReply {
     /// Shows reply interface to the user, as if they manually selected the

--- a/crates/teloxide-core/src/types/forum_topic.rs
+++ b/crates/teloxide-core/src/types/forum_topic.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 /// This object represents a forum topic.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#forumtopiccreated).
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct ForumTopic {
     /// Unique identifier of the forum topic

--- a/crates/teloxide-core/src/types/forum_topic_closed.rs
+++ b/crates/teloxide-core/src/types/forum_topic_closed.rs
@@ -4,6 +4,6 @@ use serde::{Deserialize, Serialize};
 /// chat. Currently holds no information.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#forumtopicclosed).
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct ForumTopicClosed {}

--- a/crates/teloxide-core/src/types/forum_topic_created.rs
+++ b/crates/teloxide-core/src/types/forum_topic_created.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 /// the chat.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#forumtopiccreated).
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct ForumTopicCreated {
     /// Name of the topic.

--- a/crates/teloxide-core/src/types/forum_topic_edited.rs
+++ b/crates/teloxide-core/src/types/forum_topic_edited.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 /// This object represents a service message about an edited forum topic.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#forumtopicedited).
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct ForumTopicEdited {
     /// New name of the topic, if it was edited

--- a/crates/teloxide-core/src/types/forum_topic_reopened.rs
+++ b/crates/teloxide-core/src/types/forum_topic_reopened.rs
@@ -4,6 +4,6 @@ use serde::{Deserialize, Serialize};
 /// chat. Currently holds no information.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#forumtopicreopened).
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct ForumTopicReopened {}

--- a/crates/teloxide-core/src/types/game.rs
+++ b/crates/teloxide-core/src/types/game.rs
@@ -8,7 +8,7 @@ use crate::types::{Animation, MessageEntity, PhotoSize, User};
 /// unique identifiers.
 ///
 /// [@Botfather]: https://t.me/botfather
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct Game {
     /// Title of the game.

--- a/crates/teloxide-core/src/types/game_high_score.rs
+++ b/crates/teloxide-core/src/types/game_high_score.rs
@@ -5,7 +5,7 @@ use crate::types::user::User;
 /// This object represents one row of the high scores table for a game.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#gamehighscore).
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct GameHighScore {
     /// Position in high score table for the game.

--- a/crates/teloxide-core/src/types/general_forum_topic_hidden.rs
+++ b/crates/teloxide-core/src/types/general_forum_topic_hidden.rs
@@ -4,6 +4,6 @@ use serde::{Deserialize, Serialize};
 /// the chat. Currently holds no information.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#generalforumtopichidden).
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct GeneralForumTopicHidden {}

--- a/crates/teloxide-core/src/types/general_forum_topic_unhidden.rs
+++ b/crates/teloxide-core/src/types/general_forum_topic_unhidden.rs
@@ -4,6 +4,6 @@ use serde::{Deserialize, Serialize};
 /// in the chat. Currently holds no information.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#generalforumtopicunhidden).
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct GeneralForumTopicUnhidden {}

--- a/crates/teloxide-core/src/types/inline_keyboard_button.rs
+++ b/crates/teloxide-core/src/types/inline_keyboard_button.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 /// This object represents one button of an inline keyboard.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#inlinekeyboardbutton).
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct InlineKeyboardButton {
     /// Label text on the button.

--- a/crates/teloxide-core/src/types/inline_keyboard_markup.rs
+++ b/crates/teloxide-core/src/types/inline_keyboard_markup.rs
@@ -11,7 +11,7 @@ use crate::types::InlineKeyboardButton;
 /// [The official docs](https://core.telegram.org/bots/api#inlinekeyboardmarkup).
 ///
 /// [inline keyboard]: https://core.telegram.org/bots#inline-keyboards-and-on-the-fly-updating
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, Default)]
 pub struct InlineKeyboardMarkup {
     /// Array of button rows, each represented by an array of

--- a/crates/teloxide-core/src/types/inline_query.rs
+++ b/crates/teloxide-core/src/types/inline_query.rs
@@ -8,7 +8,7 @@ use crate::types::{ChatType, Location, User};
 /// trending results.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#inlinequery).
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct InlineQuery {
     /// Unique identifier for this query.

--- a/crates/teloxide-core/src/types/inline_query_result_article.rs
+++ b/crates/teloxide-core/src/types/inline_query_result_article.rs
@@ -5,7 +5,7 @@ use crate::types::{InlineKeyboardMarkup, InputMessageContent};
 /// Represents a link to an article or web page.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#inlinequeryresultarticle).
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct InlineQueryResultArticle {
     /// Unique identifier for this result, 1-64 Bytes.

--- a/crates/teloxide-core/src/types/inline_query_result_audio.rs
+++ b/crates/teloxide-core/src/types/inline_query_result_audio.rs
@@ -9,7 +9,7 @@ use crate::types::{InlineKeyboardMarkup, InputMessageContent, MessageEntity, Par
 /// the specified content instead of the audio.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#inlinequeryresultaudio).
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct InlineQueryResultAudio {
     /// Unique identifier for this result, 1-64 bytes.

--- a/crates/teloxide-core/src/types/inline_query_result_cached_audio.rs
+++ b/crates/teloxide-core/src/types/inline_query_result_cached_audio.rs
@@ -9,7 +9,7 @@ use crate::types::{InlineKeyboardMarkup, InputMessageContent, MessageEntity, Par
 /// instead of the audio.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#inlinequeryresultcachedaudio).
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct InlineQueryResultCachedAudio {
     /// Unique identifier for this result, 1-64 bytes.

--- a/crates/teloxide-core/src/types/inline_query_result_cached_document.rs
+++ b/crates/teloxide-core/src/types/inline_query_result_cached_document.rs
@@ -9,7 +9,7 @@ use crate::types::{InlineKeyboardMarkup, InputMessageContent, MessageEntity, Par
 /// the specified content instead of the file.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#inlinequeryresultcacheddocument).
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct InlineQueryResultCachedDocument {
     /// Unique identifier for this result, 1-64 bytes.

--- a/crates/teloxide-core/src/types/inline_query_result_cached_gif.rs
+++ b/crates/teloxide-core/src/types/inline_query_result_cached_gif.rs
@@ -9,7 +9,7 @@ use crate::types::{InlineKeyboardMarkup, InputMessageContent, MessageEntity, Par
 /// message with specified content instead of the animation.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#inlinequeryresultcachedgif).
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct InlineQueryResultCachedGif {
     /// Unique identifier for this result, 1-64 bytes.

--- a/crates/teloxide-core/src/types/inline_query_result_cached_mpeg4_gif.rs
+++ b/crates/teloxide-core/src/types/inline_query_result_cached_mpeg4_gif.rs
@@ -10,7 +10,7 @@ use crate::types::{InlineKeyboardMarkup, InputMessageContent, MessageEntity, Par
 /// a message with the specified content instead of the animation.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#inlinequeryresultcachedmpeg4gif).
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct InlineQueryResultCachedMpeg4Gif {
     /// Unique identifier for this result, 1-64 bytes.

--- a/crates/teloxide-core/src/types/inline_query_result_cached_photo.rs
+++ b/crates/teloxide-core/src/types/inline_query_result_cached_photo.rs
@@ -9,7 +9,7 @@ use crate::types::{InlineKeyboardMarkup, InputMessageContent, MessageEntity, Par
 /// the specified content instead of the photo.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#inlinequeryresultcachedphoto).
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct InlineQueryResultCachedPhoto {
     /// Unique identifier for this result, 1-64 bytes.

--- a/crates/teloxide-core/src/types/inline_query_result_cached_sticker.rs
+++ b/crates/teloxide-core/src/types/inline_query_result_cached_sticker.rs
@@ -9,7 +9,7 @@ use crate::types::{InlineKeyboardMarkup, InputMessageContent};
 /// instead of the sticker.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#inlinequeryresultcachedsticker).
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct InlineQueryResultCachedSticker {
     /// Unique identifier for this result, 1-64 bytes.

--- a/crates/teloxide-core/src/types/inline_query_result_cached_video.rs
+++ b/crates/teloxide-core/src/types/inline_query_result_cached_video.rs
@@ -9,7 +9,7 @@ use crate::types::{InlineKeyboardMarkup, InputMessageContent, MessageEntity, Par
 /// message with the specified content instead of the video.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#inlinequeryresultcachedvideo).
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct InlineQueryResultCachedVideo {
     /// Unique identifier for this result, 1-64 bytes.

--- a/crates/teloxide-core/src/types/inline_query_result_cached_voice.rs
+++ b/crates/teloxide-core/src/types/inline_query_result_cached_voice.rs
@@ -9,7 +9,7 @@ use crate::types::{InlineKeyboardMarkup, InputMessageContent, MessageEntity, Par
 /// instead of the voice message.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#inlinequeryresultcachedvideo).
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct InlineQueryResultCachedVoice {
     /// Unique identifier for this result, 1-64 bytes.

--- a/crates/teloxide-core/src/types/inline_query_result_contact.rs
+++ b/crates/teloxide-core/src/types/inline_query_result_contact.rs
@@ -9,7 +9,7 @@ use crate::types::{InlineKeyboardMarkup, InputMessageContent};
 /// instead of the contact.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#inlinequeryresultcachedvideo).
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct InlineQueryResultContact {
     /// Unique identifier for this result, 1-64 Bytes.

--- a/crates/teloxide-core/src/types/inline_query_result_document.rs
+++ b/crates/teloxide-core/src/types/inline_query_result_document.rs
@@ -11,7 +11,7 @@ use crate::types::{InlineKeyboardMarkup, InputMessageContent, MessageEntity, Par
 /// **.ZIP** files can be sent using this method.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#inlinequeryresultdocument).
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct InlineQueryResultDocument {
     /// Unique identifier for this result, 1-64 bytes.

--- a/crates/teloxide-core/src/types/inline_query_result_game.rs
+++ b/crates/teloxide-core/src/types/inline_query_result_game.rs
@@ -7,7 +7,7 @@ use crate::types::InlineKeyboardMarkup;
 /// [The official docs](https://core.telegram.org/bots/api#inlinequeryresultgame).
 ///
 /// [game]: https://core.telegram.org/bots/api#games
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct InlineQueryResultGame {
     /// Unique identifier for this result, 1-64 bytes.

--- a/crates/teloxide-core/src/types/inline_query_result_gif.rs
+++ b/crates/teloxide-core/src/types/inline_query_result_gif.rs
@@ -9,7 +9,7 @@ use crate::types::{InlineKeyboardMarkup, InputMessageContent, MessageEntity, Par
 /// message with the specified content instead of the animation.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#inlinequeryresultgif).
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct InlineQueryResultGif {
     /// Unique identifier for this result, 1-64 bytes.

--- a/crates/teloxide-core/src/types/inline_query_result_location.rs
+++ b/crates/teloxide-core/src/types/inline_query_result_location.rs
@@ -9,7 +9,7 @@ use crate::types::{InlineKeyboardMarkup, InputMessageContent};
 /// instead of the location.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#inlinequeryresultlocation).
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct InlineQueryResultLocation {
     /// Unique identifier for this result, 1-64 Bytes.

--- a/crates/teloxide-core/src/types/inline_query_result_mpeg4_gif.rs
+++ b/crates/teloxide-core/src/types/inline_query_result_mpeg4_gif.rs
@@ -10,7 +10,7 @@ use crate::types::{InlineKeyboardMarkup, InputMessageContent, MessageEntity, Par
 /// a message with the specified content instead of the animation.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#inlinequeryresultmpeg4gif).
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct InlineQueryResultMpeg4Gif {
     /// Unique identifier for this result, 1-64 bytes.

--- a/crates/teloxide-core/src/types/inline_query_result_photo.rs
+++ b/crates/teloxide-core/src/types/inline_query_result_photo.rs
@@ -9,7 +9,7 @@ use crate::types::{InlineKeyboardMarkup, InputMessageContent, MessageEntity, Par
 /// the specified content instead of the photo.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#inlinequeryresultphoto).
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct InlineQueryResultPhoto {
     /// Unique identifier for this result, 1-64 bytes.

--- a/crates/teloxide-core/src/types/inline_query_result_venue.rs
+++ b/crates/teloxide-core/src/types/inline_query_result_venue.rs
@@ -9,7 +9,7 @@ use crate::types::{InlineKeyboardMarkup, InputMessageContent};
 /// of the venue.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#inlinequeryresultvenue).
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct InlineQueryResultVenue {
     /// Unique identifier for this result, 1-64 Bytes.

--- a/crates/teloxide-core/src/types/inline_query_result_video.rs
+++ b/crates/teloxide-core/src/types/inline_query_result_video.rs
@@ -11,7 +11,7 @@ use crate::types::{InlineKeyboardMarkup, InputMessageContent, MessageEntity, Par
 /// message with the specified content instead of the video.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#inlinequeryresultvideo).
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct InlineQueryResultVideo {
     /// Unique identifier for this result, 1-64 bytes.

--- a/crates/teloxide-core/src/types/inline_query_result_voice.rs
+++ b/crates/teloxide-core/src/types/inline_query_result_voice.rs
@@ -10,7 +10,7 @@ use crate::types::{InlineKeyboardMarkup, InputMessageContent, MessageEntity, Par
 /// content instead of the the voice message.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#inlinequeryresultvoice).
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct InlineQueryResultVoice {
     /// Unique identifier for this result, 1-64 bytes.

--- a/crates/teloxide-core/src/types/inline_query_results_button.rs
+++ b/crates/teloxide-core/src/types/inline_query_results_button.rs
@@ -6,7 +6,7 @@ use crate::types::WebAppInfo;
 /// must use exactly one of the optional fields.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#inlinequeryresultsbutton)
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct InlineQueryResultsButton {
     /// Label text on the button

--- a/crates/teloxide-core/src/types/input_media.rs
+++ b/crates/teloxide-core/src/types/input_media.rs
@@ -21,7 +21,7 @@ pub enum InputMedia {
 /// Represents a photo to be sent.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#inputmediaphoto).
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Serialize)]
 pub struct InputMediaPhoto {
     /// File to send.
@@ -90,7 +90,7 @@ impl InputMediaPhoto {
 /// Represents a video to be sent.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#inputmediavideo).
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Serialize)]
 pub struct InputMediaVideo {
     // File to send.
@@ -215,7 +215,7 @@ impl InputMediaVideo {
 /// sound) to be sent.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#inputmediaanimation).
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Serialize)]
 pub struct InputMediaAnimation {
     /// File to send.
@@ -331,7 +331,7 @@ impl InputMediaAnimation {
 /// Represents an audio file to be treated as music to be sent.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#inputmediaaudio).
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Serialize)]
 pub struct InputMediaAudio {
     /// File to send.
@@ -439,7 +439,7 @@ impl InputMediaAudio {
 /// Represents a general file to be sent.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#inputmediadocument).
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Serialize)]
 pub struct InputMediaDocument {
     /// File to send.

--- a/crates/teloxide-core/src/types/input_message_content.rs
+++ b/crates/teloxide-core/src/types/input_message_content.rs
@@ -18,7 +18,7 @@ pub enum InputMessageContent {
 }
 /// Represents the content of a text message to be sent as the result of an
 /// inline query.
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct InputMessageContentText {
     /// Text of the message to be sent, 1-4096 characters.
@@ -84,7 +84,7 @@ impl InputMessageContentText {
 
 /// Represents the content of a location message to be sent as the result of an
 /// inline query.
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct InputMessageContentLocation {
     /// Latitude of the location in degrees.
@@ -144,7 +144,7 @@ impl InputMessageContentLocation {
 
 /// Represents the content of a venue message to be sent as the result of
 /// an inline query.
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct InputMessageContentVenue {
     /// Latitude of the venue in degrees.
@@ -241,7 +241,7 @@ impl InputMessageContentVenue {
 
 /// Represents the content of a contact message to be sent as the result of
 /// an inline query.
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct InputMessageContentContact {
     /// Contact's phone number.
@@ -311,7 +311,7 @@ impl InputMessageContentContact {
 /// an inline query.
 ///
 /// [content]: InputMessageContent
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct InputMessageContentInvoice {
     /// Product name, 1-32 characters

--- a/crates/teloxide-core/src/types/input_sticker.rs
+++ b/crates/teloxide-core/src/types/input_sticker.rs
@@ -3,7 +3,7 @@ use serde::Serialize;
 use crate::types::{InputFile, MaskPosition};
 
 /// This object describes a sticker to be added to a sticker set.
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Serialize)]
 pub struct InputSticker {
     /// The added sticker. Pass a file_id as a String to send a file that

--- a/crates/teloxide-core/src/types/invoice.rs
+++ b/crates/teloxide-core/src/types/invoice.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 /// This object contains basic information about an invoice.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#invoice).
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct Invoice {
     /// Product name.

--- a/crates/teloxide-core/src/types/keyboard_button.rs
+++ b/crates/teloxide-core/src/types/keyboard_button.rs
@@ -10,7 +10,7 @@ use crate::types::{
 /// text of the button.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#keyboardbutton).
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct KeyboardButton {
     /// Text of the button. If none of the optional fields are used, it will
@@ -90,7 +90,7 @@ pub enum ButtonRequest {
 }
 
 /// Helper struct for (de)serializing [`ButtonRequest`](ButtonRequest)
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Serialize, Deserialize)]
 struct RawRequest {
     /// If `true`, the user's phone number will be sent as a contact

--- a/crates/teloxide-core/src/types/label_price.rs
+++ b/crates/teloxide-core/src/types/label_price.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 /// This object represents a portion of the price for goods or services.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#labeledprice).
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct LabeledPrice {
     /// Portion label.

--- a/crates/teloxide-core/src/types/location.rs
+++ b/crates/teloxide-core/src/types/location.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use crate::types::Seconds;
 
 /// This object represents a point on the map.
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Location {
     /// Longitude as defined by sender.

--- a/crates/teloxide-core/src/types/login_url.rs
+++ b/crates/teloxide-core/src/types/login_url.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 /// </div>
 ///
 /// [Telegram Login Widget]: https://core.telegram.org/widgets/login
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct LoginUrl {
     /// An HTTPS URL to be opened with user authorization data added to the

--- a/crates/teloxide-core/src/types/mask_position.rs
+++ b/crates/teloxide-core/src/types/mask_position.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 /// default.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#maskposition).
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MaskPosition {
     /// The part of the face relative to which the mask should be placed. One

--- a/crates/teloxide-core/src/types/me.rs
+++ b/crates/teloxide-core/src/types/me.rs
@@ -7,7 +7,7 @@ use crate::types::User;
 /// Returned only in [`GetMe`].
 ///
 /// [`GetMe`]: crate::payloads::GetMe
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct Me {
     #[serde(flatten)]

--- a/crates/teloxide-core/src/types/message.rs
+++ b/crates/teloxide-core/src/types/message.rs
@@ -17,7 +17,7 @@ use crate::types::{
 /// This object represents a message.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#message).
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Message {
     /// Unique message identifier inside this chat.
@@ -85,7 +85,7 @@ pub enum MessageKind {
     Empty {},
 }
 
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MessageCommon {
     /// Sender, empty for messages sent to channels.
@@ -137,7 +137,7 @@ pub struct MessageCommon {
     pub has_protected_content: bool,
 }
 
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MessageNewChatMembers {
     /// New members that were added to the group or supergroup and
@@ -146,7 +146,7 @@ pub struct MessageNewChatMembers {
     pub new_chat_members: Vec<User>,
 }
 
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MessageLeftChatMember {
     /// A member was removed from the group, information about them (this
@@ -154,35 +154,35 @@ pub struct MessageLeftChatMember {
     pub left_chat_member: User,
 }
 
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MessageNewChatTitle {
     /// A chat title was changed to this value.
     pub new_chat_title: String,
 }
 
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MessageNewChatPhoto {
     /// A chat photo was change to this value.
     pub new_chat_photo: Vec<PhotoSize>,
 }
 
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct MessageDeleteChatPhoto {
     /// Service message: the chat photo was deleted.
     pub delete_chat_photo: True,
 }
 
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct MessageGroupChatCreated {
     /// Service message: the group has been created.
     pub group_chat_created: True,
 }
 
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct MessageSupergroupChatCreated {
     /// Service message: the supergroup has been created. This field can‘t
@@ -193,7 +193,7 @@ pub struct MessageSupergroupChatCreated {
     pub supergroup_chat_created: True,
 }
 
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct MessageChannelChatCreated {
     /// Service message: the channel has been created. This field can‘t be
@@ -204,7 +204,7 @@ pub struct MessageChannelChatCreated {
     pub channel_chat_created: True,
 }
 
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MessageMessageAutoDeleteTimerChanged {
     /// Service message: auto-delete timer settings changed in the chat.
@@ -239,7 +239,7 @@ pub enum ChatMigration {
     },
 }
 
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MessagePinned {
     /// Specified message was pinned. Note that the Message object in this
@@ -261,7 +261,7 @@ pub struct MessageUserShared {
     pub user_shared: UserShared,
 }
 
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MessageInvoice {
     /// Message is an invoice for a [payment], information about the
@@ -272,7 +272,7 @@ pub struct MessageInvoice {
     pub invoice: Invoice,
 }
 
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MessageSuccessfulPayment {
     /// Message is a service message about a successful payment,
@@ -282,7 +282,7 @@ pub struct MessageSuccessfulPayment {
     pub successful_payment: SuccessfulPayment,
 }
 
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MessageConnectedWebsite {
     /// The domain name of the website on which the user has logged in.
@@ -292,7 +292,7 @@ pub struct MessageConnectedWebsite {
     pub connected_website: String,
 }
 
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MessagePassportData {
     /// Telegram Passport data.
@@ -300,7 +300,7 @@ pub struct MessagePassportData {
 }
 
 /// Information about forwarded message.
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Forward {
     /// Date the original message was sent in Unix time.
@@ -374,7 +374,7 @@ pub enum MediaKind {
     Migration(ChatMigration),
 }
 
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MediaAnimation {
     /// Message is an animation, information about the animation. For
@@ -396,7 +396,7 @@ pub struct MediaAnimation {
     // Note: for backward compatibility telegram also sends `document` field, but we ignore it
 }
 
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MediaAudio {
     /// Message is an audio file, information about the file.
@@ -415,14 +415,14 @@ pub struct MediaAudio {
     pub media_group_id: Option<String>,
 }
 
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MediaContact {
     /// Message is a shared contact, information about the contact.
     pub contact: Contact,
 }
 
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MediaDocument {
     /// Message is a general file, information about the file.
@@ -441,7 +441,7 @@ pub struct MediaDocument {
     pub media_group_id: Option<String>,
 }
 
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MediaGame {
     /// Message is a game, information about the game. [More
@@ -451,14 +451,14 @@ pub struct MediaGame {
     pub game: Game,
 }
 
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MediaLocation {
     /// Message is a shared location, information about the location.
     pub location: Location,
 }
 
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MediaPhoto {
     /// Message is a photo, available sizes of the photo.
@@ -481,28 +481,28 @@ pub struct MediaPhoto {
     pub media_group_id: Option<String>,
 }
 
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MediaPoll {
     /// Message is a native poll, information about the poll.
     pub poll: Poll,
 }
 
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MediaSticker {
     /// Message is a sticker, information about the sticker.
     pub sticker: Sticker,
 }
 
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MediaStory {
     /// Message is a forwarded story
     pub story: Story,
 }
 
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MediaText {
     /// For text messages, the actual UTF-8 text of the message, 0-4096
@@ -515,7 +515,7 @@ pub struct MediaText {
     pub entities: Vec<MessageEntity>,
 }
 
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MediaVideo {
     /// Message is a video, information about the video.
@@ -538,7 +538,7 @@ pub struct MediaVideo {
     pub media_group_id: Option<String>,
 }
 
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MediaVideoNote {
     /// Message is a [video note], information about the video message.
@@ -547,7 +547,7 @@ pub struct MediaVideoNote {
     pub video_note: VideoNote,
 }
 
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MediaVoice {
     /// Message is a voice message, information about the file.
@@ -569,14 +569,14 @@ pub struct MediaVenue {
     // Note: for backward compatibility telegram also sends `location` field, but we ignore it
 }
 
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MessageDice {
     /// Message is a dice with random value from 1 to 6.
     pub dice: Dice,
 }
 
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MessageProximityAlertTriggered {
     /// Service message. A user in the chat triggered another user's proximity
@@ -584,7 +584,7 @@ pub struct MessageProximityAlertTriggered {
     pub proximity_alert_triggered: ProximityAlertTriggered,
 }
 
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MessageWriteAccessAllowed {
     /// Service message: the user allowed the bot added to the attachment menu
@@ -592,77 +592,77 @@ pub struct MessageWriteAccessAllowed {
     pub write_access_allowed: WriteAccessAllowed,
 }
 
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MessageForumTopicCreated {
     /// Service message: forum topic created.
     pub forum_topic_created: ForumTopicCreated,
 }
 
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MessageForumTopicEdited {
     /// Service message: forum topic edited.
     pub forum_topic_edited: ForumTopicEdited,
 }
 
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MessageForumTopicClosed {
     /// Service message: forum topic closed.
     pub forum_topic_closed: ForumTopicClosed,
 }
 
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MessageForumTopicReopened {
     /// Service message: forum topic reopened.
     pub forum_topic_reopened: ForumTopicReopened,
 }
 
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MessageGeneralForumTopicHidden {
     /// Service message: the 'General' forum topic hidden.
     pub general_forum_topic_hidden: GeneralForumTopicHidden,
 }
 
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MessageGeneralForumTopicUnhidden {
     /// Service message: the 'General' forum topic unhidden.
     pub general_forum_topic_unhidden: GeneralForumTopicUnhidden,
 }
 
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MessageVideoChatScheduled {
     /// Service message: video chat scheduled
     pub video_chat_scheduled: VideoChatScheduled,
 }
 
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MessageVideoChatStarted {
     /// Service message: video chat started.
     pub video_chat_started: VideoChatStarted,
 }
 
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MessageVideoChatEnded {
     /// Service message: video chat ended.
     pub video_chat_ended: VideoChatEnded,
 }
 
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MessageVideoChatParticipantsInvited {
     /// Service message: new participants invited to a video chat.
     pub video_chat_participants_invited: VideoChatParticipantsInvited,
 }
 
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MessageWebAppData {
     /// Service message: data sent by a Web App.

--- a/crates/teloxide-core/src/types/message_auto_delete_timer_changed.rs
+++ b/crates/teloxide-core/src/types/message_auto_delete_timer_changed.rs
@@ -4,7 +4,7 @@ use crate::types::Seconds;
 
 /// This object represents a service message about a change in auto-delete timer
 /// settings.
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct MessageAutoDeleteTimerChanged {
     /// New auto-delete time for messages in the chat

--- a/crates/teloxide-core/src/types/message_entity.rs
+++ b/crates/teloxide-core/src/types/message_entity.rs
@@ -9,7 +9,7 @@ use crate::types::{User, UserId};
 /// For example, hashtags, usernames, URLs, etc.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#messageentity).
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct MessageEntity {
     #[serde(flatten)]
@@ -236,7 +236,7 @@ impl<'a> MessageEntityRef<'a> {
     }
 }
 
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 #[serde(tag = "type")]

--- a/crates/teloxide-core/src/types/order_info.rs
+++ b/crates/teloxide-core/src/types/order_info.rs
@@ -5,7 +5,7 @@ use crate::types::ShippingAddress;
 /// This object represents information about an order.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#orderinfo).
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, Default)]
 pub struct OrderInfo {
     /// User's name.

--- a/crates/teloxide-core/src/types/passport_data.rs
+++ b/crates/teloxide-core/src/types/passport_data.rs
@@ -6,7 +6,7 @@ use super::{EncryptedCredentials, EncryptedPassportElement};
 /// user.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#passportdata).
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct PassportData {
     /// Array with information about documents and other Telegram Passport

--- a/crates/teloxide-core/src/types/passport_element_error.rs
+++ b/crates/teloxide-core/src/types/passport_element_error.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 /// submitted that should be resolved by the user.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#passportelementerror).
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize)]
 pub struct PassportElementError {
     /// Error message.
@@ -74,7 +74,7 @@ pub enum PassportElementErrorKind {
 /// The error is considered resolved when the field's value changes.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#passportelementerrordatafield).
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize)]
 pub struct PassportElementErrorDataField {
     /// The section of the user's Telegram Passport which has the error.
@@ -129,7 +129,7 @@ impl PassportElementErrorDataField {
 /// document changes.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#passportelementerrorfrontside).
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize)]
 pub struct PassportElementErrorFrontSide {
     /// The section of the user's Telegram Passport which has the issue.
@@ -169,7 +169,7 @@ impl PassportElementErrorFrontSide {
 /// document changes.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#passportelementerrorreverseside).
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize)]
 pub struct PassportElementErrorReverseSide {
     /// The section of the user's Telegram Passport which has the issue.
@@ -208,7 +208,7 @@ impl PassportElementErrorReverseSide {
 /// The error is considered resolved when the file with the selfie changes.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#passportelementerrorselfie).
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize)]
 pub struct PassportElementErrorSelfie {
     /// The section of the user's Telegram Passport which has the issue.
@@ -247,7 +247,7 @@ impl PassportElementErrorSelfie {
 /// changes.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#passportelementerrorfile).
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize)]
 pub struct PassportElementErrorFile {
     /// The section of the user's Telegram Passport which has the issue.
@@ -286,7 +286,7 @@ impl PassportElementErrorFile {
 /// changes.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#passportelementerrorfiles).
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize)]
 pub struct PassportElementErrorFiles {
     /// The section of the user's Telegram Passport which has the issue.
@@ -325,7 +325,7 @@ impl PassportElementErrorFiles {
 /// The error is considered resolved when the file changes.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#passportelementerrortranslationfile).
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize)]
 pub struct PassportElementErrorTranslationFile {
     /// Type of element of the user's Telegram Passport which has the
@@ -365,7 +365,7 @@ impl PassportElementErrorTranslationFile {
 /// change.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#passportelementerrortranslationfiles).
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize)]
 pub struct PassportElementErrorTranslationFiles {
     /// Type of element of the user's Telegram Passport which has the issue
@@ -403,7 +403,7 @@ impl PassportElementErrorTranslationFiles {
 /// The error is considered resolved when new data is added.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#passportelementerrorunspecified).
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize)]
 pub struct PassportElementErrorUnspecified {
     /// Type of element of the user's Telegram Passport which has the

--- a/crates/teloxide-core/src/types/passport_file.rs
+++ b/crates/teloxide-core/src/types/passport_file.rs
@@ -10,7 +10,7 @@ use crate::types::FileMeta;
 /// don't exceed 10MB.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#passportfile).
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, Deref)]
 pub struct PassportFile {
     /// Metadata of the passport file.

--- a/crates/teloxide-core/src/types/photo_size.rs
+++ b/crates/teloxide-core/src/types/photo_size.rs
@@ -6,7 +6,7 @@ use crate::types::FileMeta;
 ///
 /// [file]: crate::types::Document
 /// [sticker]: crate::types::Sticker
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct PhotoSize {
     /// Metadata of the photo file.

--- a/crates/teloxide-core/src/types/poll.rs
+++ b/crates/teloxide-core/src/types/poll.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 /// This object contains information about a poll.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#poll).
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct Poll {
     /// Unique poll identifier.

--- a/crates/teloxide-core/src/types/poll_answer.rs
+++ b/crates/teloxide-core/src/types/poll_answer.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Deserializer, Serialize};
 
 use crate::types::{Chat, User};
 
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct PollAnswer {
     /// Unique poll identifier.

--- a/crates/teloxide-core/src/types/pre_checkout_query.rs
+++ b/crates/teloxide-core/src/types/pre_checkout_query.rs
@@ -5,7 +5,7 @@ use crate::types::{Currency, OrderInfo, User};
 /// This object contains information about an incoming pre-checkout query.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#precheckoutquery).
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct PreCheckoutQuery {
     /// Unique query identifier.

--- a/crates/teloxide-core/src/types/proximity_alert_triggered.rs
+++ b/crates/teloxide-core/src/types/proximity_alert_triggered.rs
@@ -4,7 +4,7 @@ use crate::types::User;
 
 /// This object represents the content of a service message, sent whenever a
 /// user in the chat triggers a proximity alert set by another user.
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct ProximityAlertTriggered {
     /// User that triggered the alert.

--- a/crates/teloxide-core/src/types/reply_keyboard_markup.rs
+++ b/crates/teloxide-core/src/types/reply_keyboard_markup.rs
@@ -10,7 +10,7 @@ use crate::types::KeyboardButton;
 ///
 /// [custom keyboard]: https://core.telegram.org/bots#keyboards
 /// [Introduction to bots]: https://core.telegram.org/bots#keyboards
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, Default)]
 pub struct KeyboardMarkup {
     /// Array of button rows, each represented by an Array of

--- a/crates/teloxide-core/src/types/reply_keyboard_remove.rs
+++ b/crates/teloxide-core/src/types/reply_keyboard_remove.rs
@@ -12,7 +12,7 @@ use crate::types::True;
 /// [The official docs](https://core.telegram.org/bots/api#replykeyboardremove).
 ///
 /// [`KeyboardMarkup`]: crate::types::KeyboardMarkup
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Copy, Clone, Debug, Default, Serialize, Deserialize)]
 #[derive(Eq, Hash, PartialEq)]
 pub struct KeyboardRemove {

--- a/crates/teloxide-core/src/types/sent_web_app_message.rs
+++ b/crates/teloxide-core/src/types/sent_web_app_message.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 /// of a user.
 ///
 /// [Web App]: https://core.telegram.org/bots/webapps
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct SentWebAppMessage {
     /// Identifier of the sent inline message. Available only if there is an

--- a/crates/teloxide-core/src/types/shipping_address.rs
+++ b/crates/teloxide-core/src/types/shipping_address.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 /// This object represents a shipping address.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#shippingaddress).
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct ShippingAddress {
     /// ISO 3166-1 alpha-2 country code.

--- a/crates/teloxide-core/src/types/shipping_option.rs
+++ b/crates/teloxide-core/src/types/shipping_option.rs
@@ -5,7 +5,7 @@ use crate::types::LabeledPrice;
 /// This object represents one shipping option.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#shippingoption).
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct ShippingOption {
     /// Shipping option identifier.

--- a/crates/teloxide-core/src/types/shipping_query.rs
+++ b/crates/teloxide-core/src/types/shipping_query.rs
@@ -5,7 +5,7 @@ use crate::types::{ShippingAddress, User};
 /// This object contains information about an incoming shipping query.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#shippingquery).
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct ShippingQuery {
     /// Unique query identifier.

--- a/crates/teloxide-core/src/types/sticker.rs
+++ b/crates/teloxide-core/src/types/sticker.rs
@@ -7,7 +7,7 @@ use crate::types::{FileMeta, MaskPosition, PhotoSize};
 /// This object represents a sticker.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#sticker).
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Sticker {
     /// Metadata of the sticker file.

--- a/crates/teloxide-core/src/types/sticker_set.rs
+++ b/crates/teloxide-core/src/types/sticker_set.rs
@@ -7,7 +7,7 @@ use crate::types::{PhotoSize, Sticker, StickerFormat, StickerFormatFlags, Sticke
 /// This object represents a sticker set.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#stickerset).
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct StickerSet {
     /// Sticker set name.

--- a/crates/teloxide-core/src/types/successful_payment.rs
+++ b/crates/teloxide-core/src/types/successful_payment.rs
@@ -5,7 +5,7 @@ use crate::types::{Currency, OrderInfo};
 /// This object contains basic information about a successful payment.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#successfulpayment).
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct SuccessfulPayment {
     /// Three-letter ISO 4217 [currency] code.

--- a/crates/teloxide-core/src/types/switch_inline_query_chosen_chat.rs
+++ b/crates/teloxide-core/src/types/switch_inline_query_chosen_chat.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// [The official docs](https://core.telegram.org/bots/api#switchinlinequerychosenchat)
 
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SwitchInlineQueryChosenChat {
     /// The default inline query to be inserted in the input field. If left

--- a/crates/teloxide-core/src/types/update.rs
+++ b/crates/teloxide-core/src/types/update.rs
@@ -12,7 +12,7 @@ use crate::types::{
 /// [The official docs](https://core.telegram.org/bots/api#update).
 ///
 /// [object]: https://core.telegram.org/bots/api#available-types
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Update {
     /// The update‘s unique identifier. Update identifiers start from a certain

--- a/crates/teloxide-core/src/types/user.rs
+++ b/crates/teloxide-core/src/types/user.rs
@@ -5,7 +5,7 @@ use crate::types::UserId;
 /// This object represents a Telegram user or bot.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#user).
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct User {
     /// Unique identifier for this user or bot.

--- a/crates/teloxide-core/src/types/user_profile_photos.rs
+++ b/crates/teloxide-core/src/types/user_profile_photos.rs
@@ -5,7 +5,7 @@ use crate::types::PhotoSize;
 /// This object represent a user's profile pictures.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#userprofilephotos).
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct UserProfilePhotos {
     /// Total number of profile pictures the target user has.

--- a/crates/teloxide-core/src/types/venue.rs
+++ b/crates/teloxide-core/src/types/venue.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use crate::types::Location;
 
 /// This object represents a venue.
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Venue {
     /// Venue location.

--- a/crates/teloxide-core/src/types/video.rs
+++ b/crates/teloxide-core/src/types/video.rs
@@ -6,7 +6,7 @@ use crate::types::{FileMeta, PhotoSize, Seconds};
 /// This object represents a video file.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#video).
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct Video {
     /// Metadata of the video file.

--- a/crates/teloxide-core/src/types/video_note.rs
+++ b/crates/teloxide-core/src/types/video_note.rs
@@ -9,7 +9,7 @@ use crate::types::{FileMeta, PhotoSize, Seconds};
 ///
 /// [video message]: https://telegram.org/blog/video-messages-and-telescope
 /// [v4.0]: https://telegram.org/blog/video-messages-and-telescope
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct VideoNote {
     /// Metadata of the video note file.

--- a/crates/teloxide-core/src/types/voice.rs
+++ b/crates/teloxide-core/src/types/voice.rs
@@ -6,7 +6,7 @@ use crate::types::{FileMeta, Seconds};
 /// This object represents a voice note.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#voice).
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct Voice {
     /// Metadata of the voice file.

--- a/crates/teloxide-core/src/types/webhook_info.rs
+++ b/crates/teloxide-core/src/types/webhook_info.rs
@@ -8,7 +8,7 @@ use crate::types::AllowedUpdate;
 /// Contains information about the current status of a webhook.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#webhookinfo).
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct WebhookInfo {
     /// Webhook URL, `None` if webhook is not set up.

--- a/crates/teloxide-core/src/types/write_access_allowed.rs
+++ b/crates/teloxide-core/src/types/write_access_allowed.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 /// Web App from a link.
 ///
 /// [The official docs](https://core.telegram.org/bots/api#writeaccessallowed).
-#[serde_with_macros::skip_serializing_none]
+#[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct WriteAccessAllowed {
     /// Name of the Web App which was launched from a link


### PR DESCRIPTION
Required by upcoming TBA 7.0 support (see: https://github.com/teloxide/teloxide/issues/1097#issuecomment-2233342942).

`serde_with` docs says:
> This crate should NEVER be used alone. All macros MUST be used via the re-exports in the serde_with crate.

So this change shouldn't brake anything as it doesn't bump version of `serde_with_macros`. `serde_with 1.5.2`  should be bumped later, but it will require bumping syn to syn2 in `teloxide-macros` which seems to be hard.