### PR TITLE
Fix warnings in build with PassportElementErrorKind

### DIFF
--- a/crates/teloxide-core/src/types/passport_element_error.rs
+++ b/crates/teloxide-core/src/types/passport_element_error.rs
@@ -38,33 +38,18 @@ impl PassportElementError {
 }
 
 #[derive(Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 #[serde(tag = "source")]
 pub enum PassportElementErrorKind {
     #[serde(rename = "data")]
     DataField(PassportElementErrorDataField),
-
-    #[serde(rename = "snake_case")]
     FrontSide(PassportElementErrorFrontSide),
-
-    #[serde(rename = "snake_case")]
     ReverseSide(PassportElementErrorReverseSide),
-
-    #[serde(rename = "snake_case")]
     Selfie(PassportElementErrorSelfie),
-
-    #[serde(rename = "snake_case")]
     File(PassportElementErrorFile),
-
-    #[serde(rename = "snake_case")]
     Files(PassportElementErrorFiles),
-
-    #[serde(rename = "snake_case")]
     TranslationFile(PassportElementErrorTranslationFile),
-
-    #[serde(rename = "snake_case")]
     TranslationFiles(PassportElementErrorTranslationFiles),
-
-    #[serde(rename = "snake_case")]
     Unspecified(PassportElementErrorUnspecified),
 }
 


### PR DESCRIPTION
When I build teloxide locally, I see warnings, but this PR fixes it.

Idk if this should be in Changelog
This doesn't really affect users.
So I leave decision to maintainer.

**Before:**
```sh
warning: unreachable pattern
  --> /home/fr0staman/source/repos/rust/teloxide/crates/teloxide-core/src/types/passport_element_error.rs:49:22
   |
46 |     #[serde(rename = "snake_case")]
   |                      ------------ matches all the relevant values
...
49 |     #[serde(rename = "snake_case")]
   |                      ^^^^^^^^^^^^ no value can reach this
   |
   = note: `#[warn(unreachable_patterns)]` on by default

warning: unreachable pattern
  --> /home/fr0staman/source/repos/rust/teloxide/crates/teloxide-core/src/types/passport_element_error.rs:52:22
   |
46 |     #[serde(rename = "snake_case")]
   |                      ------------ matches all the relevant values
...
52 |     #[serde(rename = "snake_case")]
   |                      ^^^^^^^^^^^^ no value can reach this

warning: unreachable pattern
  --> /home/fr0staman/source/repos/rust/teloxide/crates/teloxide-core/src/types/passport_element_error.rs:55:22
   |
46 |     #[serde(rename = "snake_case")]
   |                      ------------ matches all the relevant values
...
55 |     #[serde(rename = "snake_case")]
   |                      ^^^^^^^^^^^^ no value can reach this

warning: unreachable pattern
  --> /home/fr0staman/source/repos/rust/teloxide/crates/teloxide-core/src/types/passport_element_error.rs:58:22
   |
46 |     #[serde(rename = "snake_case")]
   |                      ------------ matches all the relevant values
...
58 |     #[serde(rename = "snake_case")]
   |                      ^^^^^^^^^^^^ no value can reach this

warning: unreachable pattern
  --> /home/fr0staman/source/repos/rust/teloxide/crates/teloxide-core/src/types/passport_element_error.rs:61:22
   |
46 |     #[serde(rename = "snake_case")]
   |                      ------------ matches all the relevant values
...
61 |     #[serde(rename = "snake_case")]
   |                      ^^^^^^^^^^^^ no value can reach this

warning: unreachable pattern
  --> /home/fr0staman/source/repos/rust/teloxide/crates/teloxide-core/src/types/passport_element_error.rs:64:22
   |
46 |     #[serde(rename = "snake_case")]
   |                      ------------ matches all the relevant values
...
64 |     #[serde(rename = "snake_case")]
   |                      ^^^^^^^^^^^^ no value can reach this

warning: unreachable pattern
  --> /home/fr0staman/source/repos/rust/teloxide/crates/teloxide-core/src/types/passport_element_error.rs:67:22
   |
46 |     #[serde(rename = "snake_case")]
   |                      ------------ matches all the relevant values
...
67 |     #[serde(rename = "snake_case")]
   |                      ^^^^^^^^^^^^ no value can reach this

   Compiling rayon v1.10.0
   Compiling pretty_env_logger v0.5.0
   Compiling unicode-width v0.2.0
   Compiling dotenvy v0.15.7
   Compiling teloxide v0.13.0 (/home/fr0staman/source/repos/rust/teloxide/crates/teloxide)
   Compiling zstd v0.13.2
warning: `teloxide-core` (lib) generated 7 warnings
```

**After:**
```sh
   Compiling teloxide-core v0.10.1 (/home/fr0staman/source/repos/rust/teloxide/crates/teloxide-core)
   Compiling teloxide v0.13.0 (/home/fr0staman/source/repos/rust/teloxide/crates/teloxide)
   Compiling fr0staman_bot v1.4.1 (/home/fr0staman/source/repos/rust/fr0staman_bot)
    Finished `release` profile [optimized] target(s) in 1m 46s
```