### PR TITLE
Bump axum to 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Environment bumps: ([PR 1147](https://github.com/teloxide/teloxide/pull/1147))
+- Environment bumps: ([PR 1147](https://github.com/teloxide/teloxide/pull/1147), [PR 1225](https://github.com/teloxide/teloxide/pull/1225))
   - MSRV (Minimal Supported Rust Version) was bumped from `1.70.0` to `1.80.0`
-  - Some dependencies was bumped: `sqlx` to `0.8.1`, `tower` to `0.5.0`, `reqwest` to `0.12.7`
+  - Some dependencies was bumped: `axum` to `0.8.0`, `sqlx` to `0.8.1`, `tower` to `0.5.0`, `reqwest` to `0.12.7`
   - `tokio` version was explicitly specified as `1.39`
 - Added new `Send` and `Sync` trait bounds to the `UListener` and `Eh` generic parameters of `try_dispatch_with_listener` and `dispatch_with_listener` ([PR 1185](https://github.com/teloxide/teloxide/pull/1185)) [**BC**]
 

--- a/crates/teloxide/Cargo.toml
+++ b/crates/teloxide/Cargo.toml
@@ -113,7 +113,7 @@ sqlx = { version = "0.8.1", optional = true, default-features = false, features 
 deadpool-redis = { version = "0.14", features = ["rt_tokio_1"], optional = true }
 serde_cbor = { version = "0.11", optional = true }
 bincode = { version = "1.3", optional = true }
-axum = { version = "0.7.0", optional = true }
+axum = { version = "0.8.0", optional = true }
 tower = { version = "0.5.0", optional = true }
 tower-http = { version = "0.5.2", features = ["trace"], optional = true }
 rand = { version = "0.8.5", optional = true }

--- a/crates/teloxide/src/update_listeners/webhooks/axum.rs
+++ b/crates/teloxide/src/update_listeners/webhooks/axum.rs
@@ -1,4 +1,4 @@
-use std::{convert::Infallible, future::Future, pin::Pin};
+use std::{convert::Infallible, future::Future};
 
 use axum::{
     extract::{FromRequestParts, State},
@@ -273,15 +273,10 @@ struct XTelegramBotApiSecretToken(Option<Vec<u8>>);
 impl<S> FromRequestParts<S> for XTelegramBotApiSecretToken {
     type Rejection = StatusCode;
 
-    fn from_request_parts<'l0, 'l1, 'at>(
-        req: &'l0 mut Parts,
-        _state: &'l1 S,
-    ) -> Pin<Box<dyn Future<Output = Result<Self, Self::Rejection>> + Send + 'at>>
-    where
-        'l0: 'at,
-        'l1: 'at,
-        Self: 'at,
-    {
+    fn from_request_parts(
+        req: &mut Parts,
+        _state: &S,
+    ) -> impl Future<Output = Result<Self, Self::Rejection>> + Send {
         use crate::update_listeners::webhooks::check_secret;
 
         let res = req
@@ -295,6 +290,6 @@ impl<S> FromRequestParts<S> for XTelegramBotApiSecretToken {
             .transpose()
             .map(Self);
 
-        Box::pin(async { res }) as _
+        async { res }
     }
 }


### PR DESCRIPTION
The code change fixes the build, aligning method signature with changes in https://github.com/tokio-rs/axum/commit/19101f624d471856b71b273a01189a0dcb4468c7#diff-6bbc3220d3ec9f22ec90857669e8b82b0d4970bcc9dd6f0ca266cb5a8c16a468L58

This update is significant for Teloxide users because it allows them to use Unix domain socket listeners for webhooks.

<!--
Before making this PR, please ensure the following:

- `CHANGELOG.md` is updated (if necessary).
- Documentation and tests are updated (if necessary).
-->
