### PR TITLE
Fix blockquote handling in the render module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Now `InlineQueryResultsButton` serializes properly ([issue 1181](https://github.com/teloxide/teloxide/issues/1181))
 - Now `ThreadId` is able to serialize in multipart requests ([PR 1179](https://github.com/teloxide/teloxide/pull/1179))
 - Now stack does not overflow on dispatch ([issue 1154](https://github.com/teloxide/teloxide/issues/1154))
+- Now blockquote handling in the render module works correctly ([PR 1267](https://github.com/teloxide/teloxide/pull/1267))
 
 ## 0.13.0 - 2024-08-16
 


### PR DESCRIPTION
Fixes #1266

Results with the example from the issue:
![image](https://github.com/user-attachments/assets/6d5eb6d3-08d8-4e48-9b50-c7a8b5f423a4)
![image](https://github.com/user-attachments/assets/af6d480c-5d5b-41b3-83f4-2a4fd44b8c86)
