### PR TITLE
Fix markdown escape specification link

### DIFF
--- a/crates/teloxide/src/utils/markdown.rs
+++ b/crates/teloxide/src/utils/markdown.rs
@@ -129,7 +129,7 @@ pub fn code_inline(s: &str) -> String {
 /// Escapes the string to be shown "as is" within the Telegram [Markdown
 /// v2][spec] message style.
 ///
-/// [spec]: https://core.telegram.org/bots/api#html-style
+/// [spec]: https://core.telegram.org/bots/api#markdownv2-style
 #[must_use = "This function returns a new string, rather than mutating the argument, so calling it \
               without using its output does nothing useful"]
 pub fn escape(s: &str) -> String {


### PR DESCRIPTION
The specification link in `teloxide::utils::markdown::escape` pointed to the HTML section, but this one is for markdown. This patches the link to point to the markdown section instead.