### PR TITLE
Add `.mailmap`

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,16 @@
+hirrolot <hirrolot@gmail.com>
+Waffle Lapkin <waffle.lapkin@gmail.com>
+Waffle Lapkin <waffle.lapkin@gmail.com> <wafflewafflerov@gmail.com>
+Dmytro Polunin <dmytro.polunin@gmail.com>
+Dmytro Polunin <dmytro.polunin@gmail.com> <48922415+p0lunin@users.noreply.github.com>
+Dmytro Polunin <dmytro.polunin@gmail.com> <polunindima2002@gmail.com>
+Сырцев Вадим Игоревич <syrtcevvi@gmail.com>
+Сырцев Вадим Игоревич <syrtcevvi@gmail.com> <74814717+syrtcevvi@users.noreply.github.com>
+TheAwiteb <awiteb@hotmail.com>
+TheAwiteb <awiteb@hotmail.com> <Awiteb@pm.me>
+TheAwiteb <awiteb@hotmail.com> <Awiteb@hotmail.com>
+LasterAlex <sasha.ishukshin@gmail.com> <75775321+LasterAlex@users.noreply.github.com>
+gymmasssorla <gymmasssorla@gmail.com>
+puh <puhovik@protonmail.com>
+puh <puhovik@protonmail.com> <54703480+puuuuh@users.noreply.github.com>
+Nextel <rm.nextel@gmail.com>


### PR DESCRIPTION
The [mailmap functionality](https://git-scm.com/docs/gitmailmap) in Git is used to correct commit authors' names without destructive history overwriting. This PR adds the file `.mailmap` which corrects some frequent commiters' information (usually taken from their last commits to our repository).
