### PR TITLE
Set proper name for CantInitiateConversation bot error

### DIFF
--- a/crates/teloxide-core/src/errors.rs
+++ b/crates/teloxide-core/src/errors.rs
@@ -668,7 +668,7 @@ impl_api_error! {
         /// 1. [`SendMessage`]
         ///
         /// [`SendMessage`]: crate::payloads::SendMessage
-        CantInitiateConversation = "Unauthorized: bot can't initiate conversation with a user",
+        CantInitiateConversation = "Forbidden: bot can't initiate conversation with a user",
 
         /// Occurs when you tries to send message to bot.
         ///


### PR DESCRIPTION
Telegram bot api uses Forbidden word instead of Unauthorized for CantInitiateConversation error, my code now throw Unknown because of this