### PR TITLE
Add ApiError::ParticipantIdInvalid and ApiError::ChatAdminRequired (closes #1349)

### DIFF
--- a/crates/teloxide-core/CHANGELOG.md
+++ b/crates/teloxide-core/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Support for TBA 9.2 ([#1403](https://github.com/teloxide/teloxide/pull/1403))
   - `ChatFullInfoPublicKind::Supergroup` is now of type `Box<ChatFullInfoPublicSupergroup>` instead of `ChatFullInfoPublicSupergroup` [**BC**]
+- `ApiError::ParticipantIdInvalid` and `ApiError::ChatAdminRequired` variants (previously surfaced as `ApiError::Unknown`) ([#1349](https://github.com/teloxide/teloxide/issues/1349))
 
 ### Fixed 
 

--- a/crates/teloxide-core/src/errors.rs
+++ b/crates/teloxide-core/src/errors.rs
@@ -394,6 +394,27 @@ impl_api_error! {
         /// crate::payloads::GetUserProfilePhotos
         UserNotFound = "Bad Request: user not found",
 
+        /// Occurs when the supplied user identifier does not refer to a
+        /// valid participant of the target chat (for example, the user
+        /// has hidden membership or never joined).
+        ///
+        /// May happen in methods:
+        /// 1. [`GetChatMember`]
+        ///
+        /// [`GetChatMember`]: crate::payloads::GetChatMember
+        ParticipantIdInvalid = "Bad Request: PARTICIPANT_ID_INVALID",
+
+        /// Occurs when bot tries to perform an action that requires chat
+        /// administrator rights without having them. Telegram also returns
+        /// this for [`GetChatMember`] queries against members whose
+        /// information is only visible to chat administrators.
+        ///
+        /// May happen in methods:
+        /// 1. [`GetChatMember`]
+        ///
+        /// [`GetChatMember`]: crate::payloads::GetChatMember
+        ChatAdminRequired = "Bad Request: CHAT_ADMIN_REQUIRED",
+
         /// Occurs when bot tries to send [`SetChatDescription`] with same text as
         /// in the current description.
         ///
@@ -914,6 +935,14 @@ mod tests {
             ("{\"data\": \"Bad Request: message is not a poll\"}", ApiError::MessageIsNotAPoll),
             ("{\"data\": \"Bad Request: chat not found\"}", ApiError::ChatNotFound),
             ("{\"data\": \"Bad Request: user not found\"}", ApiError::UserNotFound),
+            (
+                "{\"data\": \"Bad Request: PARTICIPANT_ID_INVALID\"}",
+                ApiError::ParticipantIdInvalid,
+            ),
+            (
+                "{\"data\": \"Bad Request: CHAT_ADMIN_REQUIRED\"}",
+                ApiError::ChatAdminRequired,
+            ),
             (
                 "{\"data\": \"Bad Request: chat description is not modified\"}",
                 ApiError::ChatDescriptionIsNotModified,


### PR DESCRIPTION
Closes #1349.

### What

Adds two `ApiError` variants that Telegram returns from `getChatMember` when querying (super)groups with hidden members without admin rights, and which were previously surfaced as `ApiError::Unknown`:

- `ApiError::ParticipantIdInvalid` — \`Bad Request: PARTICIPANT_ID_INVALID\`
- `ApiError::ChatAdminRequired` — \`Bad Request: CHAT_ADMIN_REQUIRED\`

### How

Two variants added next to `UserNotFound` in `crates/teloxide-core/src/errors.rs`, matching the existing doc-comment convention (what it means + which methods it can happen in). Round-trip test entries added in the existing `custom_result` test block, so the parser is verified to return the new variants instead of `Unknown`.

Added a changelog line under the `unreleased` / `Added` section of `crates/teloxide-core/CHANGELOG.md`.

### Testing

```
cargo test -p teloxide-core          # 26 passed; 0 failed
cargo clippy -p teloxide-core --all-targets  # clean
```

Tested locally on Rust 1.95.0.

### Scope notes

Labels on the issue include `good first issue` and `K-bug` — this PR is scoped narrowly to adding those two variants. I noticed the `impl_api_error!` macro supports predicate-based matchers (used by `InvalidToken`), but the two new strings are exact matches so a plain literal is sufficient and matches the style of the majority of other variants.