### PR TITLE
Release v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## unreleased
 
+## 0.14.0 - 2025-03-29
+
 ### Added
 
 - `filter_boost_added` and `filter_reply_to_story` filters to the `MessageFilterExt` trait ([PR 1131](https://github.com/teloxide/teloxide/pull/1131))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2456,7 +2456,7 @@ dependencies = [
 
 [[package]]
 name = "teloxide-core"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "aho-corasick",
  "bitflags",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2420,7 +2420,7 @@ checksum = "20f34339676cdcab560c9a82300c4c2581f68b9369aedf0fae86f2ff9565ff3e"
 
 [[package]]
 name = "teloxide"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "aquamarine",
  "axum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2494,7 +2494,7 @@ dependencies = [
 
 [[package]]
 name = "teloxide-macros"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2442,8 +2442,8 @@ dependencies = [
  "serde_cbor",
  "serde_json",
  "sqlx",
- "teloxide-core",
- "teloxide-macros",
+ "teloxide-core 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "teloxide-macros 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -2493,8 +2493,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "teloxide-core"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b38b050f6f047f5fcc21a2603d5e20633c731ca71ca2096028b8a6680edee031"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "chrono",
+ "derive_more",
+ "either",
+ "futures",
+ "log",
+ "mime",
+ "once_cell",
+ "pin-project",
+ "rc-box",
+ "reqwest",
+ "rgb",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "take_mut",
+ "takecell",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "url",
+ "uuid",
+ "vecrem",
+]
+
+[[package]]
 name = "teloxide-macros"
 version = "0.9.0"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "teloxide-macros"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3118a980ed2ec11f73d9495a6606905bd74726e3ffe95a42fbeb187ded8fdbf4"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -3,6 +3,8 @@ Note that the list of required changes is not fully exhaustive and it may lack s
 
 ## unreleased
 
+## 0.13 -> 0.14
+
 ### teloxide
 
 We have finally introduced three different categories for syntactic sugar:

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ $ rustup override set nightly
  5. Run `cargo new my_bot`, enter the directory and put these lines into your `Cargo.toml`:
 ```toml
 [dependencies]
-teloxide = { version = "0.13", features = ["macros"] }
+teloxide = { version = "0.14.0", features = ["macros"] }
 log = "0.4"
 pretty_env_logger = "0.5"
 tokio = { version =  "1.8", features = ["rt-multi-thread", "macros"] }

--- a/crates/teloxide-core/CHANGELOG.md
+++ b/crates/teloxide-core/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## unreleased
 
+## 0.11.0 - 2025-03-29
+
 ### Added
 
 - Support for TBA 7.1 ([#1131](pr1131))

--- a/crates/teloxide-core/Cargo.toml
+++ b/crates/teloxide-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "teloxide-core"
-version = "0.10.1"
+version = "0.11.0"
 description = "Core part of the `teloxide` library - telegram bot API client"
 
 rust-version.workspace = true

--- a/crates/teloxide-core/README.md
+++ b/crates/teloxide-core/README.md
@@ -25,7 +25,7 @@
 </div>
 
 ```toml
-teloxide-core = "0.10.1"
+teloxide-core = "0.11.0"
 ```
 _Compiler support: requires rustc 1.80+_.
 

--- a/crates/teloxide-core/src/lib.rs
+++ b/crates/teloxide-core/src/lib.rs
@@ -5,7 +5,7 @@
 //! asynchronous and built using [`tokio`].
 //!
 //!```toml
-//! teloxide-core = "0.10.1"
+//! teloxide-core = "0.11.0"
 //! ```
 //! _Compiler support: requires rustc 1.80+_.
 //!

--- a/crates/teloxide-macros/CHANGELOG.md
+++ b/crates/teloxide-macros/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## unreleased
 
+## 0.9.0 - 2025-03-29
+
 ### Changed
 
 - Environment bumps: ([#1147][pr1147])

--- a/crates/teloxide-macros/Cargo.toml
+++ b/crates/teloxide-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "teloxide-macros"
-version = "0.8.0"
+version = "0.9.0"
 description = "The teloxide's procedural macros"
 
 rust-version.workspace = true

--- a/crates/teloxide/Cargo.toml
+++ b/crates/teloxide/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "teloxide"
-version = "0.13.0"
+version = "0.14.0"
 description = "An elegant Telegram bots framework for Rust"
 
 rust-version.workspace = true

--- a/crates/teloxide/Cargo.toml
+++ b/crates/teloxide/Cargo.toml
@@ -81,8 +81,8 @@ full = [
 
 [dependencies]
 # replace me by the actual version when release, and return path when it's time to make 0-day fixes
-teloxide-core = { path = "../../crates/teloxide-core", default-features = false }
-teloxide-macros = { path = "../../crates/teloxide-macros", optional = true }
+teloxide-core = { version = "0.11", default-features = false }
+teloxide-macros = { version = "0.9", optional = true }
 
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
Thanks to @WaffleLapkin, all crates are released using https://github.com/teloxide/teloxide/pull/860 by `cargo release --package <package> <bump>`.
