### PR TITLE
Added local TBA file downloading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `filter_boost_added` and `filter_reply_to_story` filters to `MessageFilterExt` trait
 - Add `filter_mention_command` filter to `HandlerExt` trait ([issue #494](https://github.com/teloxide/teloxide/issues/494))
 - Add `filter_business_connection`, `filter_business_message`, `filter_edited_business_message`, and `filter_deleted_business_messages` filters to update filters ([PR 1146](https://github.com/teloxide/teloxide/pull/1146))
+- Add local TBA file downloading support in `crate::net::download`
 
 ### Changed
 

--- a/crates/teloxide-core/src/local_macros.rs
+++ b/crates/teloxide-core/src/local_macros.rs
@@ -380,7 +380,7 @@ macro_rules! download_forward {
 
             fn download_file<'dst>(
                 &self,
-                path: &str,
+                path: &'dst str,
                 destination: &'dst mut (dyn tokio::io::AsyncWrite
                                + core::marker::Unpin
                                + core::marker::Send),

--- a/crates/teloxide-core/src/net/download.rs
+++ b/crates/teloxide-core/src/net/download.rs
@@ -28,6 +28,9 @@ pub trait Download {
     ///
     /// `path` can be obtained from [`GetFile`].
     ///
+    /// If the bot uses a [local bot api](https://github.com/tdlib/telegram-bot-api), this function
+    /// just copies the file into `destination`.
+    ///
     /// To download as a stream of chunks, see [`download_file_stream`].
     ///
     /// ## Examples
@@ -54,7 +57,7 @@ pub trait Download {
     /// [`download_file_stream`]: Self::download_file_stream
     fn download_file<'dst>(
         &self,
-        path: &str,
+        path: &'dst str,
         destination: &'dst mut (dyn AsyncWrite + Unpin + Send),
     ) -> Self::Fut<'dst>;
 


### PR DESCRIPTION
Inspired by https://t.me/teloxide/22547

Made it just because it was quick and I could, if it seems useful - would be glad to see this merged, but it's not very important

Code snippet to test this:

```rust
use std::str::FromStr;

use teloxide::{
    dispatching::{UpdateFilterExt, UpdateHandler},
    net::Download,
    prelude::*,
};

type HandlerResult = Result<(), Box<dyn std::error::Error + Send + Sync>>;

async fn download_document(bot: Bot, message: Message) -> HandlerResult {
    if let Some(document) = message.document() {
        let file = bot.get_file(document.file.id.clone()).await?;
        let mut dest = tokio::fs::File::create("test.txt").await?;
        bot.download_file(&file.path, &mut dest).await?;

        assert!(tokio::fs::read_to_string("test.txt").await.is_ok());

        bot.send_message(message.chat.id, "Downloaded!").await?;

        tokio::fs::remove_file("test.txt").await?;
    } else {
        bot.send_message(message.chat.id, "Not a document").await?;
    }
    Ok(())
}

fn handler_tree() -> UpdateHandler<Box<dyn std::error::Error + Send + Sync + 'static>> {
    dptree::entry().branch(Update::filter_message().endpoint(download_document))
}

#[tokio::main]
async fn main() {
    let bot = Bot::from_env().set_api_url(reqwest::Url::from_str("http://localhost:8081").unwrap());

    Dispatcher::builder(bot, handler_tree())
        .enable_ctrlc_handler()
        .build()
        .dispatch()
        .await;
}
```
`Cargo.toml`:
```toml
[dependencies]
teloxide = { git = "https://github.com/LasterAlex/teloxide", branch = "add-local-file-downloading"}
tokio = { version = "1.38", features = ["rt-multi-thread", "macros"] }
reqwest = "0.12.7"
```

Just send a .txt file to this bot