### PR TITLE
Bump `syn` to 2.0.96 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Environment bumps: ([PR 1147](https://github.com/teloxide/teloxide/pull/1147), [PR 1225](https://github.com/teloxide/teloxide/pull/1225))
   - MSRV (Minimal Supported Rust Version) was bumped from `1.70.0` to `1.80.0`
-  - Some dependencies was bumped: `axum` to `0.8.0`, `sqlx` to `0.8.1`, `tower` to `0.5.0`, `reqwest` to `0.12.7`, `tower-http` to `0.6.2`, `derive_more` to `1.0.0`, `serde_with` to `3.12.0`, `aquamarine` to `0.6.0`, `deadpool-redis` to `0.18.0`, `thiserror` to `2.0.11`
+  - Some dependencies was bumped: `axum` to `0.8.0`, `sqlx` to `0.8.1`, `tower` to `0.5.0`, `reqwest` to `0.12.7`, `tower-http` to `0.6.2`, `derive_more` to `1.0.0`, `serde_with` to `3.12.0`, `aquamarine` to `0.6.0`, `deadpool-redis` to `0.18.0`, `thiserror` to `2.0.11`,
+  `syn` to `2.0.96`
   - `tokio` version was explicitly specified as `1.39`
 - Added new `Send` and `Sync` trait bounds to the `UListener` and `Eh` generic parameters of `try_dispatch_with_listener` and `dispatch_with_listener` ([PR 1185](https://github.com/teloxide/teloxide/pull/1185)) [**BC**]
 - Renamed `Limits::messages_per_min_channel` to `messages_per_min_channel_or_supergroup` to reflect its actual behavior ([PR 1214](https://github.com/teloxide/teloxide/pull/1214))

--- a/crates/teloxide-macros/Cargo.toml
+++ b/crates/teloxide-macros/Cargo.toml
@@ -19,7 +19,7 @@ proc-macro = true
 [dependencies]
 quote = "1.0.7"
 proc-macro2 = "1.0.67"
-syn = { version = "1.0.13", features = ["full", "extra-traits"] }
+syn = { version = "2.0.96", features = ["full", "extra-traits"] }
 heck = "0.5.0"
 
 [package.metadata.release]

--- a/crates/teloxide-macros/src/attr.rs
+++ b/crates/teloxide-macros/src/attr.rs
@@ -23,9 +23,18 @@ pub(crate) fn fold_attrs<A, R>(
                 return vec![Err(compile_error_at("expected an ident", attribute.path().span()))];
             };
 
+            // TODO: rewrite `Attrs` parser to syn 2 fully
+            //
+            // syn 2 has many breaking changes compared to syn 1.
+            // At this place, code was adapted to support syn 2, ensuring that the same
+            // tokens are passed to `Attrs::parse_with_key(input, key)`.
+            //
+            // The internal logic remains unchanged, similar to syn 1.
+            // In the future, parsing should be rewritten to take advantage of syn 2’s
+            // improvements for code deduplication and maintainability.
+
             let args = match attribute.parse_args() {
                 Ok(v) => Group::new(Delimiter::Parenthesis, v).to_token_stream(),
-                // TODO: rewrite Attrs parser to syn 2 fully
                 Err(_) => {
                     let value = match attribute.meta.require_name_value() {
                         Ok(v) => v.value.to_token_stream(),

--- a/crates/teloxide-macros/src/attr.rs
+++ b/crates/teloxide-macros/src/attr.rs
@@ -1,6 +1,7 @@
 use crate::{error::compile_error_at, Result};
 
-use proc_macro2::{Delimiter, Span};
+use proc_macro2::{Delimiter, Group, Span};
+use quote::ToTokens;
 use syn::{
     parse::{Parse, ParseStream, Parser},
     spanned::Spanned,
@@ -18,12 +19,19 @@ pub(crate) fn fold_attrs<A, R>(
         .iter()
         .filter(|&a| filter(a))
         .flat_map(|attribute| {
-            let Some(key) = attribute.path.get_ident().cloned() else {
-                return vec![Err(compile_error_at("expected an ident", attribute.path.span()))];
+            let Some(key) = attribute.path().get_ident().cloned() else {
+                return vec![Err(compile_error_at("expected an ident", attribute.path().span()))];
             };
 
+            let args = match attribute.parse_args() {
+                Ok(v) => v,
+                Err(err) => return vec![Err(err.into())],
+            };
+
+            let args_with_parents = Group::new(Delimiter::Parenthesis, args).to_token_stream();
+
             match (|input: ParseStream<'_>| Attrs::parse_with_key(input, key))
-                .parse(attribute.tokens.clone().into())
+                .parse2(args_with_parents)
             {
                 Ok(ok) => ok.0.into_iter().map(&parse).collect(),
                 Err(err) => vec![Err(err.into())],
@@ -105,7 +113,7 @@ impl Attrs {
                 }
 
                 let mut attrs =
-                    (|input: ParseStream<'_>| input.parse_terminated::<_, Token![,]>(Attrs::parse))
+                    (|input: ParseStream<'_>| input.parse_terminated(Attrs::parse, Token![,]))
                         .parse(group.token_stream().into())?
                         .into_iter()
                         .reduce(|mut l, r| {
@@ -204,12 +212,13 @@ impl AttrValue {
         match self {
             Self::None(_) => "nothing",
             Self::Lit(l) => match l {
-                Str(_) | ByteStr(_) => "a string",
+                Str(_) | ByteStr(_) | CStr(_) => "a string",
                 Char(_) => "a character",
                 Byte(_) | Int(_) => "an integer",
                 Float(_) => "a floating point integer",
                 Bool(_) => "a boolean",
                 Verbatim(_) => ":shrug:",
+                _ => ":mag:",
             },
             Self::Array(_, _) => "an array",
             Self::Path(_) => "a path",
@@ -239,8 +248,8 @@ impl Parse for AttrValue {
         } else if input.peek(syn::token::Bracket) {
             let content;
             let array_span = syn::bracketed!(content in input).span;
-            let array = content.parse_terminated::<_, Token![,]>(AttrValue::parse)?;
-            Ok(AttrValue::Array(array.into_iter().collect(), array_span))
+            let array = content.parse_terminated(AttrValue::parse, Token![,])?;
+            Ok(AttrValue::Array(array.into_iter().collect(), array_span.span()))
         } else {
             Ok(AttrValue::Path(
                 input

--- a/crates/teloxide-macros/src/command_attr.rs
+++ b/crates/teloxide-macros/src/command_attr.rs
@@ -6,8 +6,8 @@ use crate::{
     Result,
 };
 
-use proc_macro::TokenStream;
-use proc_macro2::Span;
+use proc_macro2::{Span, TokenStream};
+use quote::ToTokens;
 use syn::{
     parse::{ParseStream, Peek},
     Attribute, Token,
@@ -210,11 +210,14 @@ impl CommandAttr {
 }
 
 fn is_command_attribute(a: &Attribute) -> bool {
-    matches!(a.path.get_ident(), Some(ident) if ident == "command")
+    matches!(a.path().get_ident(), Some(ident) if ident == "command")
 }
 
 fn is_doc_comment(a: &Attribute) -> bool {
-    matches!(a.path.get_ident(), Some(ident) if ident == "doc" && peek_at_token_stream(a.tokens.clone().into(), Token![=]))
+    matches!(
+        a.path().get_ident(),
+        Some(ident) if ident == "doc" && peek_at_token_stream(a.to_token_stream(), Token![=])
+    )
 }
 
 fn peek_at_token_stream(s: TokenStream, p: impl Peek) -> bool {
@@ -225,6 +228,6 @@ fn peek_at_token_stream(s: TokenStream, p: impl Peek) -> bool {
         _ = input.step(|_| Ok(((), syn::buffer::Cursor::empty())));
         Ok(r)
     })
-    .parse(s)
+    .parse2(s)
     .unwrap()
 }

--- a/crates/teloxide-macros/src/command_attr.rs
+++ b/crates/teloxide-macros/src/command_attr.rs
@@ -6,12 +6,8 @@ use crate::{
     Result,
 };
 
-use proc_macro2::{Span, TokenStream};
-use quote::ToTokens;
-use syn::{
-    parse::{ParseStream, Peek},
-    Attribute, Token,
-};
+use proc_macro2::Span;
+use syn::Attribute;
 
 /// All attributes that can be used for `derive(BotCommands)`
 pub(crate) struct CommandAttrs {
@@ -216,18 +212,6 @@ fn is_command_attribute(a: &Attribute) -> bool {
 fn is_doc_comment(a: &Attribute) -> bool {
     matches!(
         a.path().get_ident(),
-        Some(ident) if ident == "doc" && peek_at_token_stream(a.to_token_stream(), Token![=])
+        Some(ident) if ident == "doc" && a.meta.require_name_value().is_ok()
     )
-}
-
-fn peek_at_token_stream(s: TokenStream, p: impl Peek) -> bool {
-    // syn be fr challenge 2023 (impossible)
-    use syn::parse::Parser;
-    (|input: ParseStream<'_>| {
-        let r = input.peek(p);
-        _ = input.step(|_| Ok(((), syn::buffer::Cursor::empty())));
-        Ok(r)
-    })
-    .parse2(s)
-    .unwrap()
 }

--- a/crates/teloxide/Cargo.toml
+++ b/crates/teloxide/Cargo.toml
@@ -79,7 +79,7 @@ full = [
 [dependencies]
 # replace me by the actual version when release, and return path when it's time to make 0-day fixes
 teloxide-core = { path = "../../crates/teloxide-core", default-features = false }
-teloxide-macros = { version = "0.8", optional = true }
+teloxide-macros = { path = "../../crates/teloxide-macros", optional = true }
 
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
Bump syn to version 2.

With [my bot](https://github.com/fr0staman/fr0staman_bot) works fine. Also tried cases from docs.
Implementation is not perfect, but it allowed us to get rid of the syn 1 dependency.