### PR TITLE
Release teloxide-macros 0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2579,7 +2579,7 @@ dependencies = [
 
 [[package]]
 name = "teloxide-macros"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/crates/teloxide-macros/CHANGELOG.md
+++ b/crates/teloxide-macros/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## unreleased
 
+## 0.10.0 - 2025-06-19
+
 ### Changed
 
 - MSRV (Minimal Supported Rust Version) was bumped from `1.80` to `1.82` ([#1358](https://github.com/teloxide/teloxide/pull/1358))

--- a/crates/teloxide-macros/Cargo.toml
+++ b/crates/teloxide-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "teloxide-macros"
-version = "0.9.0"
+version = "0.10.0"
 description = "The teloxide's procedural macros"
 
 rust-version.workspace = true


### PR DESCRIPTION
r? @hirrolot 

Separate from main crate bump, so it's possible to reference new versions from crates.io