### PR TITLE
Rename Limits::messages_per_min_channel to …_channel_or_supergroup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Some dependencies was bumped: `axum` to `0.8.0`, `sqlx` to `0.8.1`, `tower` to `0.5.0`, `reqwest` to `0.12.7`
   - `tokio` version was explicitly specified as `1.39`
 - Added new `Send` and `Sync` trait bounds to the `UListener` and `Eh` generic parameters of `try_dispatch_with_listener` and `dispatch_with_listener` ([PR 1185](https://github.com/teloxide/teloxide/pull/1185)) [**BC**]
+- Renamed `Limits::messages_per_min_channel` to `messages_per_min_channel_or_supergroup` to reflect its actual behavior ([PR 1214](https://github.com/teloxide/teloxide/pull/1214))
 
 ### Fixed
 

--- a/crates/teloxide-core/src/adaptors/throttle.rs
+++ b/crates/teloxide-core/src/adaptors/throttle.rs
@@ -185,7 +185,7 @@ enum ChatIdHash {
 }
 
 impl ChatIdHash {
-    fn is_channel(&self) -> bool {
+    fn is_channel_or_supergroup(&self) -> bool {
         match self {
             &Self::Id(id) => id.is_channel_or_supergroup(),
             Self::ChannelUsernameHash(_) => true,

--- a/crates/teloxide-core/src/adaptors/throttle/settings.rs
+++ b/crates/teloxide-core/src/adaptors/throttle/settings.rs
@@ -47,8 +47,8 @@ pub struct Limits {
     /// Allowed messages in one chat per minute.
     pub messages_per_min_chat: u32,
 
-    /// Allowed messages in one channel per minute.
-    pub messages_per_min_channel: u32,
+    /// Allowed messages in one channel or supergroup per minute.
+    pub messages_per_min_channel_or_supergroup: u32,
 
     /// Allowed messages per second.
     pub messages_per_sec_overall: u32,
@@ -104,7 +104,7 @@ impl Default for Limits {
             messages_per_sec_chat: 1,
             messages_per_sec_overall: 30,
             messages_per_min_chat: 20,
-            messages_per_min_channel: 10,
+            messages_per_min_channel_or_supergroup: 10,
         }
     }
 }

--- a/crates/teloxide-core/src/adaptors/throttle/worker.rs
+++ b/crates/teloxide-core/src/adaptors/throttle/worker.rs
@@ -242,8 +242,8 @@ pub(super) async fn worker<B>(
             let requests_sent_per_sec_count = requests_sent.per_sec.get(chat).copied().unwrap_or(0);
             let requests_sent_per_min_count = requests_sent.per_min.get(chat).copied().unwrap_or(0);
 
-            let messages_per_min_limit = if chat.is_channel() {
-                limits.messages_per_min_channel
+            let messages_per_min_limit = if chat.is_channel_or_supergroup() {
+                limits.messages_per_min_channel_or_supergroup
             } else {
                 limits.messages_per_min_chat
             };


### PR DESCRIPTION
Teloxide cannot distinguish supergroups from channels based on `ChatId`s, so channel throttling limits are applied to supergroups as well.

It took me a while to troubleshoot why sending a bunch of messages was twice as slow as in the original Python implementation 😄

P.S. Telegram's [docs](https://core.telegram.org/bots/faq#my-bot-is-hitting-limits-how-do-i-avoid-this) don't specify a separate limit for channels — though that admittedly doesn't mean there isn't one. I kept the default as is in Teloxide, but I will increase this limit in my bot because it doesn't interact with channels.

<!--
Before making this PR, please ensure the following:

- `CHANGELOG.md` is updated (if necessary).
- Documentation and tests are updated (if necessary).
-->
