### PR TITLE
Bump aquamarine to 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Environment bumps: ([PR 1147](https://github.com/teloxide/teloxide/pull/1147), [PR 1225](https://github.com/teloxide/teloxide/pull/1225))
   - MSRV (Minimal Supported Rust Version) was bumped from `1.70.0` to `1.80.0`
-  - Some dependencies was bumped: `axum` to `0.8.0`, `sqlx` to `0.8.1`, `tower` to `0.5.0`, `reqwest` to `0.12.7`, `tower-http` to `0.6.2`, `derive_more` to `1.0.0`
+  - Some dependencies was bumped: `axum` to `0.8.0`, `sqlx` to `0.8.1`, `tower` to `0.5.0`, `reqwest` to `0.12.7`, `tower-http` to `0.6.2`, `derive_more` to `1.0.0`, `aquamarine` to `0.6`
   - `tokio` version was explicitly specified as `1.39`
 - Added new `Send` and `Sync` trait bounds to the `UListener` and `Eh` generic parameters of `try_dispatch_with_listener` and `dispatch_with_listener` ([PR 1185](https://github.com/teloxide/teloxide/pull/1185)) [**BC**]
 - Renamed `Limits::messages_per_min_channel` to `messages_per_min_channel_or_supergroup` to reflect its actual behavior ([PR 1214](https://github.com/teloxide/teloxide/pull/1214))

--- a/crates/teloxide/Cargo.toml
+++ b/crates/teloxide/Cargo.toml
@@ -102,7 +102,7 @@ derive_more = { version = "1.0.0", features = ["display", "from", "deref"] }
 thiserror = "1.0"
 futures = "0.3.15"
 pin-project = "1.0"
-aquamarine = "0.5.0"
+aquamarine = "0.6.0"
 either = "1.9.0"
 
 sqlx = { version = "0.8.1", optional = true, default-features = false, features = [


### PR DESCRIPTION
Bump aquamarine to latest version.

Another small step towards throwing out syn 1.