### PR TITLE
Add ParticipantIdInvalid and ChatAdminRequired to ApiError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `ParticipantIdInvalid` and `ChatAdminRequired` variants to `ApiError` ([#1349](https://github.com/teloxide/teloxide/issues/1349))
 - Support for TBA 9.2 ([#1403](https://github.com/teloxide/teloxide/pull/1403))
   - Add `filter_suggested_post_approved`, `filter_suggested_post_approval_failed`, `filter_suggested_post_declined`, `filter_suggested_post_paid`, `filter_suggested_post_refunded` filters to the `MessageFilterExt` trait
   - `ChatFullInfoPublicKind::Supergroup` is now of type `Box<ChatFullInfoPublicSupergroup>` instead of `ChatFullInfoPublicSupergroup` [**BC**]

--- a/crates/teloxide-core/src/errors.rs
+++ b/crates/teloxide-core/src/errors.rs
@@ -572,6 +572,24 @@ impl_api_error! {
         /// Messages" admin right.
         NotEnoughRightsToPostMessages = "Bad Request: need administrator rights in the channel chat",
 
+        /// Occurs when bot tries to get a chat member with an invalid
+        /// participant ID.
+        ///
+        /// May happen in methods:
+        /// 1. [`GetChatMember`]
+        ///
+        /// [`GetChatMember`]: crate::payloads::GetChatMember
+        ParticipantIdInvalid = "Bad Request: PARTICIPANT_ID_INVALID",
+
+        /// Occurs when bot tries to perform an action that requires admin
+        /// privileges in the chat.
+        ///
+        /// May happen in methods:
+        /// 1. [`GetChatMember`]
+        ///
+        /// [`GetChatMember`]: crate::payloads::GetChatMember
+        ChatAdminRequired = "Bad Request: CHAT_ADMIN_REQUIRED",
+
         /// Occurs when bot tries set webhook to protocol other than HTTPS.
         ///
         /// May happen in methods:
@@ -984,6 +1002,14 @@ mod tests {
             (
                 "{\"data\": \"Bad Request: need administrator rights in the channel chat\"}",
                 ApiError::NotEnoughRightsToPostMessages,
+            ),
+            (
+                "{\"data\": \"Bad Request: PARTICIPANT_ID_INVALID\"}",
+                ApiError::ParticipantIdInvalid,
+            ),
+            (
+                "{\"data\": \"Bad Request: CHAT_ADMIN_REQUIRED\"}",
+                ApiError::ChatAdminRequired,
             ),
             (
                 "{\"data\": \"Bad Request: bad webhook: HTTPS url must be provided for webhook\"}",

--- a/crates/teloxide-core/src/errors.rs
+++ b/crates/teloxide-core/src/errors.rs
@@ -1003,14 +1003,8 @@ mod tests {
                 "{\"data\": \"Bad Request: need administrator rights in the channel chat\"}",
                 ApiError::NotEnoughRightsToPostMessages,
             ),
-            (
-                "{\"data\": \"Bad Request: PARTICIPANT_ID_INVALID\"}",
-                ApiError::ParticipantIdInvalid,
-            ),
-            (
-                "{\"data\": \"Bad Request: CHAT_ADMIN_REQUIRED\"}",
-                ApiError::ChatAdminRequired,
-            ),
+            ("{\"data\": \"Bad Request: PARTICIPANT_ID_INVALID\"}", ApiError::ParticipantIdInvalid),
+            ("{\"data\": \"Bad Request: CHAT_ADMIN_REQUIRED\"}", ApiError::ChatAdminRequired),
             (
                 "{\"data\": \"Bad Request: bad webhook: HTTPS url must be provided for webhook\"}",
                 ApiError::WebhookRequireHttps,


### PR DESCRIPTION
Fixes #1349

Adds two missing error variants to `ApiError` that currently fall through to `Unknown`:

- `ParticipantIdInvalid` — returned when querying a chat member with an invalid participant ID
- `ChatAdminRequired` — returned when the bot lacks admin privileges for the requested action

Both occur when calling `GetChatMember` on supergroups with hidden users without admin rights.