### PR TITLE
Release `teloxide-core` v0.10.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2243,7 +2243,7 @@ dependencies = [
 
 [[package]]
 name = "teloxide-core"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "aho-corasick 0.7.20",
  "bitflags 1.3.2",

--- a/crates/teloxide-core/CHANGELOG.md
+++ b/crates/teloxide-core/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## unreleased
 
+## 0.10.1 - 2024-08-17
+
 ### Fixed
 - Issue, when using `ReplyParameters` and multipart-requests involving file-sending it failed with `unimplemented error` ([#1136][pr1136], issue [#1135][issue1135])
 

--- a/crates/teloxide-core/Cargo.toml
+++ b/crates/teloxide-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "teloxide-core"
-version = "0.10.0"
+version = "0.10.1"
 description = "Core part of the `teloxide` library - telegram bot API client"
 
 rust-version.workspace = true

--- a/crates/teloxide-core/README.md
+++ b/crates/teloxide-core/README.md
@@ -25,7 +25,7 @@
 </div>
 
 ```toml
-teloxide-core = "0.10"
+teloxide-core = "0.10.1"
 ```
 _Compiler support: requires rustc 1.68+_.
 

--- a/crates/teloxide-core/src/lib.rs
+++ b/crates/teloxide-core/src/lib.rs
@@ -5,7 +5,7 @@
 //! asynchronous and built using [`tokio`].
 //!
 //!```toml
-//! teloxide-core = "0.9"
+//! teloxide-core = "0.10.1"
 //! ```
 //! _Compiler support: requires rustc 1.70+_.
 //!


### PR DESCRIPTION
Achieved by running `cargo release --package teloxide-core patch --execute` from the root.
