### PR TITLE
Fixed ThreadId serialization in multipart requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Now Vec<MessageId> in requests serializes into [number] instead of [ {message_id: number} ], `forward_messages`, `copy_messages` and `delete_messages` now work properly
+- Now `ThreadId` is able to serialize in multipart requests
 
 ## 0.13.0 - 2024-08-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Now Vec<MessageId> in requests serializes into [number] instead of [ {message_id: number} ], `forward_messages`, `copy_messages` and `delete_messages` now work properly
-- Now `ThreadId` is able to serialize in multipart requests
+- Now `ThreadId` is able to serialize in multipart requests ([PR 1179](https://github.com/teloxide/teloxide/pull/1179))
 
 ## 0.13.0 - 2024-08-16
 

--- a/crates/teloxide-core/src/serde_multipart/serializers.rs
+++ b/crates/teloxide-core/src/serde_multipart/serializers.rs
@@ -374,6 +374,17 @@ impl Serializer for PartSerializer {
         Ok(JsonPartSerializer { buf: String::new(), state: PartSerializerStructState::Empty })
     }
 
+    fn serialize_newtype_struct<T: ?Sized>(
+        self,
+        _: &'static str,
+        value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: Serialize,
+    {
+        value.serialize(self)
+    }
+
     // Unimplemented
 
     fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
@@ -388,17 +399,6 @@ impl Serializer for PartSerializer {
     }
 
     fn serialize_unit_struct(self, _: &'static str) -> Result<Self::Ok, Self::Error> {
-        unimplemented!()
-    }
-
-    fn serialize_newtype_struct<T: ?Sized>(
-        self,
-        _: &'static str,
-        _: &T,
-    ) -> Result<Self::Ok, Self::Error>
-    where
-        T: Serialize,
-    {
         unimplemented!()
     }
 


### PR DESCRIPTION
While writing a bot, I was surprised to see this error while sending a photo to a thread:
`
thread 'tokio-runtime-worker' panicked at /home/laster/Programming/RustProjects/teloxide/crates/teloxide-core/src/serde_multipart/serializers.rs:402:9: not implemented
`

So i wrote this test:

```rust
use teloxide::{
    dispatching::{UpdateFilterExt, UpdateHandler},
    prelude::*,
    types::*,
};

type HandlerResult = Result<(), Box<dyn std::error::Error + Send + Sync>>;

async fn send_document(bot: Bot, message: Message) -> HandlerResult {
    if let (Some(photo), Some(thread_id)) = (message.photo(), message.thread_id) {
        let file_id = photo.last().unwrap().file.id.clone();

        bot.send_photo(message.chat.id, InputFile::file_id(file_id))
            .message_thread_id(thread_id)
            .caption("Sent!")
            .await?;
    } else {
        bot.send_message(message.chat.id, "Not a document/thread id")
            .await?;
    }
    Ok(())
}

fn handler_tree() -> UpdateHandler<Box<dyn std::error::Error + Send + Sync + 'static>> {
    dptree::entry().branch(Update::filter_message().endpoint(send_document))
}

#[tokio::main]
async fn main() {
    dotenv::dotenv().ok();

    let bot = Bot::from_env();

    Dispatcher::builder(bot, handler_tree())
        .enable_ctrlc_handler()
        .build()
        .dispatch()
        .await;
}

#[cfg(test)]
mod tests {
    use super::*;
    use teloxide_tests::{MockBot, MockMessagePhoto};

    #[tokio::test]
    async fn test_photo_thread() {
        let bot = MockBot::new(
            MockMessagePhoto::new().thread_id(ThreadId(MessageId(1))),
            handler_tree(),
        );
        bot.dispatch_and_check_last_text("Sent!").await;
    }
}
```
With
```toml
[dependencies]
teloxide = { version = "0.13.0", features = ["full"] }
tokio = { version = "1.38", features = ["rt-multi-thread", "macros"] }
dotenv = "0.15.0"
teloxide_tests = "0.2.0"
```

And sure enough:
![image](https://github.com/user-attachments/assets/fc792efe-2881-4c0b-a065-32fe3274b1f2)

This pr fixes it

Preferably i would like to see it in `teloxide-core` 0.10.2, as it directly forbids sending any files in threaded groups, but threads are such a forgotten feature, and i am fine with using the gh version, so no rush