### PR TITLE
Allow serving path configuration for the webhook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implement `GetChatId` for `teloxide_core::types::{Chat, ChatJoinRequest, ChatMemberUpdated}`.
 - Use [deadpool-redis](https://crates.io/crates/deadpool-redis) for Redis connection pooling ([PR 1081](https://github.com/teloxide/teloxide/pull/1081)).
 - Add `MessageExt::filter_story` method for the corresponding `MediaKind::Story` variant ([PR 1087](https://github.com/teloxide/teloxide/pull/1087)).
+- Add `update_listeners::webhooks::Options::path`, an option to make the webhook server listen on a different path, which can be useful behind a reverse proxy.
 
 ### Fixed
 

--- a/crates/teloxide/src/update_listeners/webhooks.rs
+++ b/crates/teloxide/src/update_listeners/webhooks.rs
@@ -23,6 +23,13 @@ pub struct Options {
     /// [addr]: (self::Options.address)
     pub url: url::Url,
 
+    /// Server-internal path to listen for requests on.
+    ///
+    /// This can differ from the path in `url` when you use a reverse proxy.
+    ///
+    /// Default - the URL path is reused.
+    pub path: String,
+
     /// Upload your public key certificate so that the root certificate in use
     /// can be checked. See Telegram's [self-signed guide] for details.
     ///
@@ -57,14 +64,23 @@ impl Options {
     /// Construct a new webhook options, see [`Options::address`] and
     /// [`Options::url`] for details.
     pub fn new(address: SocketAddr, url: url::Url) -> Self {
+        let path = url.path().to_owned();
         Self {
             address,
             url,
+            path,
             certificate: None,
             max_connections: None,
             drop_pending_updates: false,
             secret_token: None,
         }
+    }
+
+    /// Specify a custom routing path. This can be useful when the server is
+    /// behind a reverse proxy. By default, the path will be taken from the
+    /// public URL.
+    pub fn path(self, path: String) -> Self {
+        Self { path, ..self }
     }
 
     /// Upload your public key certificate so that the root certificate in use

--- a/crates/teloxide/src/update_listeners/webhooks/axum.rs
+++ b/crates/teloxide/src/update_listeners/webhooks/axum.rs
@@ -219,7 +219,7 @@ pub fn axum_no_setup(
     let (stop_token, stop_flag) = mk_stop_token();
 
     let app = axum::Router::new()
-        .route(options.url.path(), post(telegram_request))
+        .route(&options.path, post(telegram_request))
         .layer(TraceLayer::new_for_http())
         .with_state(WebhookState {
             tx: ClosableSender::new(tx),


### PR DESCRIPTION
When running behind e.g. NGINX, Axum might receive requests on a path that is different from the one in the public webhook URL, such as `/` instead of `/bot`. This commit adds a new optional field to Options to make such a setup possible.

<!--
Before making this PR, please ensure the following:

- `CHANGELOG.md` is updated (if necessary).
- Documentation and tests are updated (if necessary).
-->
