### PR TITLE
fix: actually enable rustls flavour for PostgresStorage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## unreleased
 
+### Fixed
+
+- make sure `postgres-storage-rustls` feature actually enables rustls-based postgres storage ([#1400](https://github.com/teloxide/teloxide/pull/1400))
+
 ## 0.17.0 - 2025-07-11
 
 ### Added

--- a/crates/teloxide/src/dispatching/dialogue.rs
+++ b/crates/teloxide/src/dispatching/dialogue.rs
@@ -99,7 +99,7 @@ pub use self::{RedisStorage, RedisStorageError};
 #[cfg(any(feature = "sqlite-storage-nativetls", feature = "sqlite-storage-rustls"))]
 pub use self::{SqliteStorage, SqliteStorageError};
 
-#[cfg(feature = "postgres-storage-nativetls")]
+#[cfg(any(feature = "postgres-storage-nativetls", feature = "postgres-storage-rustls"))]
 pub use self::{PostgresStorage, PostgresStorageError};
 
 pub use get_chat_id::GetChatId;

--- a/crates/teloxide/src/dispatching/dialogue/storage.rs
+++ b/crates/teloxide/src/dispatching/dialogue/storage.rs
@@ -9,7 +9,7 @@ mod redis_storage;
 #[cfg(any(feature = "sqlite-storage-nativetls", feature = "sqlite-storage-rustls"))]
 mod sqlite_storage;
 
-#[cfg(feature = "postgres-storage-nativetls")]
+#[cfg(any(feature = "postgres-storage-nativetls", feature = "postgres-storage-rustls"))]
 mod postgres_storage;
 
 use futures::future::BoxFuture;
@@ -28,7 +28,7 @@ use std::sync::Arc;
 #[cfg(any(feature = "sqlite-storage-nativetls", feature = "sqlite-storage-rustls"))]
 pub use sqlite_storage::{SqliteStorage, SqliteStorageError};
 
-#[cfg(feature = "postgres-storage-nativetls")]
+#[cfg(any(feature = "postgres-storage-nativetls", feature = "postgres-storage-rustls"))]
 pub use postgres_storage::{PostgresStorage, PostgresStorageError};
 
 /// A storage with an erased error type.


### PR DESCRIPTION
Right now there is a feature `postgres-storage-rustls`, but it doesn't actually enable anything. Judging by the commit where it was added (https://github.com/teloxide/teloxide/commit/25fb0eed111bed93d1195c82c4404bf55e47431d), this looks like a simple oversight, so here's the simple fix :)

Not sure if this really requires a separate changelog line, but in case it does – here is the separate commit for that: 871300b354cc31a2508ca42bcbbf36d118b83506