### PR TITLE
Fixed InlineQueryResultsButton serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Now Vec<MessageId> in requests serializes into [number] instead of [ {message_id: number} ], `forward_messages`, `copy_messages` and `delete_messages` now work properly
+- Now `InlineQueryResultsButton` serializes properly ([issue 1181](https://github.com/teloxide/teloxide/issues/1181))
 
 ## 0.13.0 - 2024-08-16
 

--- a/crates/teloxide-core/src/types/inline_query_results_button.rs
+++ b/crates/teloxide-core/src/types/inline_query_results_button.rs
@@ -17,6 +17,7 @@ pub struct InlineQueryResultsButton {
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum InlineQueryResultsButtonKind {
     /// Description of the [Web App] that will be launched when the user presses
     /// the button. The Web App will be able to switch back to the inline mode
@@ -43,4 +44,20 @@ pub enum InlineQueryResultsButtonKind {
     /// [Deep-linking]: https://core.telegram.org/bots/features#deep-linking
     /// [switch_inline]: https://core.telegram.org/bots/api#inlinekeyboardmarkup
     StartParameter(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::types::{InlineQueryResultsButton, InlineQueryResultsButtonKind};
+
+    #[test]
+    fn inline_query_results_button() {
+        let button = InlineQueryResultsButton {
+            text: "test".into(),
+            kind: InlineQueryResultsButtonKind::StartParameter("bot".into()),
+        };
+        let expected = r#"{"text":"test","start_parameter":"bot"}"#;
+        let actual = serde_json::to_string(&button).unwrap();
+        assert_eq!(expected, actual);
+    }
 }


### PR DESCRIPTION
Fixes #1181

Code to recreate the issue:

```rust
use dotenv::dotenv;
use teloxide::{
    prelude::*,
    types::{InlineQueryResultsButton, InlineQueryResultsButtonKind},
};

#[tokio::main]
async fn main() {
    dotenv().ok();

    let bot = Bot::from_env();

    let handler = Update::filter_inline_query().branch(dptree::endpoint(
        |bot: Bot, q: InlineQuery| async move {
            let result = bot
                .answer_inline_query(q.id, vec![])
                .cache_time(5)
                .is_personal(true)
                .button(InlineQueryResultsButton {
                    text: "Add a new sticker".into(),
                    kind: InlineQueryResultsButtonKind::StartParameter("bot".into()),
                })
                .await;
            dbg!(result.err());
            respond(())
        },
    ));

    Dispatcher::builder(bot, handler)
        .enable_ctrlc_handler()
        .build()
        .dispatch()
        .await;
}
```

```toml
[dependencies]
teloxide = { version = "0.13.0", features = ["full"] }
tokio = { version = "1.38", features = ["rt-multi-thread", "macros"] }
dotenv = "0.15.0"
```