### PR TITLE
Unpin aHash dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.8.7"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c3a9648d43b9cd48db467b3f87fdd6e146bcc88ab0180006cef2179fe11d01"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
  "getrandom",
@@ -912,7 +912,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.6",
  "tokio",
  "tower-service",
  "tracing",

--- a/crates/teloxide/Cargo.toml
+++ b/crates/teloxide/Cargo.toml
@@ -117,9 +117,7 @@ tower = { version = "0.4.13", optional = true }
 tower-http = { version = "0.5.2", features = ["trace"], optional = true }
 rand = { version = "0.8.5", optional = true }
 
-# HACK: ahash 0.8.7 bumped MSRV to 1.72, to keep MVSR 1.68 we need to depend on an older version.
-#       this can be removed once our MSRV crosses 1.72.
-ahash = "=0.8.7"
+ahash = "0.8.11"
 
 [dev-dependencies]
 rand = "0.8.3"


### PR DESCRIPTION
Pinned aHash conflicts with AWS Rust SDK, and given that aHash rolled back the MSRV bump in [208](https://github.com/tkaitchuck/aHash/pull/208), no need for it to be pinned anymore.