### PR TITLE
Fix blockquote() in utils::markdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Now stack does not overflow on dispatch ([issue 1154](https://github.com/teloxide/teloxide/issues/1154))
 - Implement `RequestReplyExt` and `RequestLinkPreviewExt` on setters from `teloxide_core::payloads` so syntax sugar can work on bot adaptors too ([PR 1270](https://github.com/teloxide/teloxide/pull/1270))
 - Now blockquote handling in the render module works correctly ([PR 1267](https://github.com/teloxide/teloxide/pull/1267))
+- Now blockquote generation in the `utils::markdown` module works correctly ([PR 1273](https://github.com/teloxide/teloxide/pull/1273))
 - Fixed calculation of per-second limits in the `Throttle` adaptor ([PR 1212](https://github.com/teloxide/teloxide/pull/1212))
 
 ## 0.13.0 - 2024-08-16

--- a/crates/teloxide/src/utils/markdown.rs
+++ b/crates/teloxide/src/utils/markdown.rs
@@ -25,7 +25,7 @@ pub fn bold(s: &str) -> String {
 #[must_use = "This function returns a new string, rather than mutating the argument, so calling it \
               without using its output does nothing useful"]
 pub fn blockquote(s: &str) -> String {
-    format!(">{s}")
+    format!("**>{}", s.replace('\n', "\n>"))
 }
 
 /// Applies the italic font style to the string.

--- a/crates/teloxide/src/utils/markdown.rs
+++ b/crates/teloxide/src/utils/markdown.rs
@@ -224,6 +224,11 @@ mod tests {
     }
 
     #[test]
+    fn test_blockquote() {
+        assert_eq!(blockquote("foobar\n\nfoo\nbar"), "**>foobar\n>\n>foo\n>bar");
+    }
+
+    #[test]
     fn test_code_block() {
         assert_eq!(
             code_block("pre-'formatted'\nfixed-width \\code `block`"),


### PR DESCRIPTION
Follow-up on #1267

Code:
```rust
Update::filter_message().branch(Message::filter_text().endpoint(
    |msg: Message, bot: Bot| async move {
        bot.send_message(msg.chat.id, markdown::blockquote(msg.text().unwrap()))
            .parse_mode(ParseMode::MarkdownV2)
            .await?;

        Ok::<(), RequestError>(())
    },
))
```

Before:
![image](https://github.com/user-attachments/assets/601e319a-814b-440c-b4b1-64ab8ff2487d)

After:
![image](https://github.com/user-attachments/assets/0523cf47-e61b-480a-be3a-0368baff3b91)