### PR TITLE
Added default to serialized fields, so they can be deserialized

### DIFF
--- a/crates/teloxide-core/src/types/force_reply.rs
+++ b/crates/teloxide-core/src/types/force_reply.rs
@@ -29,7 +29,7 @@ pub struct ForceReply {
     /// (has reply_to_message_id), sender of the original message.
     ///
     /// [`Message`]: crate::types::Message
-    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub selective: bool,
 }
 
@@ -52,5 +52,22 @@ impl ForceReply {
     #[must_use]
     pub fn selective(self) -> Self {
         Self { selective: true, ..self }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deserialize() {
+        let data = r#"
+        {
+            "force_reply": true,
+            "input_field_placeholder": "placeholder",
+            "selective": false
+        }
+        "#;
+        serde_json::from_str::<ForceReply>(data).unwrap();
     }
 }

--- a/crates/teloxide-core/src/types/input_media.rs
+++ b/crates/teloxide-core/src/types/input_media.rs
@@ -43,7 +43,7 @@ pub struct InputMediaPhoto {
     pub caption_entities: Option<Vec<MessageEntity>>,
 
     /// Pass `true` if the photo needs to be covered with a spoiler animation.
-    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub has_spoiler: bool,
 }
 
@@ -131,7 +131,7 @@ pub struct InputMediaVideo {
     pub supports_streaming: Option<bool>,
 
     /// Pass `true` if the video needs to be covered with a spoiler animation.
-    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub has_spoiler: bool,
 }
 
@@ -254,7 +254,7 @@ pub struct InputMediaAnimation {
 
     /// Pass `true` if the animation needs to be covered with a spoiler
     /// animation.
-    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub has_spoiler: bool,
 }
 

--- a/crates/teloxide-core/src/types/reply_keyboard_markup.rs
+++ b/crates/teloxide-core/src/types/reply_keyboard_markup.rs
@@ -22,14 +22,14 @@ pub struct KeyboardMarkup {
     /// Requests clients to always show the keyboard when the regular keyboard
     /// is hidden. Defaults to `false`, in which case the custom keyboard
     /// can be hidden and opened with a keyboard icon.
-    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub is_persistent: bool,
 
     /// Requests clients to resize the keyboard vertically for optimal fit
     /// (e.g., make the keyboard smaller if there are just two rows of
     /// buttons). Defaults to `false`, in which case the custom keyboard is
     /// always of the same height as the app's standard keyboard.
-    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub resize_keyboard: bool,
 
     /// Requests clients to hide the keyboard as soon as it's been used. The
@@ -37,12 +37,12 @@ pub struct KeyboardMarkup {
     /// display the usual letter-keyboard in the chat – the user can press a
     /// special button in the input field to see the custom keyboard again.
     /// Defaults to `false`.
-    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub one_time_keyboard: bool,
 
     /// The placeholder to be shown in the input field when the keyboard is
     /// active; 1-64 characters.
-    #[serde(skip_serializing_if = "str::is_empty")]
+    #[serde(default, skip_serializing_if = "str::is_empty")]
     pub input_field_placeholder: String,
 
     /// Use this parameter if you want to show the keyboard to specific users
@@ -55,7 +55,7 @@ pub struct KeyboardMarkup {
     /// in the group don’t see the keyboard.
     ///
     /// [`Message`]: crate::types::Message
-    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub selective: bool,
 }
 
@@ -127,5 +127,25 @@ impl KeyboardMarkup {
     /// [`selective`]: KeyboardMarkup::selective
     pub fn selective<T>(self) -> Self {
         Self { selective: true, ..self }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deserialize() {
+        let data = r#"
+        {
+            "keyboard": [[{"text": "a"}, {"text": "b"}], [{"text": "c"}, {"text": "d"}]],
+            "input_field_placeholder": "",
+            "is_persistent": true,
+            "one_time_keyboard": false,
+            "resize_keyboard": true,
+            "selective": false
+        }
+        "#;
+        serde_json::from_str::<KeyboardMarkup>(data).unwrap();
     }
 }

--- a/crates/teloxide-core/src/types/reply_keyboard_remove.rs
+++ b/crates/teloxide-core/src/types/reply_keyboard_remove.rs
@@ -34,7 +34,7 @@ pub struct KeyboardRemove {
     /// showing the keyboard with poll options to users who haven't voted yet.
     ///
     /// [`Message`]: crate::types::Message
-    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub selective: bool,
 }
 
@@ -50,5 +50,21 @@ impl KeyboardRemove {
     #[must_use]
     pub const fn selective(self) -> Self {
         Self { selective: true, ..self }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deserialize() {
+        let data = r#"
+        {
+            "remove_keyboard": true,
+            "selective": false
+        }
+        "#;
+        serde_json::from_str::<KeyboardRemove>(data).unwrap();
     }
 }


### PR DESCRIPTION
Some structs have just `skip_serializing_if = "std::ops::Not::not"`, without `#[serde(default)]`, which caused `false` fields to not be included in serialization, leading to frustrating error
`Error("missing field is_persistent", line: 1, column: 34)`
even when i manually verified that `is_persistent` does exist in the string and is equal to `false`

I don't think this pr has downsides, all the other structs that need deserialization with `std::ops::Not::not` already have `default`, so it's a normal practice

Stumbled upon this bug while migrating `teloxide_tests` to `0.13.0` (because i need to deserialize the fake server request body), so I'd like this merged and released sooner rather than later, but no rush, i don't think a lot of people are using it on `0.13.0` yet (even i still don't), and it just panics on non-inline keyboards, so those who really want could still use the github version