### PR TITLE
Fix issue with Throttle and Trace adaptors losing Requester trait bounds

### DIFF
--- a/crates/teloxide-core/src/adaptors.rs
+++ b/crates/teloxide-core/src/adaptors.rs
@@ -45,37 +45,3 @@ pub use throttle::Throttle;
 pub use trace::Trace;
 
 pub use parse_mode::DefaultParseMode;
-
-#[cfg(all(
-    test,
-    feature = "cache_me",
-    feature = "throttle",
-    feature = "trace_adaptor",
-    feature = "erased"
-))]
-// Tests composition of all possible adaptors. The goal of this test is to
-// catch situations when wrapped by adaptor bot loses Requester trait bounds.
-// The problem occurs because Throttle adaptor holds queue of requests, thus
-// introducing requirement for all requests to also implement Clone.
-mod composition_test {
-    use crate::{requests::RequesterExt, types::ParseMode, Bot};
-    use throttle::Limits;
-    use trace::Settings;
-
-    use super::*;
-
-    // Has to be async test due to Throttle adaptor requirements
-    #[tokio::test]
-    async fn composition() {
-        let bot = Bot::new("TOKEN");
-
-        // Erased adaptor validates Requester trait bounds, so this should fail to
-        // compile whenever issue occurs.
-        let _ = bot
-            .throttle(Limits::default())
-            .cache_me()
-            .trace(Settings::empty())
-            .parse_mode(ParseMode::MarkdownV2)
-            .erase();
-    }
-}

--- a/crates/teloxide-core/src/adaptors.rs
+++ b/crates/teloxide-core/src/adaptors.rs
@@ -45,3 +45,37 @@ pub use throttle::Throttle;
 pub use trace::Trace;
 
 pub use parse_mode::DefaultParseMode;
+
+#[cfg(all(
+    test,
+    feature = "cache_me",
+    feature = "throttle",
+    feature = "trace_adaptor",
+    feature = "erased"
+))]
+// Tests composition of all possible adaptors. The goal of this test is to 
+// catch situations when wrapped by adaptor bot loses Requester trait bounds.
+// The problem occurs because Throttle adaptor holds queue of requests, thus 
+// introducing requirement for all requests to also implement Clone. 
+mod composition_test {
+    use crate::{requests::RequesterExt, types::ParseMode, Bot};
+    use throttle::Limits;
+    use trace::Settings;
+
+    use super::*;
+
+    // Has to be async test due to Throttle adaptor requirements
+    #[tokio::test]
+    async fn composition() {
+        let bot = Bot::new("TOKEN");
+
+        // Erased adaptor validates Requester trait bounds, so this should fail to 
+        // compile whenever issue occurs.
+        let _ = bot
+            .throttle(Limits::default())
+            .cache_me()
+            .trace(Settings::empty())
+            .parse_mode(ParseMode::MarkdownV2)
+            .erase();
+    }
+}

--- a/crates/teloxide-core/src/adaptors.rs
+++ b/crates/teloxide-core/src/adaptors.rs
@@ -53,10 +53,10 @@ pub use parse_mode::DefaultParseMode;
     feature = "trace_adaptor",
     feature = "erased"
 ))]
-// Tests composition of all possible adaptors. The goal of this test is to 
+// Tests composition of all possible adaptors. The goal of this test is to
 // catch situations when wrapped by adaptor bot loses Requester trait bounds.
-// The problem occurs because Throttle adaptor holds queue of requests, thus 
-// introducing requirement for all requests to also implement Clone. 
+// The problem occurs because Throttle adaptor holds queue of requests, thus
+// introducing requirement for all requests to also implement Clone.
 mod composition_test {
     use crate::{requests::RequesterExt, types::ParseMode, Bot};
     use throttle::Limits;
@@ -69,7 +69,7 @@ mod composition_test {
     async fn composition() {
         let bot = Bot::new("TOKEN");
 
-        // Erased adaptor validates Requester trait bounds, so this should fail to 
+        // Erased adaptor validates Requester trait bounds, so this should fail to
         // compile whenever issue occurs.
         let _ = bot
             .throttle(Limits::default())

--- a/crates/teloxide-core/src/adaptors/throttle/request.rs
+++ b/crates/teloxide-core/src/adaptors/throttle/request.rs
@@ -19,6 +19,7 @@ use crate::{
 
 /// Request returned by [`Throttling`](crate::adaptors::Throttle) methods.
 #[must_use = "Requests are lazy and do nothing unless sent"]
+#[derive(Clone)]
 pub struct ThrottlingRequest<R: HasPayload> {
     pub(super) request: Arc<R>,
     pub(super) chat_id: fn(&R::Payload) -> ChatIdHash,

--- a/crates/teloxide-core/src/adaptors/trace.rs
+++ b/crates/teloxide-core/src/adaptors/trace.rs
@@ -243,6 +243,7 @@ where
 }
 
 #[must_use = "Requests are lazy and do nothing unless sent"]
+#[derive(Clone)]
 pub struct TraceRequest<R> {
     inner: R,
     settings: Settings,


### PR DESCRIPTION
The issue is rather annoying and seems like it reoccurs from time to time. I added a (rather clumsy) test to prevent it from getting back.