### PR TITLE
Set a name for dispatcher runtime's threads

### DIFF
--- a/crates/teloxide/src/dispatching/dispatcher.rs
+++ b/crates/teloxide/src/dispatching/dispatcher.rs
@@ -419,6 +419,7 @@ where
             scope.spawn(move || {
                 let runtime = tokio::runtime::Builder::new_multi_thread()
                     .thread_stack_size(self.stack_size)
+                    .thread_name("teloxide-dispatcher-worker")
                     .enable_all()
                     .build()
                     .unwrap();


### PR DESCRIPTION
It defaults to `tokio-runtime-worker`, which is not descriptive.

<!--
Before making this PR, please ensure the following:

- `CHANGELOG.md` is updated (if necessary).
- Documentation and tests are updated (if necessary).
-->
