### PR TITLE
Allow `dead_code` in a test

### DIFF
--- a/crates/teloxide/tests/command.rs
+++ b/crates/teloxide/tests/command.rs
@@ -583,5 +583,6 @@ fn custom_result() {
     type Result = ();
 
     #[derive(BotCommands, Debug, PartialEq)]
+    #[allow(dead_code)]
     enum DefaultCommands {}
 }


### PR DESCRIPTION
rustc seems to have some changes with the `dead_code` lints which affect this.