### PR TITLE
fix: use web-archive links for tutorials section

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,8 +292,8 @@ A community made crate [`teloxide_tests`](https://github.com/LasterAlex/teloxide
 
 ## Tutorials
 
- - [_"Migrating my family finance bot from Python to Rust (teloxide) because I am tired of exceptions (part 1)"_](https://trkohler.com/posts/i-migrated-my-family-finance-bot-from-python-to-rust-because-i-am-tired-of-exceptions/) by Troy Köhler.
- - [_"Migrating my family finance bot from Python to Rust (teloxide) [part 2]"_](https://trkohler.com/posts/migrating-my-family-finance-bot-from-python-to-rust-teloxide-part-2/) by Troy Köhler.
+ - [_"Migrating my family finance bot from Python to Rust (teloxide) because I am tired of exceptions (part 1)"_](https://web.archive.org/web/20230130112018/https://trkohler.com/posts/i-migrated-my-family-finance-bot-from-python-to-rust-because-i-am-tired-of-exceptions/) by Troy Köhler.
+ - [_"Migrating my family finance bot from Python to Rust (teloxide) [part 2]"_](https://web.archive.org/web/20240529200929/https://trkohler.com/posts/migrating-my-family-finance-bot-from-python-to-rust-teloxide-part-2/) by Troy Köhler.
 
 ## FAQ
 


### PR DESCRIPTION
the links to the posts in [Tutorials](https://github.com/teloxide/teloxide?tab=readme-ov-file#tutorials) section were restored via web-archive, so there is no reason to update `CHANGELOG.md` or `Documentation`

closes #1112