### PR TITLE
Tidy up documentation regarding the latest supported version of TBA

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,6 +93,17 @@ cargo test --features "full nightly"
 cargo docs
 ```
 
+### Bumping supported TBA version
+
+When you introduce changes that bump suppported Telegram Bot API version (e.g. 6.9 → 7.0), you must:
+
+- Specify your changes in [crates/teloxide-core/CHANGELOG.md](crates/teloxide-core/CHANGELOG.md) file
+- Change TBA version and it's announce date in `api_version: ApiVersion(ver: "7.0", date: "December 29, 2023"),` line in head of [crates/teloxide-core/schema.ron](crates/teloxide-core/schema.ron) file
+- Change TBA version in `(Currently, version … is supported)` line in head of [crates/teloxide-core/src/lib.rs](crates/teloxide-core/src/lib.rs) file
+- Change TBA version in `Currently, version … of` line in head of [crates/teloxide/src/lib.rs](crates/teloxide/src/lib.rs) file
+- Change TBA version in `…https://img.shields.io/badge/API%20coverage…` line in [crates/teloxide-core/README.md](crates/teloxide-core/README.md) file
+- Change TBA version in `…https://img.shields.io/badge/API%20coverage…` line in [README.md](README.md) file
+
 ## @teloxidebot
 
 `teloxide` uses @teloxidebot as a helper to manage PRs and issues. It is based on triagebot used by rustc developers, which docs can be found [here](https://forge.rust-lang.org/triagebot/index.html).

--- a/crates/teloxide-core/src/lib.rs
+++ b/crates/teloxide-core/src/lib.rs
@@ -1,7 +1,7 @@
 //! Core part of the [`teloxide`] library.
 //!
 //! This library provides tools for making requests to the [Telegram Bot API]
-//! (Currently, version `6.6` is supported) with ease. The library is fully
+//! (Currently, version `6.9` is supported) with ease. The library is fully
 //! asynchronous and built using [`tokio`].
 //!
 //!```toml

--- a/crates/teloxide/src/lib.rs
+++ b/crates/teloxide/src/lib.rs
@@ -1,6 +1,7 @@
 //! A full-featured framework that empowers you to easily build [Telegram bots]
 //! using [Rust]. It handles all the difficult stuff so you can focus only on
-//! your business logic.
+//! your business logic. Currently, version `6.9` of [Telegram Bot API] is
+//! supported.
 //!
 //! For a high-level overview, see [our GitHub repository](https://github.com/teloxide/teloxide).
 //!
@@ -31,6 +32,7 @@
 //!   </kbd>
 //! </div>
 //!
+//! [Telegram Bot API]: https://core.telegram.org/bots/api
 //! [Telegram bots]: https://telegram.org/blog/bot-revolution
 //! [`async`/`.await`]: https://rust-lang.github.io/async-book/01_getting_started/01_chapter.html
 //! [Rust]: https://www.rust-lang.org/


### PR DESCRIPTION
This PR:

- Adds "Bumping supported TBA version" checklist for contributors. There are many places across codebase that have to be updated when TBA support in teloxide was bumped.
- Bumps supported TBA version in teloxide-core docs which has remained intact since TBA 6.6
- Adds current supported TBA version to the teloxide docs (Closes #1045)