### PR TITLE
Add MessageToEditHasNoText to ApiError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `MessageToEditHasNoText` variant to `ApiError` ([#1426](https://github.com/teloxide/teloxide/issues/1426))
 - `ParticipantIdInvalid` and `ChatAdminRequired` variants to `ApiError` ([#1349](https://github.com/teloxide/teloxide/issues/1349))
 - Support for TBA 9.2 ([#1403](https://github.com/teloxide/teloxide/pull/1403))
   - Add `filter_suggested_post_approved`, `filter_suggested_post_approval_failed`, `filter_suggested_post_declined`, `filter_suggested_post_paid`, `filter_suggested_post_refunded` filters to the `MessageFilterExt` trait

--- a/crates/teloxide-core/src/errors.rs
+++ b/crates/teloxide-core/src/errors.rs
@@ -248,6 +248,16 @@ impl_api_error! {
         /// [`EditMessageText`]: crate::payloads::EditMessageText
         MessageToEditNotFound = "Bad Request: message to edit not found",
 
+        /// Occurs when bot tries to edit a message which has no text.
+        ///
+        /// May happen in methods:
+        /// 1. [`EditMessageText`]
+        /// 2. [`EditMessageTextInline`]
+        ///
+        /// [`EditMessageText`]: crate::payloads::EditMessageText
+        /// [`EditMessageTextInline`]: crate::payloads::EditMessageTextInline
+        MessageToEditHasNoText = "Bad Request: there is no text in the message to edit",
+
         /// Occurs when bot tries to reply to a message which does not exists.
         ///
         /// May happen in methods:
@@ -881,6 +891,10 @@ mod tests {
             (
                 "{\"data\": \"Bad Request: message to edit not found\"}",
                 ApiError::MessageToEditNotFound,
+            ),
+            (
+                "{\"data\": \"Bad Request: there is no text in the message to edit\"}",
+                ApiError::MessageToEditHasNoText,
             ),
             (
                 "{\"data\": \"Bad Request: message to be replied not found\"}",


### PR DESCRIPTION
Fixes #1426.

Adds a missing error variant to `ApiError` that currently falls through to `Unknown`:

- `MessageToEditHasNoText` — returned when calling `editMessageText` on a message that has no text body (e.g. a photo with caption).