### PR TITLE
Fix parsing of get_chat responses for channels with paid reactions

### DIFF
--- a/crates/teloxide-core/src/types/reaction_type.rs
+++ b/crates/teloxide-core/src/types/reaction_type.rs
@@ -22,6 +22,8 @@ pub enum ReactionType {
         /// Custom emoji identifier.
         custom_emoji_id: String,
     },
+    /// Paid reaction.
+    Paid,
 }
 
 impl ReactionType {


### PR DESCRIPTION
Docs: https://core.telegram.org/bots/api#reactiontypepaid

Closes https://github.com/teloxide/teloxide/issues/1283

<!--
Before making this PR, please ensure the following:

- `CHANGELOG.md` is updated (if necessary).
- Documentation and tests are updated (if necessary).
-->
