### PR TITLE
Implement `Clone` for `RequestError` & `DownloadError`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,11 +111,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `filter_video_chat_ended`
   - `filter_video_chat_participants_invited`
   - `filter_web_app_data`
-- Implement `PostgresStorage`, a persistent dialogue storage based on [PostgreSQL](https://www.postgresql.org/)([PR 996](https://github.com/teloxide/teloxide/pull/996)).
-- Implement `GetChatId` for `teloxide_core::types::{Chat, ChatJoinRequest, ChatMemberUpdated}`.
-- Use [deadpool-redis](https://crates.io/crates/deadpool-redis) for Redis connection pooling ([PR 1081](https://github.com/teloxide/teloxide/pull/1081)).
-- Add `MessageExt::filter_story` method for the corresponding `MediaKind::Story` variant ([PR 1087](https://github.com/teloxide/teloxide/pull/1087)).
-- Add `update_listeners::webhooks::Options::path`, an option to make the webhook server listen on a different path, which can be useful behind a reverse proxy.
+- Implement `PostgresStorage`, a persistent dialogue storage based on [PostgreSQL](https://www.postgresql.org/)([PR 996](https://github.com/teloxide/teloxide/pull/996))
+- Implement `GetChatId` for `teloxide_core::types::{Chat, ChatJoinRequest, ChatMemberUpdated}`
+- Use [deadpool-redis](https://crates.io/crates/deadpool-redis) for Redis connection pooling ([PR 1081](https://github.com/teloxide/teloxide/pull/1081))
+- Add `MessageExt::filter_story` method for the corresponding `MediaKind::Story` variant ([PR 1087](https://github.com/teloxide/teloxide/pull/1087))
+- Add `update_listeners::webhooks::Options::path`, an option to make the webhook server listen on a different path, which can be useful behind a reverse proxy
 - Add `filter_giveaway`, `filter_giveaway_completed`, `filter_giveaway_created` and `filter_giveaway_winners` filters to `MessageFilterExt` trait ([PR 1101](https://github.com/teloxide/teloxide/pull/1101))
 
 ### Fixed
@@ -169,9 +169,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Updated `teloxide-macros` to v0.7.1; see its [changelog](crates/teloxide-macros/CHANGELOG.md#071---2023-01-17) for more.
-- Updated `teloxide-core` to v0.9.0; see its [changelog](crates/teloxide-core/CHANGELOG.md#090---2023-01-17) for more.
-- Updated `axum` to v0.6.0.
+- Updated `teloxide-macros` to v0.7.1; see its [changelog](crates/teloxide-macros/CHANGELOG.md#071---2023-01-17) for more
+- Updated `teloxide-core` to v0.9.0; see its [changelog](crates/teloxide-core/CHANGELOG.md#090---2023-01-17) for more
+- Updated `axum` to v0.6.0
 - The module structure
   - `teloxide::dispatching::update_listeners` => `teloxide::update_listeners`
   - `teloxide::dispatching::repls` => `teloxide::repls`
@@ -201,7 +201,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.11.1 - 2022-10-31 [yanked]
 
-This release was yanked because it accidentally [breaks backwards compatibility](https://github.com/teloxide/teloxide/issues/770).
+This release was yanked because it accidentally [breaks backwards compatibility](https://github.com/teloxide/teloxide/issues/770)
 
 ### Added
 
@@ -223,10 +223,10 @@ This release was yanked because it accidentally [breaks backwards compatibility]
 - Rename `dispatching::stop_token::{AsyncStopToken, AsyncStopFlag}` => `stop::{StopToken, StopFlag}`
 - Replace the generic error type `E` with `RequestError` for REPLs (`repl(_with_listener)`, `commands_repl(_with_listener)`)
 - The following functions are now `#[must_use]`:
-  - `BotCommands::ty`.
-  - `CommandDescriptions::{new, global_description, username, username_from_me}`.
-  - `teloxide::filter_command`.
-  - `teloxide::dispatching::dialogue::enter`.
+  - `BotCommands::ty`
+  - `CommandDescriptions::{new, global_description, username, username_from_me}`
+  - `teloxide::filter_command`
+  - `teloxide::dispatching::dialogue::enter`
 - `BotCommands::parse` now accept `bot_username` as `&str`
 
 ### Added
@@ -245,37 +245,37 @@ This release was yanked because it accidentally [breaks backwards compatibility]
 ### Fixed
 
 - Mark the following functions with `#[must_use]` ([PR 457](https://github.com/teloxide/teloxide/pull/457)):
-  - `TraceStorage::into_inner`.
-  - `AsyncStopToken::new_pair`.
-  - `AsyncStopFlag::is_stopped`.
-  - All from `crate::utils::{html, markdown}`.
-- Rendering of GIFs in lib.rs and crates.io ([PR 681](https://github.com/teloxide/teloxide/pull/681)).
+  - `TraceStorage::into_inner`
+  - `AsyncStopToken::new_pair`
+  - `AsyncStopFlag::is_stopped`
+  - All from `crate::utils::{html, markdown}`
+- Rendering of GIFs in lib.rs and crates.io ([PR 681](https://github.com/teloxide/teloxide/pull/681))
 
 ## 0.10.0 - 2022-07-21
 
 ### Added
 
-- Security checks based on `secret_token` param of `set_webhook` to built-in webhooks.
-- `dispatching::update_listeners::{PollingBuilder, Polling, PollingStream}`.
-- `DispatcherBuilder::enable_ctrlc_handler` method.
+- Security checks based on `secret_token` param of `set_webhook` to built-in webhooks
+- `dispatching::update_listeners::{PollingBuilder, Polling, PollingStream}`
+- `DispatcherBuilder::enable_ctrlc_handler` method
 
 ### Fixed
 
-- `Dispatcher` no longer "leaks" memory for every inactive user ([PR 657](https://github.com/teloxide/teloxide/pull/657)).
-- Allow specifying a path to a custom command parser in `parse_with` ([issue 668](https://github.com/teloxide/teloxide/issues/668)).
+- `Dispatcher` no longer "leaks" memory for every inactive user ([PR 657](https://github.com/teloxide/teloxide/pull/657))
+- Allow specifying a path to a custom command parser in `parse_with` ([issue 668](https://github.com/teloxide/teloxide/issues/668))
 
 ### Changed
 
-- Add the `Key: Clone` requirement for `impl Dispatcher` [**BC**].
-- `dispatching::update_listeners::{polling_default, polling}` now return a named, `Polling<_>` type.
-- Update `teloxide-core` to v0.7.0 with Bot API 6.1 support, see [its changelog][core07c] for more information [**BC**].
+- Add the `Key: Clone` requirement for `impl Dispatcher` [**BC**]
+- `dispatching::update_listeners::{polling_default, polling}` now return a named, `Polling<_>` type
+- Update `teloxide-core` to v0.7.0 with Bot API 6.1 support, see [its changelog][core07c] for more information [**BC**]
 
 [core07c]: https://github.com/teloxide/teloxide-core/blob/master/CHANGELOG.md#070---2022-07-19
 
 ### Deprecated
 
-- The `dispatching::update_listeners::polling` function.
-- `Dispatcher::setup_ctrlc_handler` method.
+- The `dispatching::update_listeners::polling` function
+- `Dispatcher::setup_ctrlc_handler` method
 
 ## 0.9.2 - 2022-06-07
 
@@ -287,18 +287,18 @@ This release was yanked because it accidentally [breaks backwards compatibility]
 
 ### Fixed
 
-- Fix `#[command(rename = "...")]` for custom command names ([issue 633](https://github.com/teloxide/teloxide/issues/633)).
+- Fix `#[command(rename = "...")]` for custom command names ([issue 633](https://github.com/teloxide/teloxide/issues/633))
 
 ## 0.9.0 - 2022-04-27
 
 ### Added
 
-- The `dispatching::filter_command` function (also accessible as `teloxide::filter_command`) as a shortcut for `dptree::entry().filter_command()`.
-- Re-export `dptree::case!` as `teloxide::handler!` (the former is preferred for new code).
+- The `dispatching::filter_command` function (also accessible as `teloxide::filter_command`) as a shortcut for `dptree::entry().filter_command()`
+- Re-export `dptree::case!` as `teloxide::handler!` (the former is preferred for new code)
 
 ### Changed
 
-- Update `teloxide-core` to v0.6.0 with [Bot API 6.0] support [**BC**].
+- Update `teloxide-core` to v0.6.0 with [Bot API 6.0] support [**BC**]
 
 [Bot API 6.0]: https://core.telegram.org/bots/api#april-16-2022
 
@@ -306,60 +306,60 @@ This release was yanked because it accidentally [breaks backwards compatibility]
 
 ### Fixed
 
-- Fix the broken `#[derive(DialogueState)]` (function return type `dptree::Handler`).
+- Fix the broken `#[derive(DialogueState)]` (function return type `dptree::Handler`)
 
 ## 0.8.1 - 2022-04-24
 
 ### Added
 
-- Implement `GetChatId` for `Update`.
-- The `dialogue::enter()` function as a shortcut for `dptree::entry().enter_dialogue()`.
+- Implement `GetChatId` for `Update`
+- The `dialogue::enter()` function as a shortcut for `dptree::entry().enter_dialogue()`
 
 ## 0.8.0 - 2022-04-18
 
 ### Removed
 
-- The old dispatching system and related stuff: `dispatching`, `utils::UpState`, `prelude`, `repls2`, `crate::{dialogues_repl, dialogues_repl_with_listener}`, and `#[teloxide(subtransition)]` [**BC**].
+- The old dispatching system and related stuff: `dispatching`, `utils::UpState`, `prelude`, `repls2`, `crate::{dialogues_repl, dialogues_repl_with_listener}`, and `#[teloxide(subtransition)]` [**BC**]
 
 ### Added
 
-- The new API for dialogue handlers: `teloxide::handler!` ([issue 567](https://github.com/teloxide/teloxide/issues/567)).
-- Built-in webhooks support via `teloxide::dispatching::update_listeners::webhooks` module.
-- `Dialogue::chat_id` for retrieving a chat ID from a dialogue.
+- The new API for dialogue handlers: `teloxide::handler!` ([issue 567](https://github.com/teloxide/teloxide/issues/567))
+- Built-in webhooks support via `teloxide::dispatching::update_listeners::webhooks` module
+- `Dialogue::chat_id` for retrieving a chat ID from a dialogue
 
 ### Changed
 
 - Updated `teloxide-core` from version `0.4.5` to version [`0.5.0`](https://github.com/teloxide/teloxide-core/releases/tag/v0.5.0) [**BC**]
-- Rename `dispatching2` => `dispatching` [**BC**].
-- Rename `prelude2` => `prelude` [**BC**].
-- Move `update_listeners`, `stop_token`, `IdleShutdownError`, and `ShutdownToken` from the old `dispatching` to the new `dispatching` (previously `dispatching2`).
-- Replace `crate::{commands_repl, commands_repl_with_listener, repl, repl_with_listener}` with those of the new `dispatching` [**BC**].
-- `UpdateListener::StopToken` is now always `Send` [**BC**].
-- Rename `BotCommand` trait to `BotCommands` [**BC**].
-- `BotCommands::descriptions` now returns `CommandDescriptions` instead of `String` [**BC**].
-- Mark `Dialogue::new` as `#[must_use]`.
+- Rename `dispatching2` => `dispatching` [**BC**]
+- Rename `prelude2` => `prelude` [**BC**]
+- Move `update_listeners`, `stop_token`, `IdleShutdownError`, and `ShutdownToken` from the old `dispatching` to the new `dispatching` (previously `dispatching2`)
+- Replace `crate::{commands_repl, commands_repl_with_listener, repl, repl_with_listener}` with those of the new `dispatching` [**BC**]
+- `UpdateListener::StopToken` is now always `Send` [**BC**]
+- Rename `BotCommand` trait to `BotCommands` [**BC**]
+- `BotCommands::descriptions` now returns `CommandDescriptions` instead of `String` [**BC**]
+- Mark `Dialogue::new` as `#[must_use]`
 
 ### Fixed
 
-- Concurrent update handling in the new dispatcher ([issue 536](https://github.com/teloxide/teloxide/issues/536)).
+- Concurrent update handling in the new dispatcher ([issue 536](https://github.com/teloxide/teloxide/issues/536))
 
 ### Deprecated
 
-- `HandlerFactory` and `HandlerExt::dispatch_by` in favour of `teloxide::handler!`.
+- `HandlerFactory` and `HandlerExt::dispatch_by` in favour of `teloxide::handler!`
 
 ## 0.7.3 - 2022-04-03
 
 ### Fixed
 
-- Update `teloxide-core` to version `0.4.5` to fix a security vulnerability. See more in `teloxide-core` [release notes](https://github.com/teloxide/teloxide-core/releases/tag/v0.4.5).
+- Update `teloxide-core` to version `0.4.5` to fix a security vulnerability. See more in `teloxide-core` [release notes](https://github.com/teloxide/teloxide-core/releases/tag/v0.4.5)
 
 ## 0.7.2 - 2022-03-23
 
 ### Added
 
-- The `Storage::erase` default function that returns `Arc<ErasedStorage>`.
-- `ErasedStorage`, a storage with an erased error type.
-- Allow the storage generic `S` be `?Sized` in `Dialogue` and `HandlerExt::enter_dialogue`.
+- The `Storage::erase` default function that returns `Arc<ErasedStorage>`
+- `ErasedStorage`, a storage with an erased error type
+- Allow the storage generic `S` be `?Sized` in `Dialogue` and `HandlerExt::enter_dialogue`
 
 ### Deprecated
 
@@ -367,8 +367,8 @@ This release was yanked because it accidentally [breaks backwards compatibility]
 
 ### Fixed
 
-- Log `UpdateKind::Error` in `teloxide::dispatching2::Dispatcher`.
-- Don't warn about unhandled updates in `repls2` ([issue 557](https://github.com/teloxide/teloxide/issues/557)).
+- Log `UpdateKind::Error` in `teloxide::dispatching2::Dispatcher`
+- Don't warn about unhandled updates in `repls2` ([issue 557](https://github.com/teloxide/teloxide/issues/557))
 - `parse_command` and `parse_command_with_prefix` now ignores case of the bot username
 
 ## 0.7.1 - 2022-03-09
@@ -381,7 +381,7 @@ This release was yanked because it accidentally [breaks backwards compatibility]
 
 ### Fixed
 
-- `Dispatcher` wasn't `Send`. Make `DispatcherBuilder::{default_handler, error_handler}` accept a handler that implements `Send + Sync` ([PR 517](https://github.com/teloxide/teloxide/pull/517)).
+- `Dispatcher` wasn't `Send`. Make `DispatcherBuilder::{default_handler, error_handler}` accept a handler that implements `Send + Sync` ([PR 517](https://github.com/teloxide/teloxide/pull/517))
 
 ## 0.6.1 - 2022-02-06
 
@@ -393,18 +393,18 @@ This release was yanked because it accidentally [breaks backwards compatibility]
 
 ### Added
 
-- `BotCommand::bot_commands` to obtain Telegram API commands ([issue 262](https://github.com/teloxide/teloxide/issues/262)).
-- The `dispatching2` and `prelude2` modules. They present a new dispatching model based on `dptree`.
+- `BotCommand::bot_commands` to obtain Telegram API commands ([issue 262](https://github.com/teloxide/teloxide/issues/262))
+- The `dispatching2` and `prelude2` modules. They present a new dispatching model based on `dptree`
 
 ### Changed
 
-- Require that `AsUpdateStream::Stream` is `Send`.
-- Restrict a user crate by `CARGO_CRATE_NAME` instead of `CARGO_PKG_NAME` in `enable_logging!` and `enable_logging_with_filter!`.
-- Updated `teloxide-core` to v0.4.0, see [its changelog](https://github.com/teloxide/teloxide-core/blob/master/CHANGELOG.md#040---2022-02-03).
+- Require that `AsUpdateStream::Stream` is `Send`
+- Restrict a user crate by `CARGO_CRATE_NAME` instead of `CARGO_PKG_NAME` in `enable_logging!` and `enable_logging_with_filter!`
+- Updated `teloxide-core` to v0.4.0, see [its changelog](https://github.com/teloxide/teloxide-core/blob/master/CHANGELOG.md#040---2022-02-03)
 
 ### Deprecated
 
- - The `dispatching` and `prelude` modules.
+ - The `dispatching` and `prelude` modules
 
 ### Fixed
 
@@ -421,7 +421,7 @@ This release was yanked because it accidentally [breaks backwards compatibility]
 
 ### Fixed
 
-- Depend on a correct `futures` version (v0.3.15).
+- Depend on a correct `futures` version (v0.3.15)
 
 ## 0.5.1 - 2021-08-05
 
@@ -433,56 +433,56 @@ This release was yanked because it accidentally [breaks backwards compatibility]
 
 ### Added
 
-- `Storage::get_dialogue` to obtain a dialogue indexed by a chat ID.
-- `InMemStorageError` with a single variant `DialogueNotFound` to be returned from `InMemStorage::remove_dialogue`.
-- `RedisStorageError::DialogueNotFound` and `SqliteStorageError::DialogueNotFound` to be returned from `Storage::remove_dialogue`.
+- `Storage::get_dialogue` to obtain a dialogue indexed by a chat ID
+- `InMemStorageError` with a single variant `DialogueNotFound` to be returned from `InMemStorage::remove_dialogue`
+- `RedisStorageError::DialogueNotFound` and `SqliteStorageError::DialogueNotFound` to be returned from `Storage::remove_dialogue`
 - A way to `shutdown` dispatcher
-  - `Dispatcher::shutdown_token` function.
-  - `ShutdownToken` with a `shutdown` function.
-- `Dispatcher::setup_ctrlc_handler` function ([issue 153](https://github.com/teloxide/teloxide/issues/153)).
+  - `Dispatcher::shutdown_token` function
+  - `ShutdownToken` with a `shutdown` function
+- `Dispatcher::setup_ctrlc_handler` function ([issue 153](https://github.com/teloxide/teloxide/issues/153))
 - `IdleShutdownError`
-- Automatic update filtering ([issue 389](https://github.com/teloxide/teloxide/issues/389)).
-- Added reply shortcut to every kind of messages ([PR 404](https://github.com/teloxide/teloxide/pull/404)).
+- Automatic update filtering ([issue 389](https://github.com/teloxide/teloxide/issues/389))
+- Added reply shortcut to every kind of messages ([PR 404](https://github.com/teloxide/teloxide/pull/404))
 
 ### Changed
 
-- Do not return a dialogue from `Storage::{remove_dialogue, update_dialogue}`.
-- Return an error from `Storage::remove_dialogue` if a dialogue does not exist.
-- Require `D: Clone` in `dialogues_repl(_with_listener)` and `InMemStorage`.
-- Automatically delete a webhook if it was set up in `update_listeners::polling_default` (thereby making it `async`, [issue 319](https://github.com/teloxide/teloxide/issues/319)).
+- Do not return a dialogue from `Storage::{remove_dialogue, update_dialogue}`
+- Return an error from `Storage::remove_dialogue` if a dialogue does not exist
+- Require `D: Clone` in `dialogues_repl(_with_listener)` and `InMemStorage`
+- Automatically delete a webhook if it was set up in `update_listeners::polling_default` (thereby making it `async`, [issue 319](https://github.com/teloxide/teloxide/issues/319))
 - `polling` and `polling_default` now require `R: 'static`
 - Refactor `UpdateListener` trait:
-  - Add a `StopToken` associated type.
+  - Add a `StopToken` associated type
     - It must implement a new `StopToken` trait which has the only function `fn stop(self);`
-  - Add a `stop_token` function that returns `Self::StopToken` and allows stopping the listener later ([issue 166](https://github.com/teloxide/teloxide/issues/166)).
-  - Remove blanked implementation.
-  - Remove `Stream` from super traits.
-  - Add `AsUpdateStream` to super traits.
-    - Add an `AsUpdateStream` trait that allows turning implementors into streams of updates (GAT workaround).
-  - Add a `timeout_hint` function (with a default implementation).
-- `Dispatcher::dispatch` and `Dispatcher::dispatch_with_listener` now require mutable reference to self.
-- Repls can now be stopped by `^C` signal.
-- `Noop` and `AsyncStopToken`stop tokens.
-- `StatefulListener`.
-- Emit not only errors but also warnings and general information from teloxide, when set up by `enable_logging!`.
-- Use `i64` instead of `i32` for `user_id` in `html::user_mention` and `markdown::user_mention`.
+  - Add a `stop_token` function that returns `Self::StopToken` and allows stopping the listener later ([issue 166](https://github.com/teloxide/teloxide/issues/166))
+  - Remove blanked implementation
+  - Remove `Stream` from super traits
+  - Add `AsUpdateStream` to super traits
+    - Add an `AsUpdateStream` trait that allows turning implementors into streams of updates (GAT workaround)
+  - Add a `timeout_hint` function (with a default implementation)
+- `Dispatcher::dispatch` and `Dispatcher::dispatch_with_listener` now require mutable reference to self
+- Repls can now be stopped by `^C` signal
+- `Noop` and `AsyncStopToken`stop tokens
+- `StatefulListener`
+- Emit not only errors but also warnings and general information from teloxide, when set up by `enable_logging!`
+- Use `i64` instead of `i32` for `user_id` in `html::user_mention` and `markdown::user_mention`
 - Updated to `teloxide-core` `v0.3.0` (see it's [changelog](https://github.com/teloxide/teloxide-core/blob/master/CHANGELOG.md#030---2021-07-05) for more)
 
 ### Fixed
 
-- Remove the `reqwest` dependency. It's not needed after the [teloxide-core] integration.
-- A storage persistence bug ([issue 304](https://github.com/teloxide/teloxide/issues/304)).
-- Log errors from `Storage::{remove_dialogue, update_dialogue}` in `DialogueDispatcher` ([issue 302](https://github.com/teloxide/teloxide/issues/302)).
-- Mark all the functions of `Storage` as `#[must_use]`.
+- Remove the `reqwest` dependency. It's not needed after the [teloxide-core] integration
+- A storage persistence bug ([issue 304](https://github.com/teloxide/teloxide/issues/304))
+- Log errors from `Storage::{remove_dialogue, update_dialogue}` in `DialogueDispatcher` ([issue 302](https://github.com/teloxide/teloxide/issues/302))
+- Mark all the functions of `Storage` as `#[must_use]`
 
 ## 0.4.0 - 2021-03-22
 
 ### Added
 
-- Integrate [teloxide-core].
-- Allow arbitrary error types to be returned from (sub)transitions ([issue 242](https://github.com/teloxide/teloxide/issues/242)).
-- The `respond` function, a shortcut for `ResponseResult::Ok(())`.
-- The `sqlite-storage` feature -- enables SQLite support.
+- Integrate [teloxide-core]
+- Allow arbitrary error types to be returned from (sub)transitions ([issue 242](https://github.com/teloxide/teloxide/issues/242))
+- The `respond` function, a shortcut for `ResponseResult::Ok(())`
+- The `sqlite-storage` feature -- enables SQLite support
 - `Dispatcher::{my_chat_members_handler, chat_members_handler}`
 
 [teloxide-core]: https://github.com/teloxide/teloxide-core
@@ -493,13 +493,13 @@ This release was yanked because it accidentally [breaks backwards compatibility]
 
 ### Fixed
 
-- Hide `SubtransitionOutputType` from the docs.
+- Hide `SubtransitionOutputType` from the docs
 
 ### Changed
 
-- Export `teloxide_macros::teloxide` in `prelude`.
+- Export `teloxide_macros::teloxide` in `prelude`
 - `dispatching::dialogue::serializer::{JSON -> Json, CBOR -> Cbor}`
-- Allow `bot_name` be `N`, where `N: Into<String> + ...` in `commands_repl` & `commands_repl_with_listener`.
+- Allow `bot_name` be `N`, where `N: Into<String> + ...` in `commands_repl` & `commands_repl_with_listener`
 - 'Edit methods' (namely `edit_message_live_location`, `stop_message_live_location`, `edit_message_text`,
    `edit_message_caption`, `edit_message_media` and `edit_message_reply_markup`) are split into common and inline
    versions (e.g.: `edit_message_text` and `edit_inline_message_text`). Instead of `ChatOrInlineMessage` common versions
@@ -509,7 +509,7 @@ This release was yanked because it accidentally [breaks backwards compatibility]
    `#[non_exhaustive]` annotation is removed from the enum, type of `TargetMessage::Inline::inline_message_id` changed
    `i32` => `String`. `TargetMessage` now implements `From<String>`, `get_game_high_scores` and `set_game_score` use
    `Into<TargetMessage>` to accept `String`s. ([issue 253], [pr 257])
-- Remove `ResponseResult` from `prelude`.
+- Remove `ResponseResult` from `prelude`
 
 [issue 253]: https://github.com/teloxide/teloxide/issues/253
 [pr 257]: https://github.com/teloxide/teloxide/pull/257
@@ -518,7 +518,7 @@ This release was yanked because it accidentally [breaks backwards compatibility]
 
 ### Fixed
 
-- Failing compilation with `serde::export` ([issue 328](https://github.com/teloxide/teloxide/issues/328)).
+- Failing compilation with `serde::export` ([issue 328](https://github.com/teloxide/teloxide/issues/328))
 
 ## 0.3.3 - 2020-10-30
 
@@ -536,31 +536,31 @@ This release was yanked because it accidentally [breaks backwards compatibility]
 
 ### Added
 
-- `Bot::builder` method ([PR 269](https://github.com/teloxide/teloxide/pull/269)).
+- `Bot::builder` method ([PR 269](https://github.com/teloxide/teloxide/pull/269))
 
 ## 0.3.0 - 2020-07-31
 
 ### Added
 
-- Support for typed bot commands ([issue 152](https://github.com/teloxide/teloxide/issues/152)).
-- `BotBuilder`, which allows setting a default `ParseMode`.
-- The `Transition`, `Subtransition`, `SubtransitionOutputType` traits.
-- A nicer approach to manage dialogues via `#[derive(Transition)]` + `#[teloxide(subtransition)]` (see [`examples/dialogue_bot`](https://github.com/teloxide/teloxide/tree/af2aa218e7bfc442ab4475023a1c661834f576fc/examples/dialogue_bot)).
-- The `redis-storage` feature -- enables the Redis support.
-- The `cbor-serializer` feature -- enables the `CBOR` serializer for dialogues.
-- The `bincode-serializer` feature -- enables the `Bincode` serializer for dialogues.
-- The `frunk` feature -- enables `teloxide::utils::UpState`, which allows mapping from a structure of `field1, ..., fieldN` to a structure of `field1, ..., fieldN, fieldN+1`.
-- Upgrade to v4.9 Telegram bots API.
-- `teloxide::utils::client_from_env` -- constructs a client from the `TELOXIDE_TOKEN` environmental variable.
-- Import `Transition`, `TransitionIn`, `TransitionOut`, `UpState` to `teloxide::prelude`.
-- Import `repl`, `commands_repl` to `teloxide`.
-- Let users inspect an unknown API error using `ApiErrorKind::Unknown(String)`. All the known API errors are placed into `KnownApiErrorKind`.
-- Setters to all the API types.
-- `teloxide::dispatching::dialogue::serializer` -- various serializers for memory storages. The `Serializer` trait, `Bincode`, `CBOR`, `JSON`.
+- Support for typed bot commands ([issue 152](https://github.com/teloxide/teloxide/issues/152))
+- `BotBuilder`, which allows setting a default `ParseMode`
+- The `Transition`, `Subtransition`, `SubtransitionOutputType` traits
+- A nicer approach to manage dialogues via `#[derive(Transition)]` + `#[teloxide(subtransition)]` (see [`examples/dialogue_bot`](https://github.com/teloxide/teloxide/tree/af2aa218e7bfc442ab4475023a1c661834f576fc/examples/dialogue_bot))
+- The `redis-storage` feature -- enables the Redis support
+- The `cbor-serializer` feature -- enables the `CBOR` serializer for dialogues
+- The `bincode-serializer` feature -- enables the `Bincode` serializer for dialogues
+- The `frunk` feature -- enables `teloxide::utils::UpState`, which allows mapping from a structure of `field1, ..., fieldN` to a structure of `field1, ..., fieldN, fieldN+1`
+- Upgrade to v4.9 Telegram bots API
+- `teloxide::utils::client_from_env` -- constructs a client from the `TELOXIDE_TOKEN` environmental variable
+- Import `Transition`, `TransitionIn`, `TransitionOut`, `UpState` to `teloxide::prelude`
+- Import `repl`, `commands_repl` to `teloxide`
+- Let users inspect an unknown API error using `ApiErrorKind::Unknown(String)`. All the known API errors are placed into `KnownApiErrorKind`
+- Setters to all the API types
+- `teloxide::dispatching::dialogue::serializer` -- various serializers for memory storages. The `Serializer` trait, `Bincode`, `CBOR`, `JSON`
 - `teloxide::{repl, repl_with_listener, commands_repl, commands_repl_with_listener, dialogues_repl, dialogues_repl_with_listener}`
 - `InputFile::Memory`
-- Option to hide a command from description ([issue 217](https://github.com/teloxide/teloxide/issues/217)).
-- Respect the `TELOXIDE_PROXY` environment variable in `Bot::from_env`.
+- Option to hide a command from description ([issue 217](https://github.com/teloxide/teloxide/issues/217))
+- Respect the `TELOXIDE_PROXY` environment variable in `Bot::from_env`
 
 ### Deprecated
 
@@ -568,39 +568,39 @@ This release was yanked because it accidentally [breaks backwards compatibility]
 
 ### Changed
 
-- `DialogueDispatcherHandlerCx` -> `DialogueWithCx`.
-- `DispatcherHandlerCx` -> `UpdateWithCx`.
-- Now provided description of unknown telegram error, by splitting ApiErrorKind at `ApiErrorKind` and `ApiErrorKindKnown` enums ([issue 199](https://github.com/teloxide/teloxide/issues/199)).
-- Extract `Bot` from `Arc` ([issue 216](https://github.com/teloxide/teloxide/issues/230)).
-- Mark all the API types as `#[non_exhaustive]`.
-- Replace all `mime_type: String` with `MimeWrapper`.
+- `DialogueDispatcherHandlerCx` -> `DialogueWithCx`
+- `DispatcherHandlerCx` -> `UpdateWithCx`
+- Now provided description of unknown telegram error, by splitting ApiErrorKind at `ApiErrorKind` and `ApiErrorKindKnown` enums ([issue 199](https://github.com/teloxide/teloxide/issues/199))
+- Extract `Bot` from `Arc` ([issue 216](https://github.com/teloxide/teloxide/issues/230))
+- Mark all the API types as `#[non_exhaustive]`
+- Replace all `mime_type: String` with `MimeWrapper`
 
 ### Fixed
 
-- Now methods which can send file to Telegram return `tokio::io::Result<T>`. Before that it could panic ([issue 216](https://github.com/teloxide/teloxide/issues/216)).
-- If a bot wasn't triggered for several days, it stops responding ([issue 223](https://github.com/teloxide/teloxide/issues/223)).
+- Now methods which can send file to Telegram return `tokio::io::Result<T>`. Before that it could panic ([issue 216](https://github.com/teloxide/teloxide/issues/216))
+- If a bot wasn't triggered for several days, it stops responding ([issue 223](https://github.com/teloxide/teloxide/issues/223))
 
 ## 0.2.0 - 2020-02-25
 
 ### Added
 
-- The functionality to parse commands only with a correct bot's name (breaks backwards compatibility) ([Issue 168](https://github.com/teloxide/teloxide/issues/168)).
-- This `CHANGELOG.md`.
+- The functionality to parse commands only with a correct bot's name (breaks backwards compatibility) ([Issue 168](https://github.com/teloxide/teloxide/issues/168))
+- This `CHANGELOG.md`
 
 ### Fixed
 
-- Fix parsing a pinned message ([Issue 167](https://github.com/teloxide/teloxide/issues/167)).
-- Replace `LanguageCode` with `String`, because [the official Telegram documentation](https://core.telegram.org/bots/api#getchat) doesn't specify a concrete version of IETF language tag.
-- Problems with the `poll_type` field ([Issue 178](https://github.com/teloxide/teloxide/issues/178)).
-- Make `polling_default` actually a long polling update listener ([PR 182](https://github.com/teloxide/teloxide/pull/182)).
+- Fix parsing a pinned message ([Issue 167](https://github.com/teloxide/teloxide/issues/167))
+- Replace `LanguageCode` with `String`, because [the official Telegram documentation](https://core.telegram.org/bots/api#getchat) doesn't specify a concrete version of IETF language tag
+- Problems with the `poll_type` field ([Issue 178](https://github.com/teloxide/teloxide/issues/178))
+- Make `polling_default` actually a long polling update listener ([PR 182](https://github.com/teloxide/teloxide/pull/182))
 
 ### Removed
 
-- [either](https://crates.io/crates/either) from the dependencies in `Cargo.toml`.
-- `teloxide-macros` migrated into [the separate repository](https://github.com/teloxide/teloxide-macros) to easier releases and testing.
+- [either](https://crates.io/crates/either) from the dependencies in `Cargo.toml`
+- `teloxide-macros` migrated into [the separate repository](https://github.com/teloxide/teloxide-macros) to easier releases and testing
 
 ## 0.1.0 - 2020-02-19
 
 ### Added
 
-- This project.
+- This project

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## unreleased
 
+### Changed
+
+- Implement `Clone` for `teloxide::RequestError`
+  - `RequestError::Network` now accepts `Arc<reqwest::Error>` [**BC**]
+  - `RequestError::InvalidJson` now accepts `source: Arc<serde_json::Error>` [**BC**]
+  - `RequestError::Io` now accepts `Arc<io::Error>` [**BC**]
+
 ## 0.14.1 - 2025-03-30
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `RequestError::Network` now accepts `Arc<reqwest::Error>` [**BC**]
   - `RequestError::InvalidJson` now accepts `source: Arc<serde_json::Error>` [**BC**]
   - `RequestError::Io` now accepts `Arc<io::Error>` [**BC**]
+- Implement `Clone` for `teloxide::DownloadError`
+  - `DownloadError::Network` now accepts `Arc<reqwest::Error>` [**BC**]
+  - `DownloadError::Io` now accepts `Arc<std::io::Error>` [**BC**]
 
 ## 0.14.1 - 2025-03-30
 

--- a/crates/teloxide-core/src/errors.rs
+++ b/crates/teloxide-core/src/errors.rs
@@ -48,16 +48,16 @@ pub enum RequestError {
 }
 
 /// An error caused by downloading a file.
-#[derive(Debug, Error)]
+#[derive(Debug, Error, Clone)]
 pub enum DownloadError {
     /// A network error while downloading a file from Telegram.
     #[error("A network error: {0}")]
     // NOTE: this variant must not be created by anything except the explicit From impl
-    Network(#[source] reqwest::Error),
+    Network(#[source] Arc<reqwest::Error>),
 
     /// An I/O error while writing a file to destination.
     #[error("An I/O error: {0}")]
-    Io(#[from] std::io::Error),
+    Io(#[from] Arc<std::io::Error>),
 }
 
 pub trait AsResponseParameters {
@@ -750,15 +750,15 @@ impl_api_error! {
 impl From<DownloadError> for RequestError {
     fn from(download_err: DownloadError) -> Self {
         match download_err {
-            DownloadError::Network(err) => RequestError::Network(Arc::new(err)),
-            DownloadError::Io(err) => RequestError::Io(Arc::new(err)),
+            DownloadError::Network(err) => RequestError::Network(err),
+            DownloadError::Io(err) => RequestError::Io(err),
         }
     }
 }
 
 impl From<reqwest::Error> for DownloadError {
     fn from(error: reqwest::Error) -> Self {
-        DownloadError::Network(hide_token(error))
+        DownloadError::Network(Arc::new(hide_token(error)))
     }
 }
 

--- a/crates/teloxide-core/src/net/download.rs
+++ b/crates/teloxide-core/src/net/download.rs
@@ -1,4 +1,4 @@
-use std::future::Future;
+use std::{future::Future, sync::Arc};
 
 use bytes::Bytes;
 use futures::{
@@ -100,7 +100,7 @@ where
         let mut res = r?.error_for_status()?;
 
         while let Some(chunk) = res.chunk().await? {
-            dst.write_all(&chunk).await?;
+            dst.write_all(&chunk).await.map_err(Arc::new)?;
         }
 
         Ok(())

--- a/crates/teloxide-core/src/net/request.rs
+++ b/crates/teloxide-core/src/net/request.rs
@@ -1,4 +1,4 @@
-use std::{any::TypeId, time::Duration};
+use std::{any::TypeId, sync::Arc, time::Duration};
 
 use reqwest::{
     header::{HeaderValue, CONTENT_TYPE},
@@ -156,7 +156,7 @@ where
 
             response
         })
-        .map_err(|source| RequestError::InvalidJson { source, raw: text.into() })?
+        .map_err(|source| RequestError::InvalidJson { source: Arc::new(source), raw: text.into() })?
         .into()
 }
 

--- a/crates/teloxide-core/src/serde_multipart/error.rs
+++ b/crates/teloxide-core/src/serde_multipart/error.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use std::{fmt, sync::Arc};
 
 use serde::ser;
 
@@ -39,7 +39,7 @@ impl std::error::Error for Error {}
 impl From<Error> for RequestError {
     fn from(err: Error) -> Self {
         match err {
-            Error::Io(ioerr) => RequestError::Io(ioerr),
+            Error::Io(ioerr) => RequestError::Io(Arc::new(ioerr)),
 
             // This should be ok since we (hopefuly) don't write request those may trigger errors
             // and `Error` is internal.


### PR DESCRIPTION
This will 1) make [the middlewares example] work and 2) make it generally easier to deal with these errors in user code.

[the middlewares example]: https://github.com/teloxide/teloxide/pull/1310
