### PR TITLE
Don't ignore argument separator in CommandEnum and both separators in Command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `premium_animation` field of `StickerKind::Regular` enum variant is now of type `Option<File>`, not `Option<FileMeta>`
   - `users` field of `VideoChatParticipantsInvited` struct now is of type `Vec<User>`, not `Option<Vec<User>>`
 
+- Don't ignore argument separator in CommandEnum and both separators in Command ([#1462](https://github.com/teloxide/teloxide/pull/1462))
+  - Now it's possible to specify `separator` in each command variant
+  - Usage of `command_separator` in a command variant now leads to a compile time error instead of silent ignoring
+  - Now usage of `separator` without `parse_with = "split"` both in the command enum and in the command variant gives a compile time error
+
 ### Changed
 
 - Some dependencies were bumped: `derive_more` to `2.0.1`, `deadpool-redis` to `0.22.0` ([#1408](https://github.com/teloxide/teloxide/pull/1408))

--- a/crates/teloxide-macros/CHANGELOG.md
+++ b/crates/teloxide-macros/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## unreleased
 
+### Fixed
+
+- Don't ignore argument separator in CommandEnum and both separators in Command ([#1462](https://github.com/teloxide/teloxide/pull/1462))
+  - Now it's possible to specify `separator` in each command variant
+  - Usage of `command_separator` in a command variant now leads to a compile time error instead of silent ignoring
+  - Now usage of `separator` without `parse_with = "split"` both in the command enum and in the command variant gives a compile time error
+
 ## 0.10.0 - 2025-06-19
 
 ### Changed

--- a/crates/teloxide-macros/src/command.rs
+++ b/crates/teloxide-macros/src/command.rs
@@ -1,8 +1,11 @@
 use proc_macro2::Span;
 
 use crate::{
-    command_attr::CommandAttrs, command_enum::CommandEnum, error::compile_error_at,
-    fields_parse::ParserType, Result,
+    command_attr::{match_separator, CommandAttrs},
+    command_enum::CommandEnum,
+    error::compile_error_at,
+    fields_parse::ParserType,
+    Result,
 };
 
 pub(crate) struct Command {
@@ -37,13 +40,18 @@ impl Command {
             rename,
             aliases,
             parser,
-            // FIXME: error on/do not ignore separator
-            separator: _,
-            // FIXME: error on/do not ignore command separator
-            command_separator: _,
+            separator,
+            command_separator,
             hide,
             hide_aliases,
         } = attrs;
+
+        if let Some((_, sp)) = command_separator {
+            return Err(compile_error_at(
+                "`command_separator` can only be applied to the enum, not to individual variants",
+                sp,
+            ));
+        }
 
         let name = match (rename, rename_rule) {
             (Some((rename, _)), None) => rename,
@@ -58,7 +66,9 @@ impl Command {
         };
 
         let prefix = prefix.map(|(p, _)| p).unwrap_or_else(|| global_options.prefix.clone());
-        let parser = parser.map(|(p, _)| p).unwrap_or_else(|| global_options.parser_type.clone());
+        let mut parser =
+            parser.map(|(p, _)| p).unwrap_or_else(|| global_options.parser_type.clone());
+        match_separator(&mut parser, separator)?;
         let hidden = hide.is_some();
         let hidden_aliases = hide_aliases.is_some();
 

--- a/crates/teloxide-macros/src/command_attr.rs
+++ b/crates/teloxide-macros/src/command_attr.rs
@@ -209,6 +209,30 @@ fn is_command_attribute(a: &Attribute) -> bool {
     matches!(a.path().get_ident(), Some(ident) if ident == "command")
 }
 
+pub(crate) fn match_separator(
+    parser: &mut ParserType,
+    separator: Option<(String, Span)>,
+) -> Result<()> {
+    match (parser, separator) {
+        (ParserType::Split { separator }, Some((s, _))) => *separator = Some(s),
+        (ParserType::Default, Some((_, sp))) => {
+            return Err(compile_error_at(
+                "`separator` can only be used with `parse_with = \"split\"`",
+                sp,
+            ))
+        }
+        (ParserType::Custom(_), Some((_, sp))) => {
+            return Err(compile_error_at(
+                "`separator` can only be used with `parse_with = \"split\"`",
+                sp,
+            ))
+        }
+        (_, None) => {}
+    }
+
+    Ok(())
+}
+
 fn is_doc_comment(a: &Attribute) -> bool {
     matches!(
         a.path().get_ident(),

--- a/crates/teloxide-macros/src/command_enum.rs
+++ b/crates/teloxide-macros/src/command_enum.rs
@@ -1,6 +1,9 @@
 use crate::{
-    command_attr::CommandAttrs, error::compile_error_at, fields_parse::ParserType,
-    rename_rules::RenameRule, Result,
+    command_attr::{match_separator, CommandAttrs},
+    error::compile_error_at,
+    fields_parse::ParserType,
+    rename_rules::RenameRule,
+    Result,
 };
 
 /// Create a if block that checks if the given attribute is applied to a enum
@@ -47,10 +50,7 @@ impl CommandEnum {
 
         let mut parser = parser.map(|(p, _)| p).unwrap_or(ParserType::Default);
 
-        // FIXME: Error on unused separator
-        if let (ParserType::Split { separator }, Some((s, _))) = (&mut parser, &separator) {
-            *separator = Some(s.clone())
-        }
+        match_separator(&mut parser, separator)?;
 
         Ok(Self {
             prefix: prefix.map(|(p, _)| p).unwrap_or_else(|| "/".to_owned()),


### PR DESCRIPTION
This PR fixes multiple things:

1. Now it's possible to specify `separator` in each command variant. Earlier, this code would panic on unwrap at runtime:
    ```rust
   use teloxide::utils::command::BotCommands;

    #[tokio::main]
    async fn main() {
        // Earlier it would be `Err(TooFewArguments { _ }`
        let command = Command::parse("/usernameandage name|10", "").unwrap();
        assert_eq!(
            command,
            Command::UsernameAndAge {
                username: "name".to_owned(),
                age: 10
            }
        );
    }

    #[derive(BotCommands, Clone, Debug, PartialEq)]
    #[command(rename_rule = "lowercase")]
    enum Command {
        #[command(parse_with = "split", separator = "|")]
        UsernameAndAge { username: String, age: u8 },
    }
    ```
2. Usage of `command_separator` in a command variant now leads to a compile time error instead of silent ignoring. This code would compile earlier:
    ```rust
    use teloxide::utils::command::BotCommands;

    #[tokio::main]
    async fn main() {
        let command = Command::parse("/usernameandage name|10", "").unwrap();
        assert_eq!(
            command,
            Command::UsernameAndAge {
                username: "name".to_owned(),
                age: 10
            }
        );
    }

    #[derive(BotCommands, Clone, Debug, PartialEq)]
    #[command(rename_rule = "lowercase")]
    enum Command {
        #[command(parse_with = "split", command_separator = "|")]
        UsernameAndAge { username: String, age: u8 },
    }
    ```
3. It isn't possible to use `separator` without `parse_with = "split"` both in the command enum and in the command variant, but no error was given to the user. Now it's a proper compile time error:
    ```rust
    use teloxide::utils::command::BotCommands;

    #[tokio::main]
    async fn main() {
        let command = Command::parse("/usernameandage name", "").unwrap();
        assert_eq!(
            command,
            Command::UsernameAndAge {
                username: "name".to_owned(),
            }
        );
    }

    #[derive(BotCommands, Clone, Debug, PartialEq)]
    #[command(rename_rule = "lowercase", separator = "|")]
    enum Command {
        UsernameAndAge { username: String },
    }
    ```

r? @LasterAlex 