### PR TITLE
Release teloxide 0.16.0 and teloxide-macros 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## unreleased
 
+## 0.16.0 - 2025-06-19
+
 ### Added
 
 - `dptree` type checking and dead code checking [**BC**].

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2504,7 +2504,7 @@ checksum = "20f34339676cdcab560c9a82300c4c2581f68b9369aedf0fae86f2ff9565ff3e"
 
 [[package]]
 name = "teloxide"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "aquamarine",
  "axum",
@@ -2526,8 +2526,8 @@ dependencies = [
  "serde_cbor",
  "serde_json",
  "sqlx",
- "teloxide-core",
- "teloxide-macros",
+ "teloxide-core 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "teloxide-macros 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -2578,8 +2578,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "teloxide-core"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd7c27c35350ddf2965403b7ffe122ae8b8090c6882f520e31717e81cc839296"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "chrono",
+ "derive_more",
+ "either",
+ "futures",
+ "log",
+ "mime",
+ "once_cell",
+ "pin-project",
+ "rc-box",
+ "reqwest",
+ "rgb",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "stacker",
+ "take_mut",
+ "takecell",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "url",
+ "uuid",
+ "vecrem",
+]
+
+[[package]]
 name = "teloxide-macros"
-version = "0.9.0"
+version = "0.10.0"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "teloxide-macros"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300fadcaf0c182f19b5ca10bf23a45dc9a48925f00c704405fd90ee2c03942f9"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -33,6 +33,17 @@ Also `refund_star_payment`, `SuccessfulPayment` and `StarTransaction` switched f
 +bot.refund_star_payment(user_id, "txn".into()).await?;
 ```
 
+dptree's handler signature has changed:
+
+```diff
+type UpdHandler = Handler<
+    'static,
+-    DependencyMap,
+    core::result::Result<(), Box<dyn std::error::Error + Send + Sync + 'static>>,
+    teloxide::dispatching::DpHandlerDescription,
+>;
+```
+
 ## 0.14.1 -> 0.15.0
 
 ### teloxide

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ $ rustup override set nightly
  5. Run `cargo new my_bot`, enter the directory and put these lines into your `Cargo.toml`:
 ```toml
 [dependencies]
-teloxide = { version = "0.15.0", features = ["macros"] }
+teloxide = { version = "0.16.0", features = ["macros"] }
 log = "0.4"
 pretty_env_logger = "0.5"
 tokio = { version =  "1.8", features = ["rt-multi-thread", "macros"] }

--- a/crates/teloxide-macros/CHANGELOG.md
+++ b/crates/teloxide-macros/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## unreleased
 
+## 0.10.0 - 2025-06-19
+
 ### Changed
 
 - MSRV (Minimal Supported Rust Version) was bumped from `1.80` to `1.82` ([#1358](https://github.com/teloxide/teloxide/pull/1358))

--- a/crates/teloxide-macros/Cargo.toml
+++ b/crates/teloxide-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "teloxide-macros"
-version = "0.9.0"
+version = "0.10.0"
 description = "The teloxide's procedural macros"
 
 rust-version.workspace = true

--- a/crates/teloxide/Cargo.toml
+++ b/crates/teloxide/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "teloxide"
-version = "0.15.0"
+version = "0.16.0"
 description = "An elegant Telegram bots framework for Rust"
 
 rust-version.workspace = true
@@ -85,8 +85,8 @@ full = [
 
 [dependencies]
 # replace me by the actual version when release, and return path when it's time to make 0-day fixes
-teloxide-core = { path = "../teloxide-core", default-features = false }
-teloxide-macros = { path = "../teloxide-macros", optional = true }
+teloxide-core = { version = "0.12", default-features = false }
+teloxide-macros = { version = "0.10", optional = true }
 
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
r? @hirrolot 

teloxide-core has already slipped into master, I'll write a release checklist soon so it doesn't happen again