### PR TITLE
Bump bitflags to 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `tokio` version was explicitly specified as `1.39`
 - Added new `Send` and `Sync` trait bounds to the `UListener` and `Eh` generic parameters of `try_dispatch_with_listener` and `dispatch_with_listener` ([PR 1185](https://github.com/teloxide/teloxide/pull/1185)) [**BC**]
 - Renamed `Limits::messages_per_min_channel` to `messages_per_min_channel_or_supergroup` to reflect its actual behavior ([PR 1214](https://github.com/teloxide/teloxide/pull/1214))
+- Added derive `Clone`, `Debug`, `PartialEq`, `Eq`, `Hash` to `ChatPermissions`
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added new `Send` and `Sync` trait bounds to the `UListener` and `Eh` generic parameters of `try_dispatch_with_listener` and `dispatch_with_listener` ([PR 1185](https://github.com/teloxide/teloxide/pull/1185)) [**BC**]
 - Renamed `Limits::messages_per_min_channel` to `messages_per_min_channel_or_supergroup` to reflect its actual behavior ([PR 1214](https://github.com/teloxide/teloxide/pull/1214))
 - Added derive `Clone`, `Debug`, `PartialEq`, `Eq`, `Hash` to `ChatPermissions` ([PR 1242](https://github.com/teloxide/teloxide/pull/1242))
+- Added derive `Clone`, `Debug` to `Settings` ([PR 1242](https://github.com/teloxide/teloxide/pull/1242))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `tokio` version was explicitly specified as `1.39`
 - Added new `Send` and `Sync` trait bounds to the `UListener` and `Eh` generic parameters of `try_dispatch_with_listener` and `dispatch_with_listener` ([PR 1185](https://github.com/teloxide/teloxide/pull/1185)) [**BC**]
 - Renamed `Limits::messages_per_min_channel` to `messages_per_min_channel_or_supergroup` to reflect its actual behavior ([PR 1214](https://github.com/teloxide/teloxide/pull/1214))
-- Added derive `Clone`, `Debug`, `PartialEq`, `Eq`, `Hash` to `ChatPermissions`
+- Added derive `Clone`, `Debug`, `PartialEq`, `Eq`, `Hash` to `ChatPermissions` ([PR 1242](https://github.com/teloxide/teloxide/pull/1242))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Environment bumps: ([PR 1147](https://github.com/teloxide/teloxide/pull/1147), [PR 1225](https://github.com/teloxide/teloxide/pull/1225))
   - MSRV (Minimal Supported Rust Version) was bumped from `1.70.0` to `1.80.0`
-  - Some dependencies was bumped: `axum` to `0.8.0`, `sqlx` to `0.8.1`, `tower` to `0.5.0`, `reqwest` to `0.12.7`, `tower-http` to `0.6.2`, `derive_more` to `1.0.0`
+  - Some dependencies was bumped: `axum` to `0.8.0`, `sqlx` to `0.8.1`, `tower` to `0.5.0`, `reqwest` to `0.12.7`, `tower-http` to `0.6.2`, `derive_more` to `1.0.0`, `bitflags` to `2`
   - `tokio` version was explicitly specified as `1.39`
 - Added new `Send` and `Sync` trait bounds to the `UListener` and `Eh` generic parameters of `try_dispatch_with_listener` and `dispatch_with_listener` ([PR 1185](https://github.com/teloxide/teloxide/pull/1185)) [**BC**]
 - Renamed `Limits::messages_per_min_channel` to `messages_per_min_channel_or_supergroup` to reflect its actual behavior ([PR 1214](https://github.com/teloxide/teloxide/pull/1214))

--- a/crates/teloxide-core/Cargo.toml
+++ b/crates/teloxide-core/Cargo.toml
@@ -75,7 +75,7 @@ take_mut = "0.2"
 rc-box = "1.1.1"
 chrono = { version = "0.4.32", default-features = false }
 either = "1.6.1"
-bitflags = { version = "1.2" }
+bitflags = "2"
 rgb = "0.8.48"
 
 vecrem = { version = "0.1", optional = true }

--- a/crates/teloxide-core/src/adaptors/trace.rs
+++ b/crates/teloxide-core/src/adaptors/trace.rs
@@ -45,7 +45,7 @@ impl<B> Trace<B> {
     }
 
     pub fn settings(&self) -> Settings {
-        self.settings
+        self.settings.clone()
     }
 }
 
@@ -64,6 +64,7 @@ bitflags::bitflags! {
     /// // Trace requests verbosely and responses (non verbosely)
     /// let _ = Settings::TRACE_REQUESTS_VERBOSE | Settings::TRACE_RESPONSES;
     /// ```
+    #[derive(Debug, Clone)]
     pub struct Settings: u8 {
         /// Trace requests (only request kind, e.g. `send_message`)
         const TRACE_REQUESTS = 1;
@@ -71,7 +72,7 @@ bitflags::bitflags! {
         /// Trace requests verbosely (with all parameters).
         ///
         /// Implies [`TRACE_REQUESTS`]
-        const TRACE_REQUESTS_VERBOSE = (1 << 1) | Self::TRACE_REQUESTS.bits;
+        const TRACE_REQUESTS_VERBOSE = (1 << 1) | Self::TRACE_REQUESTS.bits();
 
         /// Trace responses (only request kind, e.g. `send_message`)
         const TRACE_RESPONSES = 1 << 2;
@@ -79,17 +80,17 @@ bitflags::bitflags! {
         /// Trace responses verbosely (with full response).
         ///
         /// Implies [`TRACE_RESPONSES`]
-        const TRACE_RESPONSES_VERBOSE = (1 << 3) | Self::TRACE_RESPONSES.bits;
+        const TRACE_RESPONSES_VERBOSE = (1 << 3) | Self::TRACE_RESPONSES.bits();
 
         /// Trace everything.
         ///
         /// Implies [`TRACE_REQUESTS`] and [`TRACE_RESPONSES`].
-        const TRACE_EVERYTHING = Self::TRACE_REQUESTS.bits | Self::TRACE_RESPONSES.bits;
+        const TRACE_EVERYTHING = Self::TRACE_REQUESTS.bits() | Self::TRACE_RESPONSES.bits();
 
         /// Trace everything verbosely.
         ///
         /// Implies [`TRACE_REQUESTS_VERBOSE`] and [`TRACE_RESPONSES_VERBOSE`].
-        const TRACE_EVERYTHING_VERBOSE = Self::TRACE_REQUESTS_VERBOSE.bits | Self::TRACE_RESPONSES_VERBOSE.bits;
+        const TRACE_EVERYTHING_VERBOSE = Self::TRACE_REQUESTS_VERBOSE.bits() | Self::TRACE_RESPONSES_VERBOSE.bits();
     }
 }
 
@@ -103,7 +104,7 @@ macro_rules! fwd_inner {
     ($m:ident $this:ident ($($arg:ident : $T:ty),*)) => {
         TraceRequest {
             inner: $this.inner().$m($($arg),*),
-            settings: $this.settings
+            settings: $this.settings.clone()
         }
     };
 }

--- a/crates/teloxide-core/src/types/chat.rs
+++ b/crates/teloxide-core/src/types/chat.rs
@@ -371,7 +371,7 @@ impl Chat {
             if let PublicChatKind::Group(PublicChatGroup { permissions })
             | PublicChatKind::Supergroup(PublicChatSupergroup { permissions, .. }) = &this.kind
             {
-                return *permissions;
+                return permissions.clone();
             }
         }
 

--- a/crates/teloxide-core/src/types/chat_permissions.rs
+++ b/crates/teloxide-core/src/types/chat_permissions.rs
@@ -34,7 +34,7 @@ bitflags::bitflags! {
     /// let permissions_v2 = permissions_v1 - ChatPermissions::SEND_VIDEOS;
     /// assert!(!permissions_v2.contains(ChatPermissions::SEND_VIDEOS));
     /// ```
-    #[derive(Serialize, Deserialize)]
+    #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
     #[serde(from = "ChatPermissionsRaw", into = "ChatPermissionsRaw")]
     pub struct ChatPermissions: u16 {
         /// Set if the user is allowed to send text messages, contacts,
@@ -90,12 +90,12 @@ bitflags::bitflags! {
         /// `SEND_AUDIOS`, `SEND_DOCUMENTS`, `SEND_PHOTOS`,
         /// `SEND_VIDEOS`, `SEND_VIDEO_NOTES` and `SEND_VOICE_NOTES`.
         /// Note: this is not a separate permission on it's own, this is just a alias for all the permissions mentioned.
-        const SEND_MEDIA_MESSAGES = Self::SEND_AUDIOS.bits
-                                            | Self::SEND_DOCUMENTS.bits
-                                            | Self::SEND_PHOTOS.bits
-                                            | Self::SEND_VIDEOS.bits
-                                            | Self::SEND_VIDEO_NOTES.bits
-                                            | Self::SEND_VOICE_NOTES.bits;
+        const SEND_MEDIA_MESSAGES = Self::SEND_AUDIOS.bits()
+                                            | Self::SEND_DOCUMENTS.bits()
+                                            | Self::SEND_PHOTOS.bits()
+                                            | Self::SEND_VIDEOS.bits()
+                                            | Self::SEND_VIDEO_NOTES.bits()
+                                            | Self::SEND_VOICE_NOTES.bits();
 
     }
 }


### PR DESCRIPTION
Bump bitflags to latest major.

Note about `permissions.clone()`:
`derive_more::Deref` cannot be applied to `ChatPermissions`, because it created internal _BitFlags type.

It is probably possible to write impl Deref manually, but I decided not to do it.