### PR TITLE
Fix the issue where requests will not consider API URL subpath.

### DIFF
--- a/crates/teloxide-core/src/bot.rs
+++ b/crates/teloxide-core/src/bot.rs
@@ -142,6 +142,12 @@ impl Bot {
 
         match std::env::var(TELOXIDE_API_URL) {
             Ok(env_api_url) => {
+                // Remove the trailing slash if it exists
+                let env_api_url = if env_api_url.ends_with('/') {
+                    env_api_url.trim_end_matches('/')
+                } else {
+                    &env_api_url
+                };
                 let api_url = reqwest::Url::parse(&env_api_url)
                     .expect("Failed to parse the `TELOXIDE_API_URL` env variable");
                 bot.set_api_url(api_url)


### PR DESCRIPTION
This PR fixes the issue where requests will not consider API URL subpath.

**Background**:
When I use `https://example.com/telegram` or `https://example.com/telegram/` as `TELOXIDE_API_URL`, the request is sent to `https://example.com/botTOKEN/METHOD` instead of the expected `https://example.com/telegram/botTOKEN/METHOD`.

**What I do**:
I fix the `method_url` behavior by utilizing [`path_segments_mut()`](https://docs.rs/url/latest/url/struct.Url.html#method.path_segments_mut) and removing the trailing slash in the API URL if neccessary.

**Bug reason**:
The behavior of `.join` varies depending on whether the `base` URL has a trailing slash and whether the joined path has a leading slash.
I use the following code to diagnose the issue:
```Rust
fn method_url(base: reqwest::Url, token: &str, method_name: &str) -> reqwest::Url {
    base.join(&format!("/bot{token}/{method_name}"))
        .expect("failed to format url")
}

fn method_url_without_slash(base: reqwest::Url, token: &str, method_name: &str) -> reqwest::Url {
    // Remove the leading slash
    base.join(&format!("bot{token}/{method_name}"))
        .expect("failed to format url")
}

fn main() {
    let env_api_url_with_slash = "https://example.com/telegram/";
    let env_api_url_without_slash = "https://example.com/telegram";
    let token = "TOKEN";
    let method_name = "getMe";

    // Define the type of the function
    type UrlFunction = fn(reqwest::Url, &str, &str) -> reqwest::Url;

    // Define the functions to test
    let functions: Vec<(UrlFunction, &str)> = vec![
        (
            method_url_without_slash as UrlFunction,
            "method_url_without_slash",
        ),
        (method_url as UrlFunction, "method_url"),
    ];

    // Test the functions with different API URLs
    for (f, f_name) in functions {
        for env_api_url in vec![env_api_url_with_slash, env_api_url_without_slash] {
            let api_url = reqwest::Url::parse(env_api_url).unwrap();
            let url = f(api_url, token, method_name);
            println!(
                "function: {}, env_api_url: {:?}, url: {:?}",
                f_name,
                env_api_url,
                url.as_str()
            );
        }
    }
}
```
It outputs:
```text
function: method_url_without_slash, env_api_url: "https://example.com/telegram/", url: "https://example.com/telegram/botTOKEN/getMe"
function: method_url_without_slash, env_api_url: "https://example.com/telegram", url: "https://example.com/botTOKEN/getMe"
function: method_url, env_api_url: "https://example.com/telegram/", url: "https://example.com/botTOKEN/getMe"
function: method_url, env_api_url: "https://example.com/telegram", url: "https://example.com/botTOKEN/getMe"
```
**Other attempts**:
I attempted to fix the issue by removing the leading slash in `method_url` and ensuring the trailing slash for `base`, but this caused cargo test to fail. I was unable to determine the reason for the failure.

