### PR TITLE
Add `sender_boost_count` method to the `Message` struct

### DIFF
--- a/crates/teloxide-core/CHANGELOG.md
+++ b/crates/teloxide-core/CHANGELOG.md
@@ -43,9 +43,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Add `BusinessConnection`, `BusinessMessage`, `EditedBusinessMessage` and `DeletedBusinessMessages` variants to `UpdateKind` enum
 
 - `ApiError::BotKickedFromChannel` ([#1157][pr1157])
+- `sender_boost_count` method to the `Message` struct ([#1264][pr1264])
 - `From<&Message> for MessageId` impl ([#1271][pr1271])
 
 [pr1157]: https://github.com/teloxide/teloxide/pull/1157
+[pr1264]: https://github.com/teloxide/teloxide/pull/1264
 [pr1271]: https://github.com/teloxide/teloxide/pull/1271
 
 ### Changed

--- a/crates/teloxide-core/src/types/message.rs
+++ b/crates/teloxide-core/src/types/message.rs
@@ -786,6 +786,14 @@ mod getters {
         }
 
         #[must_use]
+        pub fn sender_boost_count(&self) -> Option<u16> {
+            match &self.kind {
+                Common(MessageCommon { sender_boost_count, .. }) => *sender_boost_count,
+                _ => None,
+            }
+        }
+
+        #[must_use]
         pub fn forward_date(&self) -> Option<DateTime<Utc>> {
             self.forward_origin().map(|f| f.date())
         }


### PR DESCRIPTION
Somehow I missed this in the TBA 7.1 PR.