### PR TITLE
Removed thread creation in favor of stacker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## unreleased
 
+### Fixed
+
+- Stack overflow issues using `stacker` crate
+- Thread being locked because of thread spawining in dispatcher
+
+### Removed
+
+- `stack_size` setter to `DispatcherBuilder` [**BC**]
+
 ### Added
 
 - Add two examples to demonstrate how to execute functions _before_ and _after_ some endpoint:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1632,6 +1632,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "psm"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f58e5423e24c18cc840e1c98370b3993c6649cd1678b4d24318bcf0a083cbe88"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2332,6 +2341,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
+name = "stacker"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601f9201feb9b09c00266478bf459952b9ef9a6b94edb2f21eba14ab681a60a9"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "stringprep"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2481,6 +2503,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "stacker",
  "take_mut",
  "takecell",
  "thiserror",

--- a/crates/teloxide-core/Cargo.toml
+++ b/crates/teloxide-core/Cargo.toml
@@ -66,6 +66,8 @@ serde_json = "1.0.55"
 serde_with = "3.12.0"
 uuid = { version = "1.1.0", features = ["v4"] }        # for attaching input files
 
+stacker = "0.1"
+
 derive_more = { version = "1.0.0", features = ["display", "from", "deref"] }
 mime = "0.3.16"
 thiserror = "2.0.11"

--- a/crates/teloxide-core/src/bot.rs
+++ b/crates/teloxide-core/src/bot.rs
@@ -236,7 +236,7 @@ impl Bot {
         let api_url = Arc::clone(&self.api_url);
 
         let timeout_hint = payload.timeout_hint();
-        let params = serde_json::to_vec(payload)
+        let params = stacker::maybe_grow(256 * 1024, 1024 * 1024, || serde_json::to_vec(payload))
             // this `expect` should be ok since we don't write request those may trigger error here
             .expect("serialization of request to be infallible");
 

--- a/crates/teloxide-core/src/types/update.rs
+++ b/crates/teloxide-core/src/types/update.rs
@@ -449,7 +449,7 @@ impl<'de> Deserialize<'de> for UpdateKind {
             }
         }
 
-        deserializer.deserialize_any(Visitor)
+        stacker::maybe_grow(256 * 1024, 1024 * 1024, || deserializer.deserialize_any(Visitor))
     }
 }
 


### PR DESCRIPTION
Fixes #1236 #1319

### Testing of functionality:

https://github.com/teloxide/teloxide/issues/1154#issuecomment-2603154272 now works correctly


This code: 

```rust

use std::time;

use teloxide::{
    dispatching::{UpdateFilterExt, UpdateHandler},
    prelude::*,
};

type HandlerResult = Result<(), Box<dyn std::error::Error + Send + Sync>>;

async fn hello_world(bot: Bot, message: Message, update: Update) -> HandlerResult {
    bot.send_message(message.chat.id, "Hello World!").await?;
    Ok(())
}

fn handler_tree() -> UpdateHandler<Box<dyn std::error::Error + Send + Sync + 'static>> {
    dptree::entry().branch(Update::filter_message().endpoint(hello_world))
}

fn run() {
    tokio::runtime::Builder::new_multi_thread()
        .enable_all()
        .build()
        .unwrap()
        .block_on(async {
            dotenv::dotenv().ok();

            let bot = Bot::from_env();

            Dispatcher::builder(bot, handler_tree())
                .enable_ctrlc_handler()
                .build()
                .dispatch()
                .await;
        });
}

fn main() {
    let child = std::thread::Builder::new()
        .stack_size(400 * 1024)
        // For some reason tokios thread_stack_size is just wrong sometimes,
        // so i need to spawn it using std::thread and then block on it
        .spawn(run)
        .unwrap();
    child.join().unwrap();
}
```

Now works, in spite of having just 400 KiB of stack (much less than 1MiB of windows stack)


### Performance:

Serializing/deserializing speed of `Update` is unaffected, if anything it sped up by ~10%

The test: 
```rust
let start = time::SystemTime::now();
for _ in 0..10000 {
    let str_update = serde_json::to_string(&update).unwrap();
    serde_json::from_str::<Update>(&str_update).unwrap();
}
dbg!(start.elapsed().unwrap());

```

`teloxide` 0.13.0: 472ms, 481ms, 526ms, 484ms
`teloxide` this pr: 411ms, 463ms, 454ms, 455ms

### Breaking changes:

- `stack_size()` is gone from the `DispatcherBuilder` due to it requiring a bad design choice that breaks tokio


### Drawbacks:

The problem has a chance of coming back, as not all serialization and deserialization is wrapped, unlike the previous method

But the fact that it breaks so much is enough of a reason to risk it