### PR TITLE
Bump derive_more to 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Environment bumps: ([PR 1147](https://github.com/teloxide/teloxide/pull/1147), [PR 1225](https://github.com/teloxide/teloxide/pull/1225))
   - MSRV (Minimal Supported Rust Version) was bumped from `1.70.0` to `1.80.0`
-  - Some dependencies was bumped: `axum` to `0.8.0`, `sqlx` to `0.8.1`, `tower` to `0.5.0`, `reqwest` to `0.12.7`, `tower-http` to `0.6.2`
+  - Some dependencies was bumped: `axum` to `0.8.0`, `sqlx` to `0.8.1`, `tower` to `0.5.0`, `reqwest` to `0.12.7`, `tower-http` to `0.6.2`, `derive_more` to `1.0.0`
   - `tokio` version was explicitly specified as `1.39`
 - Added new `Send` and `Sync` trait bounds to the `UListener` and `Eh` generic parameters of `try_dispatch_with_listener` and `dispatch_with_listener` ([PR 1185](https://github.com/teloxide/teloxide/pull/1185)) [**BC**]
 - Renamed `Limits::messages_per_min_channel` to `messages_per_min_channel_or_supergroup` to reflect its actual behavior ([PR 1214](https://github.com/teloxide/teloxide/pull/1214))

--- a/crates/teloxide-core/Cargo.toml
+++ b/crates/teloxide-core/Cargo.toml
@@ -66,7 +66,7 @@ serde_json = "1.0.55"
 serde_with = "1.5.2"
 uuid = { version = "1.1.0", features = ["v4"] }        # for attaching input files
 
-derive_more = "0.99.9"
+derive_more = { version = "1.0.0", features = ["display", "from", "deref"] }
 mime = "0.3.16"
 thiserror = "1.0.20"
 once_cell = "1.5.0"

--- a/crates/teloxide-core/src/types/recipient.rs
+++ b/crates/teloxide-core/src/types/recipient.rs
@@ -11,11 +11,11 @@ use crate::types::{ChatId, UserId};
 #[serde(untagged)]
 pub enum Recipient {
     /// A chat identifier.
-    #[display(fmt = "{_0}")]
+    #[display("{_0}")]
     Id(ChatId),
 
     /// A channel username (in the format @channelusername).
-    #[display(fmt = "{_0}")]
+    #[display("{_0}")]
     ChannelUsername(String),
 }
 

--- a/crates/teloxide-core/src/types/seconds.rs
+++ b/crates/teloxide-core/src/types/seconds.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Copy)]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[derive(Debug, derive_more::Display)]
-#[display(fmt = "{_0}s")]
+#[display("{_0}s")]
 #[derive(Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct Seconds(u32);

--- a/crates/teloxide/Cargo.toml
+++ b/crates/teloxide/Cargo.toml
@@ -98,7 +98,7 @@ log = "0.4"
 bytes = "1.0"
 mime = "0.3"
 
-derive_more = "0.99"
+derive_more = { version = "1.0.0", features = ["display", "from", "deref"] }
 thiserror = "1.0"
 futures = "0.3.15"
 pin-project = "1.0"


### PR DESCRIPTION
Upgrade `derive_more` to 1.0.0

Reduce some dependencies, slightly faster compilation.